### PR TITLE
Implement MONTH function

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -269,6 +269,7 @@ var tokenPriority = map[string]int{
 //    CUMPRINC
 //    DATE
 //    DATEDIF
+//    DAY
 //    DB
 //    DDB
 //    DEC2BIN
@@ -6106,6 +6107,28 @@ func (fn *formulaFuncs) DATEDIF(argsList *list.List) formulaArg {
 		return newErrorFormulaArg(formulaErrorVALUE, "DATEDIF has invalid unit")
 	}
 	return newNumberFormulaArg(diff)
+}
+
+// DAY Returns the day of a date, represented by a serial number.
+// The day is given as an integer ranging from 1 to 31.
+// The syntax of the function is:
+//
+//    DAY(serial_number)
+//
+// Serial_number (required) is the date of the day you are trying to find.
+// Dates should be entered by using the DATE function,
+// or as results of other formulas or functions.
+// For example, use DATE(2008,5,23) for the 23rd day of May, 2008. 
+func (fn *formulaFuncs) DAY(argsList *list.List) formulaArg {
+	if argsList.Len() != 1 {
+		return newErrorFormulaArg(formulaErrorVALUE, "DAY requires exactly one argument")
+	}
+	excelDate := argsList.Front().Value.(formulaArg).ToNumber()
+	if excelDate.Type != ArgNumber {
+		return newErrorFormulaArg(formulaErrorVALUE, "DAY requires a number argument")
+	}
+	t := timeFromExcelTime(excelDate.Number, false)
+	return newNumberFormulaArg(float64(t.Day()))
 }
 
 // NOW function returns the current date and time. The function receives no

