### PR TITLE
Fix data validation issues

### DIFF
--- a/datavalidation.go
+++ b/datavalidation.go
@@ -12,6 +12,8 @@
 package excelize
 
 import (
+	"bytes"
+	"encoding/xml"
 	"fmt"
 	"strings"
 )
@@ -111,6 +113,12 @@ func (dd *DataValidation) SetInput(title, msg string) {
 // SetDropList data validation list.
 func (dd *DataValidation) SetDropList(keys []string) error {
 	formula := "\"" + strings.Join(keys, ",") + "\""
+	buf := bytes.NewBuffer(nil)
+	if err := xml.EscapeText(buf, []byte(formula)); err != nil {
+		return err
+	}
+	formula = buf.String()
+
 	if dataValidationFormulaStrLen < len(formula) {
 		return fmt.Errorf(dataValidationFormulaStrLenErr)
 	}

--- a/datavalidation.go
+++ b/datavalidation.go
@@ -132,14 +132,8 @@ func (dd *DataValidation) SetDropList(keys []string) error {
 
 // SetRange provides function to set data validation range in drop list.
 func (dd *DataValidation) SetRange(f1, f2 float64, t DataValidationType, o DataValidationOperator) error {
-	formula1 := fmt.Sprintf("%f", f1)
-	formula2 := fmt.Sprintf("%f", f2)
-	if dataValidationFormulaStrLen+21 < len(dd.Formula1) || dataValidationFormulaStrLen+21 < len(dd.Formula2) {
-		return fmt.Errorf(dataValidationFormulaStrLenErr)
-	}
-
-	dd.Formula1 = fmt.Sprintf("<formula1>%s</formula1>", formula1)
-	dd.Formula2 = fmt.Sprintf("<formula2>%s</formula2>", formula2)
+	dd.Formula1 = fmt.Sprintf("<formula1>%.17g</formula1>", f1)
+	dd.Formula2 = fmt.Sprintf("<formula2>%.17g</formula2>", f2)
 	dd.Type = convDataValidationType(t)
 	dd.Operator = convDataValidationOperatior(o)
 	return nil

--- a/datavalidation.go
+++ b/datavalidation.go
@@ -34,8 +34,8 @@ const (
 )
 
 const (
-	// dataValidationFormulaStrLen 255 characters+ 2 quotes
-	dataValidationFormulaStrLen = 257
+	// dataValidationFormulaStrLen
+	dataValidationFormulaStrLen = 255
 	// dataValidationFormulaStrLenErr
 	dataValidationFormulaStrLenErr = "data validation must be 0-255 characters"
 )
@@ -119,11 +119,13 @@ func (dd *DataValidation) SetInput(title, msg string) {
 
 // SetDropList data validation list.
 func (dd *DataValidation) SetDropList(keys []string) error {
-	formula := `"` + formulaEscaper.Replace(strings.Join(keys, ",")) + `"`
-	if dataValidationFormulaStrLen < len(formula) {
+	formula := strings.Join(keys, ",")
+	if dataValidationFormulaStrLen < UTF16Length(formula) {
 		return fmt.Errorf(dataValidationFormulaStrLenErr)
 	}
-	dd.Formula1 = fmt.Sprintf("<formula1>%s</formula1>", formula)
+
+	formula = formulaEscaper.Replace(formula)
+	dd.Formula1 = fmt.Sprintf(`<formula1>"%s"</formula1>`, formula)
 	dd.Type = convDataValidationType(typeList)
 	return nil
 }

--- a/datavalidation_test.go
+++ b/datavalidation_test.go
@@ -10,6 +10,7 @@
 package excelize
 
 import (
+	"math"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -103,8 +104,9 @@ func TestDataValidationError(t *testing.T) {
 	assert.NoError(t, f.AddDataValidation("Sheet1", dvRange))
 	assert.NoError(t, f.SaveAs(resultFile))
 
-	dvRange.Formula1 = strings.Repeat("s", dataValidationFormulaStrLen+22)
-	assert.EqualError(t, dvRange.SetRange(10, 20, DataValidationTypeWhole, DataValidationOperatorGreaterThan), "data validation must be 0-255 characters")
+	assert.NoError(t, dvRange.SetRange(
+		math.SmallestNonzeroFloat64, math.MaxFloat64,
+		DataValidationTypeWhole, DataValidationOperatorGreaterThan))
 
 	// Test add data validation on no exists worksheet.
 	f = NewFile()

--- a/lib.go
+++ b/lib.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
-	"unicode/utf16"
 )
 
 // ReadZipReader can be used to read the spreadsheet in memory without touching the
@@ -591,10 +590,4 @@ func (stack *Stack) Len() int {
 // Empty the stack.
 func (stack *Stack) Empty() bool {
 	return stack.list.Len() == 0
-}
-
-// UTF16Length encodes the given string in UTF-16, and
-// returns the count of 16-bit code units in this form of the string.
-func UTF16Length(s string) int {
-	return len(utf16.Encode([]rune(s)))
 }

--- a/lib.go
+++ b/lib.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf16"
 )
 
 // ReadZipReader can be used to read the spreadsheet in memory without touching the
@@ -590,4 +591,10 @@ func (stack *Stack) Len() int {
 // Empty the stack.
 func (stack *Stack) Empty() bool {
 	return stack.list.Len() == 0
+}
+
+// UTF16Length encodes the given string in UTF-16, and
+// returns the count of 16-bit code units in this form of the string.
+func UTF16Length(s string) int {
+	return len(utf16.Encode([]rune(s)))
 }


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

This patch escapes the drop-down list items, and changes the way to calculate the formula length.
<!--- Describe your changes in detail -->

## Related Issue

Fixes #971 and #972.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

### Changes for #971
This patch included a XML entity mapping table, instead of simply reusing `xml.EscapeText()` in the standard library. This was on purpose. Disassembly of an OOXML file produced by Microsoft Excel indicated that, it implemented a different escaping rule which was more or less incompatible with `xml.EscapeText()`. Consider the following example:

```xml
A<,B>,C",D	,E',F
```

Microsoft Excel escaped it into:

```xml
<formula1>"A&lt;,B&gt;,C"",D	,E',F"</formula1>
```

And my initial attempt to fix #971 in commit b1faede323757cd48f81950a5105143832637859, which employed `xml.EscapeText()`, produced:

```xml
<formula1>"A&lt;,B&gt;,C&#34;,D&#x9;,E&#39;,F"</formula1>
```

The latter was unfortunately still incompatible with Microsoft Excel, not to mention it was longer:

![image](https://user-images.githubusercontent.com/10341686/127277098-c57d966e-3a88-4cd9-b51d-ab40aa89e2ee.png)

### Changes for #972
This patch calculated the string length in UTF-16 code units instead of UTF-8 bytes.
Tests indicated that Microsoft Excel's limitation of data validation formula always worked in this way, even on UTF-8 dominated platforms like macOS. The following snippet was developed to help identification of the upper bound:

```go
package main

import (
	"fmt"
	"strings"
	"unicode/utf16"

	"github.com/360EntSecGroup-Skylar/excelize/v2"
)

func main() {
	var choices = []string{
		strings.Repeat("😅", 100), // U+1F605, "SMILING FACE WITH OPEN MOUTH AND COLD SWEAT"
		strings.Repeat("漢", 55),  // U+06F22, "CJK UNIFIED IDEOGRAPH-6F22"
	}

	joined := strings.Join(choices, ",")
	runes := []rune(joined)
	codeUnits := utf16.Encode(runes)

	fmt.Printf("%4d bytes in utf-8 \n", len(joined))
	fmt.Printf("%4d units in utf-16\n", len(codeUnits))
	fmt.Printf("%4d runes in utf-32\n", len(runes))

	newWorkbookWithDropList(choices)
}

func newWorkbookWithDropList(choices []string) {
	f := excelize.NewFile()
	dv := excelize.NewDataValidation(false)
	dv.Sqref = "A:A"
	if err := dv.SetDropList(choices); err != nil {
		panic(err)
	}
	f.AddDataValidation(f.GetSheetName(0), dv)
	f.SaveAs("TestDropList.xlsx")
}
```

The snippet would print ...

```js
 566 bytes in utf-8
 256 units in utf-16
 156 runes in utf-32
```

... and produce a corrupt file (or panic if the original length validation was not removed from excelize codebase).

![image](https://user-images.githubusercontent.com/10341686/127277098-c57d966e-3a88-4cd9-b51d-ab40aa89e2ee.png)

Change the constant `55` to `54`, and then the snippet would print ...

```js
 563 bytes in utf-8
 255 units in utf-16
 155 runes in utf-32
```

... and produce a valid Excel workbook:

![image](https://user-images.githubusercontent.com/10341686/127280932-6944c395-a8f4-45b1-a70b-f274898222d3.png)

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

The patches was tested against:

* Microsoft Office 365 for Mac, 16.49 (21050901)
* Microsoft Office 365 for Windows, 2102 (Build 13801.20808)
* Microsoft Office 2019 Professional Plus for Windows, 2105 (Build 14026.20302)
* Microsoft Office 2013 Professional Plus for Windows, 15.0.4919.1002

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
