### PR TITLE
Preserve whitespace in cells

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -308,14 +308,14 @@ func (f *File) setSharedString(val string) int {
 	sst.Count++
 	sst.UniqueCount++
 	val = bstrMarshal(val)
-	t := xlsxT{Val: val}
-	// Leading and ending space(s) character detection.
-	if len(val) > 0 && (val[0] == 32 || val[len(val)-1] == 32) {
-		ns := xml.Attr{
+	t := xlsxT{
+		Val: val,
+	}
+	if strings.ContainsAny(val, "\r\n ") {
+		t.Space = xml.Attr{
 			Name:  xml.Name{Space: NameSpaceXML, Local: "space"},
 			Value: "preserve",
 		}
-		t.Space = ns
 	}
 	sst.SI = append(sst.SI, xlsxSI{T: &t})
 	f.sharedStringsMap[val] = sst.UniqueCount - 1

--- a/cell.go
+++ b/cell.go
@@ -307,16 +307,8 @@ func (f *File) setSharedString(val string) int {
 	}
 	sst.Count++
 	sst.UniqueCount++
-	val = bstrMarshal(val)
-	t := xlsxT{
-		Val: val,
-	}
-	if strings.ContainsAny(val, "\r\n ") {
-		t.Space = xml.Attr{
-			Name:  xml.Name{Space: NameSpaceXML, Local: "space"},
-			Value: "preserve",
-		}
-	}
+	t := xlsxT{Val: val}
+	_, val, t.Space = setCellStr(val)
 	sst.SI = append(sst.SI, xlsxSI{T: &t})
 	f.sharedStringsMap[val] = sst.UniqueCount - 1
 	return sst.UniqueCount - 1
@@ -327,11 +319,16 @@ func setCellStr(value string) (t string, v string, ns xml.Attr) {
 	if len(value) > TotalCellChars {
 		value = value[0:TotalCellChars]
 	}
-	// Leading and ending space(s) character detection.
-	if len(value) > 0 && (value[0] == 32 || value[len(value)-1] == 32) {
-		ns = xml.Attr{
-			Name:  xml.Name{Space: NameSpaceXML, Local: "space"},
-			Value: "preserve",
+	if len(value) > 0 {
+		prefix, suffix := value[0], value[len(value)-1]
+		for _, ascii := range []byte{10, 13, 32} {
+			if prefix == ascii || suffix == ascii {
+				ns = xml.Attr{
+					Name:  xml.Name{Space: NameSpaceXML, Local: "space"},
+					Value: "preserve",
+				}
+				break
+			}
 		}
 	}
 	t = "str"
@@ -702,11 +699,14 @@ func (f *File) SetCellRichText(sheet, cell string, runs []RichTextRun) error {
 	si := xlsxSI{}
 	sst := f.sharedStringsReader()
 	textRuns := []xlsxR{}
+	totalCellChars := 0
 	for _, textRun := range runs {
-		run := xlsxR{T: &xlsxT{Val: textRun.Text}}
-		if strings.ContainsAny(textRun.Text, "\r\n ") {
-			run.T.Space = xml.Attr{Name: xml.Name{Space: NameSpaceXML, Local: "space"}, Value: "preserve"}
+		totalCellChars += len(textRun.Text)
+		if totalCellChars > TotalCellChars {
+			return ErrCellCharsLength
 		}
+		run := xlsxR{T: &xlsxT{}}
+		_, run.T.Val, run.T.Space = setCellStr(textRun.Text)
 		fnt := textRun.Font
 		if fnt != nil {
 			rpr := xlsxRPr{}

--- a/cell_test.go
+++ b/cell_test.go
@@ -401,6 +401,9 @@ func TestSetCellRichText(t *testing.T) {
 	assert.EqualError(t, f.SetCellRichText("SheetN", "A1", richTextRun), "sheet SheetN is not exist")
 	// Test set cell rich text with illegal cell coordinates
 	assert.EqualError(t, f.SetCellRichText("Sheet1", "A", richTextRun), `cannot convert cell "A" to coordinates: invalid cell name "A"`)
+	richTextRun = []RichTextRun{{Text: strings.Repeat("s", TotalCellChars+1)}}
+	// Test set cell rich text with characters over the maximum limit
+	assert.EqualError(t, f.SetCellRichText("Sheet1", "A1", richTextRun), ErrCellCharsLength.Error())
 }
 
 func TestFormattedValue2(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -45,7 +45,7 @@ var (
 	ErrColumnNumber = errors.New("column number exceeds maximum limit")
 	// ErrColumnWidth defined the error message on receive an invalid column
 	// width.
-	ErrColumnWidth = errors.New("the width of the column must be smaller than or equal to 255 characters")
+	ErrColumnWidth = fmt.Errorf("the width of the column must be smaller than or equal to %d characters", MaxColumnWidth)
 	// ErrOutlineLevel defined the error message on receive an invalid outline
 	// level number.
 	ErrOutlineLevel = errors.New("invalid outline level")
@@ -105,4 +105,13 @@ var (
 	ErrSheetIdx = errors.New("invalid worksheet index")
 	// ErrGroupSheets defined the error message on group sheets.
 	ErrGroupSheets = errors.New("group worksheet must contain an active worksheet")
+	// ErrDataValidationFormulaLenth defined the error message for receiving a
+	// data validation formula length that exceeds the limit.
+	ErrDataValidationFormulaLenth = errors.New("data validation must be 0-255 characters")
+	// ErrDataValidationRange defined the error message on set decimal range
+	// exceeds limit.
+	ErrDataValidationRange = errors.New("data validation range exceeds limit")
+	// ErrCellCharsLength defined the error message for receiving a
+	// cell characters length that exceeds the limit.
+	ErrCellCharsLength = fmt.Errorf("cell value must be 0-%d characters", TotalCellChars)
 )


### PR DESCRIPTION
# PR Details

## Description
This patch backports the more reasonable whitespace detection condition from `SetCellRichText()` to `setSharedString()`.

## Related Issue
#69, #269
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

A relevant formatting fix was first introduced in `setSharedString()` in dc012645. Unfortunately, a strict condition was applied, so the patch only fixed formatting for the cells with prefix and trailing spaces, not the ones with line ending characters:

```go
t := xlsxT{Val: val}
// Leading and ending space(s) character detection.
if len(val) > 0 && (val[0] == 32 || val[len(val)-1] == 32) {
	ns := xml.Attr{
		Name:  xml.Name{Space: NameSpaceXML, Local: "space"},
		Value: "preserve",
	}
	t.Space = ns
}
```

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

* Microsoft Office 365 for Mac, 16.49 (21050901)
* Microsoft Office 2019 Professional Plus for Windows, 2105 (Build 14026.20302)
* Microsoft Office 2013 Professional Plus for Windows, 15.0.4919.1002

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
