### PR TITLE
Added view configuration to SheetView

### DIFF
--- a/sheetview.go
+++ b/sheetview.go
@@ -59,6 +59,11 @@ type (
 	// when the flag is true. (Default setting is true.)
 	ShowZeros bool
 
+	// View is a SheetViewOption. It specifies a flag indicating
+	// how sheet is displayed, by default it uses empty string
+	// avl options: pageLayout, pageBreakPreview
+	View string
+	
 	/* TODO
 	// ShowWhiteSpace is a SheetViewOption. It specifies a flag indicating
 	// whether page layout view shall display margins. False means do not display
@@ -78,6 +83,14 @@ func (o TopLeftCell) setSheetViewOption(view *xlsxSheetView) {
 
 func (o *TopLeftCell) getSheetViewOption(view *xlsxSheetView) {
 	*o = TopLeftCell(string(view.TopLeftCell))
+}
+
+func (o View) setSheetViewOption(view *xlsxSheetView) {
+	view.View = string(o)
+}
+
+func (o *View) getSheetViewOption(view *xlsxSheetView) {
+	*o = View(string(view.View))
 }
 
 func (o DefaultGridColor) setSheetViewOption(view *xlsxSheetView) {

--- a/sheetview.go
+++ b/sheetview.go
@@ -58,10 +58,9 @@ type (
 	// When using a formula to reference another cell which is empty, the referenced value becomes 0
 	// when the flag is true. (Default setting is true.)
 	ShowZeros bool
-
 	// View is a SheetViewOption. It specifies a flag indicating
 	// how sheet is displayed, by default it uses empty string
-	// avl options: pageLayout, pageBreakPreview
+	// available options: pageLayout, pageBreakPreview
 	View string
 	
 	/* TODO

--- a/sheetview_test.go
+++ b/sheetview_test.go
@@ -14,6 +14,7 @@ var _ = []SheetViewOption{
 	ShowGridLines(true),
 	ShowRowColHeaders(true),
 	TopLeftCell("B2"),
+	View("pageLayout"),
 	// SheetViewOptionPtr are also SheetViewOption
 	new(DefaultGridColor),
 	new(RightToLeft),
@@ -30,6 +31,7 @@ var _ = []SheetViewOptionPtr{
 	(*ShowGridLines)(nil),
 	(*ShowRowColHeaders)(nil),
 	(*TopLeftCell)(nil),
+	(*View)(nil),
 }
 
 func ExampleFile_SetSheetViewOptions() {
@@ -44,6 +46,7 @@ func ExampleFile_SetSheetViewOptions() {
 		ShowRowColHeaders(true),
 		ZoomScale(80),
 		TopLeftCell("C3"),
+		View("pageLayout"),
 	); err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
Hi @xuri 

I'm adding an additional configuration, for how sheet is presented:

Normal:
```
<sheetViews>
    <sheetView workbookViewId="0" tabSelected="1"/>
</sheetViews>
```

Page Break Preview: `view="pageBreakPreview" `

```
<sheetViews>
    <sheetView workbookViewId="0" zoomScaleNormal="100" zoomScale="60" view="pageBreakPreview" tabSelected="1"/>
</sheetViews>
```

Page Layout: `view="pageLayout"`

```
<sheetViews>
    <sheetView workbookViewId="0" zoomScaleNormal="100" view="pageLayout" tabSelected="1"/>
</sheetViews>
```

![image](https://user-images.githubusercontent.com/4760084/152353013-5d6e8fc0-407d-45ee-a534-4689bc40b3a9.png)

