### PR TITLE
Fix call getNumFmtID with builtInNumFmt return -1

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -2229,11 +2229,11 @@ func (f *File) newFont(style *Style) *xlsxFont {
 // If given number format code is not exist, will return -1.
 func getNumFmtID(styleSheet *xlsxStyleSheet, style *Style) (numFmtID int) {
 	numFmtID = -1
-	if styleSheet.NumFmts == nil {
-		return
-	}
 	if _, ok := builtInNumFmt[style.NumFmt]; ok {
 		return style.NumFmt
+	}
+	if styleSheet.NumFmts == nil {
+		return
 	}
 	if fmtCode, ok := currencyNumFmt[style.NumFmt]; ok {
 		for _, numFmt := range styleSheet.NumFmts.NumFmt {

--- a/styles_test.go
+++ b/styles_test.go
@@ -330,3 +330,18 @@ func TestThemeColor(t *testing.T) {
 		assert.Equal(t, clr[0], clr[1])
 	}
 }
+
+func TestGetNumFmtID(t *testing.T) {
+	f := NewFile()
+
+	fs1, err := parseFormatStyleSet(`{"protection":{"hidden":false,"locked":false},"number_format":10}`)
+	assert.NoError(t, err)
+	id1 := getNumFmtID(&xlsxStyleSheet{}, fs1)
+
+	fs2, err := parseFormatStyleSet(`{"protection":{"hidden":false,"locked":false},"number_format":0}`)
+	assert.NoError(t, err)
+	id2 := getNumFmtID(&xlsxStyleSheet{}, fs2)
+
+	assert.NotEqual(t, id1, id2)
+	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestStyleNumFmt.xlsx")))
+}


### PR DESCRIPTION
# PR Details

更改了一下`getNumFmtID()`中内置格式检查和自定义格式检查的顺序

## Description

创建内建`number_format`的`style`，可能会出现返回已经创建的`styleID`的情况。
详细可见提交的test

## Related Issue


## Motivation and Context

解决创建多个仅`number_fomat`不同的`style`时会返回相同的`styleID`

## How Has This Been Tested

已有的和添加的单元测试

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
