### PR TITLE
Compatible with Tabs

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -409,7 +409,7 @@ func setCellStr(value string) (t string, v string, ns xml.Attr) {
 	}
 	if len(value) > 0 {
 		prefix, suffix := value[0], value[len(value)-1]
-		for _, ascii := range []byte{9,10, 13, 32} {
+		for _, ascii := range []byte{9, 10, 13, 32} {
 			if prefix == ascii || suffix == ascii {
 				ns = xml.Attr{
 					Name:  xml.Name{Space: NameSpaceXML, Local: "space"},

--- a/cell.go
+++ b/cell.go
@@ -409,7 +409,7 @@ func setCellStr(value string) (t string, v string, ns xml.Attr) {
 	}
 	if len(value) > 0 {
 		prefix, suffix := value[0], value[len(value)-1]
-		for _, ascii := range []byte{10, 13, 32} {
+		for _, ascii := range []byte{9,10, 13, 32} {
 			if prefix == ascii || suffix == ascii {
 				ns = xml.Attr{
 					Name:  xml.Name{Space: NameSpaceXML, Local: "space"},

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xuri/excelize/v2
+module github.com/vst93/excelize/v2
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vst93/excelize/v2
+module github.com/xuri/excelize/v2
 
 go 1.15
 


### PR DESCRIPTION
# PR Details

Compatible with tabs in string format

## Description

add ascii 9 

## Related Issue


## Motivation and Context

I need to write the string ID in pure numbers, but when the length is too long, after editing office will automatically become scientific notation, so I think it needs to be compatible with tabs

## How Has This Been Tested



## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