--- a/calc.go
+++ b/calc.go
@@ -367,6 +367,7 @@ var tokenPriority = map[string]int{
 //    MINA
 //    MIRR
 //    MOD
+//    MONTH
 //    MROUND
 //    MULTINOMIAL
 //    MUNIT
@@ -6143,7 +6144,7 @@ func (fn *formulaFuncs) DAY(argsList *list.List) formulaArg {
 	return timeFunc("DAY", argsList)
 }
 
-// Returns the month of a date represented by a serial number.
+// MONTH function returns the month of a date represented by a serial number.
 // The month is given as an integer, ranging from 1 (January) to 12 (December).
 // The syntax of the function is:
 //

--- a/calc.go
+++ b/calc.go
@@ -6109,6 +6109,26 @@ func (fn *formulaFuncs) DATEDIF(argsList *list.List) formulaArg {
 	return newNumberFormulaArg(diff)
 }
 
+// timeFunc is a helper function for DAY and MONTH
+func timeFunc(name string, argsList *list.List) formulaArg {
+	if argsList.Len() != 1 {
+		return newErrorFormulaArg(formulaErrorVALUE, name+" requires exactly one argument")
+	}
+	excelDate := argsList.Front().Value.(formulaArg).ToNumber()
+	if excelDate.Type != ArgNumber {
+		return newErrorFormulaArg(formulaErrorVALUE, name+" requires a number argument")
+	}
+	t := timeFromExcelTime(excelDate.Number, false)
+	var result float64
+	switch name {
+	case "DAY":
+		result = float64(t.Day())
+	case "MONTH":
+		result = float64(t.Month())
+	}
+	return newNumberFormulaArg(result)
+}
+
 // DAY Returns the day of a date, represented by a serial number.
 // The day is given as an integer ranging from 1 to 31.
 // The syntax of the function is:
@@ -6118,17 +6138,23 @@ func (fn *formulaFuncs) DATEDIF(argsList *list.List) formulaArg {
 // Serial_number (required) is the date of the day you are trying to find.
 // Dates should be entered by using the DATE function,
 // or as results of other formulas or functions.
-// For example, use DATE(2008,5,23) for the 23rd day of May, 2008. 
+// For example, use DATE(2008,5,23) for the 23rd day of May, 2008.
 func (fn *formulaFuncs) DAY(argsList *list.List) formulaArg {
-	if argsList.Len() != 1 {
-		return newErrorFormulaArg(formulaErrorVALUE, "DAY requires exactly one argument")
-	}
-	excelDate := argsList.Front().Value.(formulaArg).ToNumber()
-	if excelDate.Type != ArgNumber {
-		return newErrorFormulaArg(formulaErrorVALUE, "DAY requires a number argument")
-	}
-	t := timeFromExcelTime(excelDate.Number, false)
-	return newNumberFormulaArg(float64(t.Day()))
+	return timeFunc("DAY", argsList)
+}
+
+// Returns the month of a date represented by a serial number.
+// The month is given as an integer, ranging from 1 (January) to 12 (December).
+// The syntax of the function is:
+//
+//    MONTH(serial_number)
+//
+// Serial_number (required) is the date of the month you are trying to find.
+// Dates should be entered by using the DATE function,
+// or as results of other formulas or functions.
+// For example, use DATE(2008,5,23) for the 23rd day of May, 2008.
+func (fn *formulaFuncs) MONTH(argsList *list.List) formulaArg {
+	return timeFunc("MONTH", argsList)
 }
 
 // NOW function returns the current date and time. The function receives no

--- a/calc_test.go
+++ b/calc_test.go
@@ -1131,6 +1131,9 @@ func TestCalcCellValue(t *testing.T) {
 		// LOOKUP
 		"=LOOKUP(F8,F8:F9,F8:F9)":      "32080",
 		"=LOOKUP(F8,F8:F9,D8:D9)":      "Feb",
+		"=LOOKUP(E3,E2:E5,F2:F5)":      "22100",
+		"=LOOKUP(E3,E2:F5)":            "22100",
+		"=LOOKUP(1,MUNIT(1))":          "1",
 		"=LOOKUP(1,MUNIT(1),MUNIT(1))": "1",
 		// ROW
 		"=ROW()":                "1",
@@ -2090,6 +2093,7 @@ func TestCalcCellValue(t *testing.T) {
 		"=LOOKUP()":                     "LOOKUP requires at least 2 arguments",
 		"=LOOKUP(D2,D1,D2)":             "LOOKUP requires second argument of table array",
 		"=LOOKUP(D2,D1,D2,FALSE)":       "LOOKUP requires at most 3 arguments",
+		"=LOOKUP(1,MUNIT(0))":           "LOOKUP requires not empty range as second argument",
 		"=LOOKUP(D1,MUNIT(1),MUNIT(1))": "LOOKUP no result found",
 		// ROW
 		"=ROW(1,2)":          "ROW requires at most 1 argument",

--- a/calc_test.go
+++ b/calc_test.go
@@ -946,6 +946,8 @@ func TestCalcCellValue(t *testing.T) {
 		"=DATEDIF(42171,44242,\"yd\")": "244",
 		// DAY
 		"=DAY(42171)": "16",
+		// MONTH
+		"=MONTH(42171)": "6",
 		// Text Functions
 		// CHAR
 		"=CHAR(65)": "A",
@@ -1933,6 +1935,10 @@ func TestCalcCellValue(t *testing.T) {
 		"=DAY()":            "DAY requires exactly one argument",
 		"=DAY(43891,43101)": "DAY requires exactly one argument",
 		`=DAY("text")`:      "DAY requires a number argument",
+		// MONTH
+		"=MONTH()":            "MONTH requires exactly one argument",
+		"=MONTH(43891,43101)": "MONTH requires exactly one argument",
+		`=MONTH("text")`:      "MONTH requires a number argument",
 		// NOW
 		"=NOW(A1)": "NOW accepts no arguments",
 		// TODAY

--- a/calc_test.go
+++ b/calc_test.go
@@ -963,7 +963,8 @@ func TestCalcCellValue(t *testing.T) {
 		"=DAY(\"01/25/20\")":                     "25",
 		"=DAY(\"01/25/31\")":                     "25",
 		// MONTH
-		"=MONTH(42171)": "6",
+		"=MONTH(42171)":           "6",
+		"=MONTH(\"31-May-2015\")": "5",
 		// Text Functions
 		// CHAR
 		"=CHAR(65)": "A",
@@ -1984,9 +1985,11 @@ func TestCalcCellValue(t *testing.T) {
 		"=DAY(\"9223372036854775808-January-1900\")":                          "#VALUE!",
 		"=DAY(\"0-January-1900\")":                                            "#VALUE!",
 		// MONTH
-		"=MONTH()":            "MONTH requires exactly one argument",
-		"=MONTH(43891,43101)": "MONTH requires exactly one argument",
-		`=MONTH("text")`:      "MONTH requires a number argument",
+		"=MONTH()":                    "MONTH requires exactly 1 argument",
+		"=MONTH(43891,43101)":         "MONTH requires exactly 1 argument",
+		"=MONTH(-1)":                  "MONTH only accepts positive argument",
+		"=MONTH(\"text\")":            "#VALUE!",
+		"=MONTH(\"January 25, 100\")": "#VALUE!",
 		// NOW
 		"=NOW(A1)": "NOW accepts no arguments",
 		// TODAY

--- a/calc_test.go
+++ b/calc_test.go
@@ -944,6 +944,8 @@ func TestCalcCellValue(t *testing.T) {
 		"=DATEDIF(43101,43891,\"YD\")": "59",
 		"=DATEDIF(36526,73110,\"YD\")": "60",
 		"=DATEDIF(42171,44242,\"yd\")": "244",
+		// DAY
+		"=DAY(42171)": "16",
 		// Text Functions
 		// CHAR
 		"=CHAR(65)": "A",
@@ -1927,6 +1929,10 @@ func TestCalcCellValue(t *testing.T) {
 		"=DATEDIF(\"\",\"\",\"\")":    "strconv.ParseFloat: parsing \"\": invalid syntax",
 		"=DATEDIF(43891,43101,\"Y\")": "start_date > end_date",
 		"=DATEDIF(43101,43891,\"x\")": "DATEDIF has invalid unit",
+		// DAY
+		"=DAY()":            "DAY requires exactly one argument",
+		"=DAY(43891,43101)": "DAY requires exactly one argument",
+		`=DAY("text")`:      "DAY requires a number argument",
 		// NOW
 		"=NOW(A1)": "NOW accepts no arguments",
 		// TODAY


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

**Description**

Returns the month of a date represented by a serial number. The month is given as an integer, ranging from 1 (January) to 12 (December).
https://support.microsoft.com/en-us/office/month-function-579a2881-199b-48b2-ab90-ddba0eba86e8

**Syntax**

MONTH(serial_number)

The MONTH function syntax has the following arguments:

- **Serial_number**    Required. The date of the month you are trying to find. Dates should be entered by using the DATE function, or as results of other formulas or functions. For example, use DATE(2008,5,23) for the 23rd day of May, 2008. Problems can occur if dates are entered as text.

## Related Issue

Fixes #1004 
Important: pull request https://github.com/qax-os/excelize/pull/1003 must be merged first!

## Motivation and Context

This helps with Excels from third party, where the MONTH function is frequently used.

## How Has This Been Tested

Added tests to calc_test.go

Tested on:
- OS: Archlinux 5.13.10-arch1-1
- WPS Spreadsheets (version wps-office 11.1.0.10702-1)
- LibreCalc (version libreoffice-fresh 7.1.5-2)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
