### PR TITLE
fix LOOKUP function for Array form

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -7263,7 +7263,11 @@ func (fn *formulaFuncs) LOOKUP(argsList *list.List) formulaArg {
 	if lookupVector.Type != ArgMatrix && lookupVector.Type != ArgList {
 		return newErrorFormulaArg(formulaErrorVALUE, "LOOKUP requires second argument of table array")
 	}
-	cols, matchIdx := lookupCol(lookupVector), -1
+	arrayForm := lookupVector.Type == ArgMatrix
+	if arrayForm && len(lookupVector.Matrix) == 0 {
+		return newErrorFormulaArg(formulaErrorVALUE, "LOOKUP requires not empty range as second argument")
+	}
+	cols, matchIdx := lookupCol(lookupVector, 0), -1
 	for idx, col := range cols {
 		lhs := lookupValue
 		switch col.Type {
@@ -7280,9 +7284,13 @@ func (fn *formulaFuncs) LOOKUP(argsList *list.List) formulaArg {
 			break
 		}
 	}
-	column := cols
+	var column []formulaArg
 	if argsList.Len() == 3 {
-		column = lookupCol(argsList.Back().Value.(formulaArg))
+		column = lookupCol(argsList.Back().Value.(formulaArg), 0)
+	} else if arrayForm && len(lookupVector.Matrix[0]) > 0 {
+		column = lookupCol(lookupVector, 1)
+	} else {
+		column = cols
 	}
 	if matchIdx < 0 || matchIdx >= len(column) {
 		return newErrorFormulaArg(formulaErrorNA, "LOOKUP no result found")
@@ -7291,13 +7299,13 @@ func (fn *formulaFuncs) LOOKUP(argsList *list.List) formulaArg {
 }
 
 // lookupCol extract columns for LOOKUP.
-func lookupCol(arr formulaArg) []formulaArg {
+func lookupCol(arr formulaArg, idx int) []formulaArg {
 	col := arr.List
 	if arr.Type == ArgMatrix {
 		col = nil
 		for _, r := range arr.Matrix {
 			if len(r) > 0 {
-				col = append(col, r[0])
+				col = append(col, r[idx])
 				continue
 			}
 			col = append(col, newEmptyFormulaArg())

--- a/calc_test.go
+++ b/calc_test.go
@@ -1131,6 +1131,8 @@ func TestCalcCellValue(t *testing.T) {
 		// LOOKUP
 		"=LOOKUP(F8,F8:F9,F8:F9)":      "32080",
 		"=LOOKUP(F8,F8:F9,D8:D9)":      "Feb",
+		"=LOOKUP(E3,E2:E5,F2:F5)":      "22100",
+		"=LOOKUP(E3,E2:F5)":            "22100",
 		"=LOOKUP(1,MUNIT(1),MUNIT(1))": "1",
 		// ROW
 		"=ROW()":                "1",


### PR DESCRIPTION
# PR Details

Support Array form use of function LOOKUP

## Description

Excelize already supports the Vector form of LOOKUP. This pull request fixes Array form use of function LOOKUP. As a result these two expressions are equivalent and return the same result:
```
LOOKUP(E3,E2:E5,F2:F5)
LOOKUP(E3,E2:F5)
```

## Related Issue

Fixes #994

## Motivation and Context

This helps with Excels from third party, where one has no control which form of LOOKUP is used.

## How Has This Been Tested

Added tests to calc_test.go

Tested on:
- OS: Archlinux 5.13.10-arch1-1
- WPS Spreadsheets (version wps-office 11.1.0.10702-1)
- LibreCalc (version libreoffice-fresh 7.1.5-2)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
