### PR TITLE
excelize: support nested calc for if formula

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -6746,7 +6746,7 @@ func (fn *formulaFuncs) IF(argsList *list.List) formulaArg {
 	var (
 		cond   bool
 		err    error
-		result string
+		result formulaArg
 	)
 	switch token.Type {
 	case ArgString:
@@ -6757,13 +6757,26 @@ func (fn *formulaFuncs) IF(argsList *list.List) formulaArg {
 			return newBoolFormulaArg(cond)
 		}
 		if cond {
-			return newStringFormulaArg(argsList.Front().Next().Value.(formulaArg).String)
+			value := argsList.Front().Next().Value.(formulaArg)
+			switch value.Type {
+			case ArgNumber:
+				result = value.ToNumber()
+			default:
+				result = newStringFormulaArg(value.String)
+			}
+			return result
 		}
 		if argsList.Len() == 3 {
-			result = argsList.Back().Value.(formulaArg).String
+			value := argsList.Back().Value.(formulaArg)
+			switch value.Type {
+			case ArgNumber:
+				result = value.ToNumber()
+			default:
+				result = newStringFormulaArg(value.String)
+			}
 		}
 	}
-	return newStringFormulaArg(result)
+	return result
 }
 
 // Lookup and Reference Functions

--- a/calc_test.go
+++ b/calc_test.go
@@ -1090,6 +1090,8 @@ func TestCalcCellValue(t *testing.T) {
 		`=IF(1<>1, "equal", "notequal")`:        "notequal",
 		`=IF("A"="A", "equal", "notequal")`:     "equal",
 		`=IF("A"<>"A", "equal", "notequal")`:    "notequal",
+		`=IF(FALSE,0,ROUND(4/2,0))`:             "2",
+		`=IF(TRUE,ROUND(4/2,0),0)`:              "2",
 		// Excel Lookup and Reference Functions
 		// CHOOSE
 		"=CHOOSE(4,\"red\",\"blue\",\"green\",\"brown\")": "brown",


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Support nested calc for if formula

## Description

<!--- Describe your changes in detail -->
`if` formula can be placed with formula, e.q. ROUND

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/qax-os/excelize/issues/987

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
it solves the problem for nested formula doesn't calculation

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
MAC os 11.5
golang 1.16.6

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
