### PR TITLE
Add Showruler to Sheetview

### DIFF
--- a/sheetview.go
+++ b/sheetview.go
@@ -62,7 +62,10 @@ type (
 	// how sheet is displayed, by default it uses empty string
 	// available options: pageLayout, pageBreakPreview
 	View string
-	
+	// ShowRuler is a SheetViewOption. It specifies a flag indicating
+	// this sheet should display ruler.
+	ShowRuler bool
+
 	/* TODO
 	// ShowWhiteSpace is a SheetViewOption. It specifies a flag indicating
 	// whether page layout view shall display margins. False means do not display
@@ -122,6 +125,14 @@ func (o ShowGridLines) setSheetViewOption(view *xlsxSheetView) {
 
 func (o *ShowGridLines) getSheetViewOption(view *xlsxSheetView) {
 	*o = ShowGridLines(defaultTrue(view.ShowGridLines)) // Excel default: true
+}
+
+func (o ShowRuler) setSheetViewOption(view *xlsxSheetView) {
+	view.ShowRuler = boolPtr(bool(o))
+}
+
+func (o *ShowRuler) getSheetViewOption(view *xlsxSheetView) {
+	*o = ShowRuler(defaultTrue(view.ShowRuler)) // Excel default: true
 }
 
 func (o ShowZeros) setSheetViewOption(view *xlsxSheetView) {

--- a/sheetview.go
+++ b/sheetview.go
@@ -60,7 +60,7 @@ type (
 	ShowZeros bool
 	// View is a SheetViewOption. It specifies a flag indicating
 	// how sheet is displayed, by default it uses empty string
-	// available options: pageLayout, pageBreakPreview
+	// available options: normal, pageLayout, pageBreakPreview
 	View string
 	// ShowRuler is a SheetViewOption. It specifies a flag indicating
 	// this sheet should display ruler.

--- a/sheetview_test.go
+++ b/sheetview_test.go
@@ -15,6 +15,7 @@ var _ = []SheetViewOption{
 	ShowRowColHeaders(true),
 	TopLeftCell("B2"),
 	View("pageLayout"),
+	ShowRuler(false),
 	// SheetViewOptionPtr are also SheetViewOption
 	new(DefaultGridColor),
 	new(RightToLeft),
@@ -32,6 +33,7 @@ var _ = []SheetViewOptionPtr{
 	(*ShowRowColHeaders)(nil),
 	(*TopLeftCell)(nil),
 	(*View)(nil),
+	(*ShowRuler)(nil),
 }
 
 func ExampleFile_SetSheetViewOptions() {
@@ -47,6 +49,7 @@ func ExampleFile_SetSheetViewOptions() {
 		ZoomScale(80),
 		TopLeftCell("C3"),
 		View("pageLayout"),
+		ShowRuler(false),
 	); err != nil {
 		fmt.Println(err)
 	}

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -191,6 +191,7 @@ type xlsxSheetView struct {
 	ShowZeros                *bool            `xml:"showZeros,attr,omitempty"`
 	RightToLeft              bool             `xml:"rightToLeft,attr,omitempty"`
 	TabSelected              bool             `xml:"tabSelected,attr,omitempty"`
+	ShowRuler                *bool            `xml:"showRuler,attr,omitempty"`
 	ShowWhiteSpace           *bool            `xml:"showWhiteSpace,attr"`
 	ShowOutlineSymbols       bool             `xml:"showOutlineSymbols,attr,omitempty"`
 	DefaultGridColor         *bool            `xml:"defaultGridColor,attr"`
@@ -204,7 +205,6 @@ type xlsxSheetView struct {
 	WorkbookViewID           int              `xml:"workbookViewId,attr"`
 	Pane                     *xlsxPane        `xml:"pane,omitempty"`
 	Selection                []*xlsxSelection `xml:"selection"`
-	ShowRuler                *bool            `xml:"showRuler,attr,omitempty"`
 }
 
 // xlsxSelection directly maps the selection element in the namespace

--- a/xmlWorksheet.go
+++ b/xmlWorksheet.go
@@ -204,6 +204,7 @@ type xlsxSheetView struct {
 	WorkbookViewID           int              `xml:"workbookViewId,attr"`
 	Pane                     *xlsxPane        `xml:"pane,omitempty"`
 	Selection                []*xlsxSelection `xml:"selection"`
+	ShowRuler                *bool            `xml:"showRuler,attr,omitempty"`
 }
 
 // xlsxSelection directly maps the selection element in the namespace


### PR DESCRIPTION
This adds showRuler="false" to hide ruler from sheetView

```
<sheetViews>
<sheetView workbookViewId="0" zoomScaleNormal="100" view="pageLayout" showRuler="false" tabSelected="1" showRowColHeaders="0" showGridLines="0"/>
</sheetViews>
```

![image](https://user-images.githubusercontent.com/4760084/152604920-c5cbf68f-e764-4230-bcb7-8a275d68b280.png)
