### PR TITLE
Fix adjustMergeCells not modifies cell rect

### DIFF
--- a/adjust.go
+++ b/adjust.go
@@ -226,6 +226,7 @@ func (f *File) adjustMergeCells(ws *xlsxWorksheet, dir adjustDirection, num, off
 			i--
 			continue
 		}
+		areaData.rect = []int{x1, y1, x2, y2}
 		if areaData.Ref, err = f.coordinatesToAreaRef([]int{x1, y1, x2, y2}); err != nil {
 			return err
 		}

--- a/adjust_test.go
+++ b/adjust_test.go
@@ -54,6 +54,7 @@ func TestAdjustMergeCells(t *testing.T) {
 		num    int
 		offset int
 		expect string
+		expectRect []int
 	}
 
 	// testing insert
@@ -64,6 +65,7 @@ func TestAdjustMergeCells(t *testing.T) {
 		num    int
 		offset int
 		expect string
+		expectRect []int
 	}{
 		{
 			label: "insert row on ref",
@@ -72,6 +74,7 @@ func TestAdjustMergeCells(t *testing.T) {
 					Cells: []*xlsxMergeCell{
 						{
 							Ref: "A2:B3",
+							rect: []int{1,2,2,3},
 						},
 					},
 				},
@@ -80,6 +83,7 @@ func TestAdjustMergeCells(t *testing.T) {
 			num:    2,
 			offset: 1,
 			expect: "A3:B4",
+			expectRect: []int{1,3,2,4},
 		},
 		{
 			label: "insert row on bottom of ref",
@@ -88,6 +92,7 @@ func TestAdjustMergeCells(t *testing.T) {
 					Cells: []*xlsxMergeCell{
 						{
 							Ref: "A2:B3",
+							rect: []int{1,2,2,3},
 						},
 					},
 				},
@@ -96,6 +101,7 @@ func TestAdjustMergeCells(t *testing.T) {
 			num:    3,
 			offset: 1,
 			expect: "A2:B4",
+			expectRect: []int{1,2,2,4},
 		},
 		{
 			label: "insert column on the left",
@@ -104,6 +110,7 @@ func TestAdjustMergeCells(t *testing.T) {
 					Cells: []*xlsxMergeCell{
 						{
 							Ref: "A2:B3",
+							rect: []int{1,2,2,3},
 						},
 					},
 				},
@@ -112,11 +119,13 @@ func TestAdjustMergeCells(t *testing.T) {
 			num:    1,
 			offset: 1,
 			expect: "B2:C3",
+			expectRect: []int{2,2,3,3},
 		},
 	}
 	for _, c := range cases {
 		assert.NoError(t, f.adjustMergeCells(c.ws, c.dir, c.num, 1))
 		assert.Equal(t, c.expect, c.ws.MergeCells.Cells[0].Ref, c.label)
+		assert.Equal(t, c.expectRect, c.ws.MergeCells.Cells[0].rect, c.label)
 	}
 
 	// testing delete
@@ -127,6 +136,7 @@ func TestAdjustMergeCells(t *testing.T) {
 		num    int
 		offset int
 		expect string
+		expectRect []int
 	}{
 		{
 			label: "delete row on top of ref",
@@ -135,6 +145,7 @@ func TestAdjustMergeCells(t *testing.T) {
 					Cells: []*xlsxMergeCell{
 						{
 							Ref: "A2:B3",
+							rect: []int{1,2,2,3},
 						},
 					},
 				},
@@ -143,6 +154,7 @@ func TestAdjustMergeCells(t *testing.T) {
 			num:    2,
 			offset: -1,
 			expect: "A2:B2",
+			expectRect: []int{1,2,2,2},
 		},
 		{
 			label: "delete row on bottom of ref",
@@ -151,6 +163,7 @@ func TestAdjustMergeCells(t *testing.T) {
 					Cells: []*xlsxMergeCell{
 						{
 							Ref: "A2:B3",
+							rect: []int{1,2,2,3},
 						},
 					},
 				},
@@ -159,6 +172,7 @@ func TestAdjustMergeCells(t *testing.T) {
 			num:    3,
 			offset: -1,
 			expect: "A2:B2",
+			expectRect: []int{1,2,2,2},
 		},
 		{
 			label: "delete column on the ref left",
@@ -167,6 +181,7 @@ func TestAdjustMergeCells(t *testing.T) {
 					Cells: []*xlsxMergeCell{
 						{
 							Ref: "A2:B3",
+							rect: []int{1,2,2,3},
 						},
 					},
 				},
@@ -175,6 +190,7 @@ func TestAdjustMergeCells(t *testing.T) {
 			num:    1,
 			offset: -1,
 			expect: "A2:A3",
+			expectRect: []int{1,2,1,3},
 		},
 		{
 			label: "delete column on the ref right",
@@ -183,6 +199,7 @@ func TestAdjustMergeCells(t *testing.T) {
 					Cells: []*xlsxMergeCell{
 						{
 							Ref: "A2:B3",
+							rect: []int{1,2,2,3},
 						},
 					},
 				},
@@ -191,6 +208,7 @@ func TestAdjustMergeCells(t *testing.T) {
 			num:    2,
 			offset: -1,
 			expect: "A2:A3",
+			expectRect: []int{1,2,1,3},
 		},
 	}
 	for _, c := range cases {
@@ -206,6 +224,7 @@ func TestAdjustMergeCells(t *testing.T) {
 		num    int
 		offset int
 		expect string
+		expectRect []int
 	}{
 		{
 			label: "delete one row ref",
@@ -214,6 +233,7 @@ func TestAdjustMergeCells(t *testing.T) {
 					Cells: []*xlsxMergeCell{
 						{
 							Ref: "A1:B1",
+							rect: []int{1,1,2,1},
 						},
 					},
 				},
@@ -229,6 +249,7 @@ func TestAdjustMergeCells(t *testing.T) {
 					Cells: []*xlsxMergeCell{
 						{
 							Ref: "A1:A2",
+							rect: []int{1,1,1,2},
 						},
 					},
 				},

--- a/adjust_test.go
+++ b/adjust_test.go
@@ -48,23 +48,23 @@ func TestAdjustMergeCells(t *testing.T) {
 
 	// testing adjustMergeCells
 	var cases []struct {
-		label  string
-		ws     *xlsxWorksheet
-		dir    adjustDirection
-		num    int
-		offset int
-		expect string
+		label      string
+		ws         *xlsxWorksheet
+		dir        adjustDirection
+		num        int
+		offset     int
+		expect     string
 		expectRect []int
 	}
 
 	// testing insert
 	cases = []struct {
-		label  string
-		ws     *xlsxWorksheet
-		dir    adjustDirection
-		num    int
-		offset int
-		expect string
+		label      string
+		ws         *xlsxWorksheet
+		dir        adjustDirection
+		num        int
+		offset     int
+		expect     string
 		expectRect []int
 	}{
 		{
@@ -73,17 +73,17 @@ func TestAdjustMergeCells(t *testing.T) {
 				MergeCells: &xlsxMergeCells{
 					Cells: []*xlsxMergeCell{
 						{
-							Ref: "A2:B3",
-							rect: []int{1,2,2,3},
+							Ref:  "A2:B3",
+							rect: []int{1, 2, 2, 3},
 						},
 					},
 				},
 			},
-			dir:    rows,
-			num:    2,
-			offset: 1,
-			expect: "A3:B4",
-			expectRect: []int{1,3,2,4},
+			dir:        rows,
+			num:        2,
+			offset:     1,
+			expect:     "A3:B4",
+			expectRect: []int{1, 3, 2, 4},
 		},
 		{
 			label: "insert row on bottom of ref",
@@ -91,17 +91,17 @@ func TestAdjustMergeCells(t *testing.T) {
 				MergeCells: &xlsxMergeCells{
 					Cells: []*xlsxMergeCell{
 						{
-							Ref: "A2:B3",
-							rect: []int{1,2,2,3},
+							Ref:  "A2:B3",
+							rect: []int{1, 2, 2, 3},
 						},
 					},
 				},
 			},
-			dir:    rows,
-			num:    3,
-			offset: 1,
-			expect: "A2:B4",
-			expectRect: []int{1,2,2,4},
+			dir:        rows,
+			num:        3,
+			offset:     1,
+			expect:     "A2:B4",
+			expectRect: []int{1, 2, 2, 4},
 		},
 		{
 			label: "insert column on the left",
@@ -109,17 +109,17 @@ func TestAdjustMergeCells(t *testing.T) {
 				MergeCells: &xlsxMergeCells{
 					Cells: []*xlsxMergeCell{
 						{
-							Ref: "A2:B3",
-							rect: []int{1,2,2,3},
+							Ref:  "A2:B3",
+							rect: []int{1, 2, 2, 3},
 						},
 					},
 				},
 			},
-			dir:    columns,
-			num:    1,
-			offset: 1,
-			expect: "B2:C3",
-			expectRect: []int{2,2,3,3},
+			dir:        columns,
+			num:        1,
+			offset:     1,
+			expect:     "B2:C3",
+			expectRect: []int{2, 2, 3, 3},
 		},
 	}
 	for _, c := range cases {
@@ -130,12 +130,12 @@ func TestAdjustMergeCells(t *testing.T) {
 
 	// testing delete
 	cases = []struct {
-		label  string
-		ws     *xlsxWorksheet
-		dir    adjustDirection
-		num    int
-		offset int
-		expect string
+		label      string
+		ws         *xlsxWorksheet
+		dir        adjustDirection
+		num        int
+		offset     int
+		expect     string
 		expectRect []int
 	}{
 		{
@@ -144,17 +144,17 @@ func TestAdjustMergeCells(t *testing.T) {
 				MergeCells: &xlsxMergeCells{
 					Cells: []*xlsxMergeCell{
 						{
-							Ref: "A2:B3",
-							rect: []int{1,2,2,3},
+							Ref:  "A2:B3",
+							rect: []int{1, 2, 2, 3},
 						},
 					},
 				},
 			},
-			dir:    rows,
-			num:    2,
-			offset: -1,
-			expect: "A2:B2",
-			expectRect: []int{1,2,2,2},
+			dir:        rows,
+			num:        2,
+			offset:     -1,
+			expect:     "A2:B2",
+			expectRect: []int{1, 2, 2, 2},
 		},
 		{
 			label: "delete row on bottom of ref",
@@ -162,17 +162,17 @@ func TestAdjustMergeCells(t *testing.T) {
 				MergeCells: &xlsxMergeCells{
 					Cells: []*xlsxMergeCell{
 						{
-							Ref: "A2:B3",
-							rect: []int{1,2,2,3},
+							Ref:  "A2:B3",
+							rect: []int{1, 2, 2, 3},
 						},
 					},
 				},
 			},
-			dir:    rows,
-			num:    3,
-			offset: -1,
-			expect: "A2:B2",
-			expectRect: []int{1,2,2,2},
+			dir:        rows,
+			num:        3,
+			offset:     -1,
+			expect:     "A2:B2",
+			expectRect: []int{1, 2, 2, 2},
 		},
 		{
 			label: "delete column on the ref left",
@@ -180,17 +180,17 @@ func TestAdjustMergeCells(t *testing.T) {
 				MergeCells: &xlsxMergeCells{
 					Cells: []*xlsxMergeCell{
 						{
-							Ref: "A2:B3",
-							rect: []int{1,2,2,3},
+							Ref:  "A2:B3",
+							rect: []int{1, 2, 2, 3},
 						},
 					},
 				},
 			},
-			dir:    columns,
-			num:    1,
-			offset: -1,
-			expect: "A2:A3",
-			expectRect: []int{1,2,1,3},
+			dir:        columns,
+			num:        1,
+			offset:     -1,
+			expect:     "A2:A3",
+			expectRect: []int{1, 2, 1, 3},
 		},
 		{
 			label: "delete column on the ref right",
@@ -198,17 +198,17 @@ func TestAdjustMergeCells(t *testing.T) {
 				MergeCells: &xlsxMergeCells{
 					Cells: []*xlsxMergeCell{
 						{
-							Ref: "A2:B3",
-							rect: []int{1,2,2,3},
+							Ref:  "A2:B3",
+							rect: []int{1, 2, 2, 3},
 						},
 					},
 				},
 			},
-			dir:    columns,
-			num:    2,
-			offset: -1,
-			expect: "A2:A3",
-			expectRect: []int{1,2,1,3},
+			dir:        columns,
+			num:        2,
+			offset:     -1,
+			expect:     "A2:A3",
+			expectRect: []int{1, 2, 1, 3},
 		},
 	}
 	for _, c := range cases {
@@ -218,12 +218,12 @@ func TestAdjustMergeCells(t *testing.T) {
 
 	// testing delete one row/column
 	cases = []struct {
-		label  string
-		ws     *xlsxWorksheet
-		dir    adjustDirection
-		num    int
-		offset int
-		expect string
+		label      string
+		ws         *xlsxWorksheet
+		dir        adjustDirection
+		num        int
+		offset     int
+		expect     string
 		expectRect []int
 	}{
 		{
@@ -232,8 +232,8 @@ func TestAdjustMergeCells(t *testing.T) {
 				MergeCells: &xlsxMergeCells{
 					Cells: []*xlsxMergeCell{
 						{
-							Ref: "A1:B1",
-							rect: []int{1,1,2,1},
+							Ref:  "A1:B1",
+							rect: []int{1, 1, 2, 1},
 						},
 					},
 				},
@@ -248,8 +248,8 @@ func TestAdjustMergeCells(t *testing.T) {
 				MergeCells: &xlsxMergeCells{
 					Cells: []*xlsxMergeCell{
 						{
-							Ref: "A1:A2",
-							rect: []int{1,1,1,2},
+							Ref:  "A1:A2",
+							rect: []int{1, 1, 1, 2},
 						},
 					},
 				},

--- a/rows.go
+++ b/rows.go
@@ -661,7 +661,8 @@ func (f *File) DuplicateRowTo(sheet string, row, row2 int) error {
 	if err != nil {
 		return err
 	}
-	if row > len(ws.SheetData.Row) || row2 < 1 || row == row2 {
+
+	if row2 < 1 || row == row2 {
 		return nil
 	}
 
@@ -675,12 +676,13 @@ func (f *File) DuplicateRowTo(sheet string, row, row2 int) error {
 			break
 		}
 	}
-	if !ok {
-		return nil
-	}
 
 	if err := f.adjustHelper(sheet, rows, row2, 1); err != nil {
 		return err
+	}
+
+	if !ok {
+		return nil
 	}
 
 	idx2 := -1

--- a/rows_test.go
+++ b/rows_test.go
@@ -847,7 +847,18 @@ func TestDuplicateRowInvalidRowNum(t *testing.T) {
 }
 
 func TestDuplicateRowTo(t *testing.T) {
-	f := File{}
+	f, sheetName := NewFile(), "Sheet1"
+	// Test duplicate row with invalid target row number
+	assert.Equal(t, nil, f.DuplicateRowTo(sheetName, 1, 0))
+	// Test duplicate row with equal source and target row number
+	assert.Equal(t, nil, f.DuplicateRowTo(sheetName, 1, 1))
+	// Test duplicate row on the blank worksheet
+	assert.Equal(t, nil, f.DuplicateRowTo(sheetName, 1, 2))
+	// Test duplicate row on the worksheet with illegal cell coordinates
+	f.Sheet.Store("xl/worksheets/sheet1.xml", &xlsxWorksheet{
+		MergeCells: &xlsxMergeCells{Cells: []*xlsxMergeCell{{Ref: "A:B1"}}}})
+	assert.EqualError(t, f.DuplicateRowTo(sheetName, 1, 2), newCellNameToCoordinatesError("A", newInvalidCellNameError("A")).Error())
+	// Test duplicate row on not exists worksheet
 	assert.EqualError(t, f.DuplicateRowTo("SheetN", 1, 2), "sheet SheetN is not exist")
 }
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -669,6 +669,7 @@ func TestDuplicateRowInsertBefore(t *testing.T) {
 		f := newFileWithDefaults()
 
 		assert.NoError(t, f.DuplicateRowTo(sheet, 2, 1))
+		assert.NoError(t, f.DuplicateRowTo(sheet, 10, 4))
 
 		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, "InsertBefore"))) {
 			t.FailNow()
@@ -678,7 +679,7 @@ func TestDuplicateRowInsertBefore(t *testing.T) {
 			"A1": cells["A2"], "B1": cells["B2"],
 			"A2": cells["A1"], "B2": cells["B1"],
 			"A3": cells["A2"], "B3": cells["B2"],
-			"A4": cells["A3"], "B4": cells["B3"],
+			"A5": cells["A3"], "B5": cells["B3"],
 		}
 		for cell, val := range expect {
 			v, err := f.GetCellValue(sheet, cell)


### PR DESCRIPTION
Fix DuplicateRowTo unvalied thad duplicates later row to forehead

# PR Details

Fix adjustMergeCells not modifies cell rect and DuplicateRowTo unvalied thad duplicates later row to forehead

## Description

`MergeCell` after `DupliacteRowTo` will get unexpected result. Such as below cases: 
```go
         // Test merge cell after duplicate null row
	{
		f := excelize.NewFile()
		sheet := "Sheet1"
		assert.NoError(t, f.MergeCell(sheet,"A4","A5"))

		assert.NoError(t, f.DuplicateRowTo(sheet, 2, 3))
		assert.NoError(t, f.DuplicateRowTo(sheet, 2, 4))
		assert.NoError(t, f.MergeCell(sheet,"A2","A3"))
		assert.NoError(t, f.MergeCell(sheet,"A3","A4"))

		mergeCells, err := f.GetMergeCells(sheet)
		assert.NoError(t, err)
		assert.ElementsMatch(t, mergeCells, []excelize.MergeCell{{"A6:A7",""},{"A2:A4",""}})
	}

	// Test merge cell after duplicate null col
	{

		f := excelize.NewFile()
		sheet := "Sheet1"

		assert.NoError(t, f.MergeCell(sheet,"D1","E1"))

		assert.NoError(t, f.InsertCol(sheet, "C"))
		assert.NoError(t, f.InsertCol(sheet, "D"))
		assert.NoError(t, f.MergeCell(sheet,"B1","C1"))
		assert.NoError(t, f.MergeCell(sheet,"C1","D1"))

		mergeCells, err := f.GetMergeCells(sheet)
		assert.NoError(t, err)
		assert.ElementsMatch(t, mergeCells, []excelize.MergeCell{{"B1:D1",""},{"F1:G1",""}})
	}
```
Related unit test have been added in test file.

## Related Issue

## Motivation and Context

## How Has This Been Tested

Run unit testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
