### PR TITLE
Fix LOOKUP function to find nearest match

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -7267,7 +7267,7 @@ func (fn *formulaFuncs) LOOKUP(argsList *list.List) formulaArg {
 	if arrayForm && len(lookupVector.Matrix) == 0 {
 		return newErrorFormulaArg(formulaErrorVALUE, "LOOKUP requires not empty range as second argument")
 	}
-	cols, matchIdx := lookupCol(lookupVector, 0), -1
+	cols, matchIdx, ok := lookupCol(lookupVector, 0), -1, false
 	for idx, col := range cols {
 		lhs := lookupValue
 		switch col.Type {
@@ -7279,10 +7279,21 @@ func (fn *formulaFuncs) LOOKUP(argsList *list.List) formulaArg {
 				}
 			}
 		}
-		if compareFormulaArg(lhs, col, false, false) == criteriaEq {
+		compare := compareFormulaArg(lhs, col, false, false)
+		// Find exact match
+		if compare == criteriaEq {
 			matchIdx = idx
 			break
 		}
+		// Find nearest match if lookup value is more than or equal to the first value in lookup vector
+		if idx == 0 {
+			ok = compare == criteriaG
+		} else if ok && compare == criteriaL && matchIdx == -1 {
+			matchIdx = idx - 1
+		}
+	}
+	if ok && matchIdx == -1 {
+		matchIdx = len(cols) - 1
 	}
 	var column []formulaArg
 	if argsList.Len() == 3 {

--- a/calc_test.go
+++ b/calc_test.go
@@ -1133,6 +1133,8 @@ func TestCalcCellValue(t *testing.T) {
 		"=LOOKUP(F8,F8:F9,D8:D9)":      "Feb",
 		"=LOOKUP(E3,E2:E5,F2:F5)":      "22100",
 		"=LOOKUP(E3,E2:F5)":            "22100",
+		"=LOOKUP(F3+1,F3:F4,F3:F4)":    "22100",
+		"=LOOKUP(F4+1,F3:F4,F3:F4)":    "53321",
 		"=LOOKUP(1,MUNIT(1))":          "1",
 		"=LOOKUP(1,MUNIT(1),MUNIT(1))": "1",
 		// ROW


### PR DESCRIPTION
# PR Details

Fix LOOKUP function to find nearest match

## Description

The LOOKUP function should return the nearest match:

> If the LOOKUP function can't find the lookup_value, the function matches the largest value in lookup_vector that is less than or equal to lookup_value.
> 
> If lookup_value is smaller than the smallest value in lookup_vector, LOOKUP returns the #N/A error value.
>
> **Important**: The values in array must be placed in ascending order: ..., -2, -1, 0, 1, 2, ..., A-Z, FALSE, TRUE; otherwise, LOOKUP might not return the correct value. Uppercase and lowercase text are equivalent.

According to the official Microsoft Excel documentation: https://support.microsoft.com/en-us/office/lookup-function-446d94af-663b-451d-8251-369d5e3864cb

## Related Issue

Fixes #997 

## Motivation and Context

This helps with Excels from third party, where one has no control which form of LOOKUP is used.

## How Has This Been Tested

Added tests to calc_test.go

Tested on:
- OS: Archlinux 5.13.10-arch1-1
- WPS Spreadsheets (version wps-office 11.1.0.10702-1)
- LibreCalc (version libreoffice-fresh 7.1.5-2)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
