### PR TITLE
feat: add SetCellsData for set values by struct array

### DIFF
--- a/cell_test.go
+++ b/cell_test.go
@@ -172,6 +172,63 @@ func TestSetCellValues(t *testing.T) {
 	assert.Equal(t, v, "1600-12-31T00:00:00Z")
 }
 
+func TestSetCellsData(t *testing.T) {
+	timeValue := time.Now()
+	structArray := []struct{
+	Id        int
+	Feild1    string
+	Feild2    float64
+	DateField time.Time
+	}{
+		{1, "string value 1", 2.35, timeValue},
+		{2, "string value 2", 3.48, timeValue.Add(time.Minute * time.Duration(2))},
+	}
+	localize := map[string]string{
+		"Id":        "Identity Number",
+		"Feild1":    "Field First",
+		"Feild2":    "Field Second",
+		"DateField": "Created Date",
+	}
+	f := NewFile()
+	err := f.SetCellsData("Sheet1", structArray, localize)
+	assert.NoError(t, err)
+
+	v, err := f.GetCellValue("Sheet1", "A1")
+	assert.NoError(t, err)
+	assert.Equal(t, v, "Identity Number")
+
+	v2, err := f.GetCellValue("Sheet1", "B3")
+	assert.NoError(t, err)
+	assert.Equal(t, v2, "string value 2")
+
+	err2 := f.SetCellsData("Sheet1", structArray, nil)
+	assert.NoError(t, err2)
+
+	v21, err2 := f.GetCellValue("Sheet1", "A1")
+	assert.NoError(t, err2)
+	assert.Equal(t, v21, "Id")
+
+	v22, err2 := f.GetCellValue("Sheet1", "B1")
+	assert.NoError(t, err2)
+	assert.Equal(t, v22, "Feild1")
+
+	err3 := f.SetCellsData("Sheet1", "something", nil)
+	assert.EqualError(t, err3, ErrDatasourceTypeValidation.Error())
+
+	emptyStructArray := []struct{
+		Id        int
+		Feild1    string
+		Feild2    float64
+		DateField time.Time
+		}{}
+	err4 := f.SetCellsData("Sheet1", emptyStructArray, nil)
+	assert.EqualError(t, err4, ErrDatasourceValueContent.Error())
+
+	emptyStringArray := []string{"123", "456"}
+	err5 := f.SetCellsData("Sheet1", emptyStringArray, nil)
+	assert.EqualError(t, err5, ErrDatasourceItemTypeValidation.Error())
+}
+
 func TestSetCellBool(t *testing.T) {
 	f := NewFile()
 	assert.EqualError(t, f.SetCellBool("Sheet1", "A", true), `cannot convert cell "A" to coordinates: invalid cell name "A"`)

--- a/errors.go
+++ b/errors.go
@@ -131,4 +131,13 @@ var (
 	// ErrCellCharsLength defined the error message for receiving a cell
 	// characters length that exceeds the limit.
 	ErrCellCharsLength = fmt.Errorf("cell value must be 0-%d characters", TotalCellChars)
+	// ErrDatasourceTypeValidation defined the error message for type of
+	// datasource.
+	ErrDatasourceTypeValidation = errors.New("datasource must be SLICE")
+	// ErrDatasourceValueContent defined the error message for value of
+	// datasource.
+	ErrDatasourceValueContent = errors.New("datasource is nil")
+	// ErrDatasourceItemTypeValidation defined the error message for type of
+	// datasource item.
+	ErrDatasourceItemTypeValidation = errors.New("slice item is not a STRUCT")
 )


### PR DESCRIPTION


# PR Details

this feature enables you to create an excel sheet very simple and fast from a struct array.

## Description

SetCellsData provides a function to insert the values of a struct slice. you can set column names by localize parameter. the key of localize parameter is the name of the struct field. if set localize parameter as a nil value, the column name will be set by struct field name.

## How Has This Been Tested

write unit test for this feature

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
