### PR TITLE
passing excelize.File by value 

### DIFF
--- a/file.go
+++ b/file.go
@@ -52,6 +52,10 @@ func NewFile() *File {
 	ws, _ := f.workSheetReader("Sheet1")
 	f.Sheet.Store("xl/worksheets/sheet1.xml", ws)
 	f.Theme = f.themeReader()
+
+	f.SharedStrings = &xlsxSST{}
+	f.SharedStrings.SI = make([]xlsxSI, 0)
+
 	return f
 }
 

--- a/file_test.go
+++ b/file_test.go
@@ -69,3 +69,22 @@ func TestClose(t *testing.T) {
 	f.tempFiles.Store("/d/", "/d/")
 	require.Error(t, f.Close())
 }
+
+func UpdateExcelizeFile(f File, sheetName string, cellAxis string, cellValue string) {
+	f.SetCellStr(sheetName, cellAxis, cellValue)
+}
+
+func TestPassByValueExcelFile(t *testing.T) {
+	excelFile := NewFile()
+	sheetName := "testSheet"
+	excelFile.NewSheet(sheetName)
+	cellAxis := "A1"
+
+	cellValue := "this is a test"
+	UpdateExcelizeFile(*excelFile, sheetName, cellAxis, cellValue)
+
+	cellValueReturned, getCellErr := excelFile.GetCellValue(sheetName, cellAxis)
+	//fmt.Println("cellValue:", cellValue, "getCellErr:", getCellErr)
+	assert.Equal(t, cellValue, cellValueReturned)
+	assert.Nil(t, getCellErr)
+}


### PR DESCRIPTION
# PR Details

## Description

passing excelize.File by value will result in the caller getting shared-string-table index returned from the cell being queried (when setting strings in cells). Effectively a new instance of the shared strings table will be created.

## Related Issue


## Motivation and Context

You can't pass excelize.File by value and update cells containing strings

## How Has This Been Tested

Added unit test to show how the behavior is now correct

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
