### PR TITLE
added macro functionality to shape

### DIFF
--- a/shape.go
+++ b/shape.go
@@ -32,7 +32,8 @@ func parseFormatShapeSet(formatSet string) (*formatShape, error) {
 			XScale:           1.0,
 			YScale:           1.0,
 		},
-		Line: formatLine{Width: 1},
+		Line:  formatLine{Width: 1},
+		Macro: "",
 	}
 	err := json.Unmarshal([]byte(formatSet), &format)
 	return &format, err
@@ -369,6 +370,7 @@ func (f *File) addDrawingShape(sheet, drawingXML, cell string, formatSet *format
 	twoCellAnchor.From = &from
 	twoCellAnchor.To = &to
 	shape := xdrSp{
+		Macro: formatSet.Macro,
 		NvSpPr: &xdrNvSpPr{
 			CNvPr: &xlsxCNvPr{
 				ID:   cNvPrID,

--- a/xmlDrawing.go
+++ b/xmlDrawing.go
@@ -477,6 +477,7 @@ type formatPicture struct {
 
 // formatShape directly maps the format settings of the shape.
 type formatShape struct {
+	Macro     string                 `json:"macro"`
 	Type      string                 `json:"type"`
 	Width     int                    `json:"width"`
 	Height    int                    `json:"height"`


### PR DESCRIPTION
this adds macro functionality to shape:

Ex. 
![image](https://user-images.githubusercontent.com/4760084/158033103-511dd1b5-ae2b-4885-95cb-6937aaa4e3b4.png)

```
_ = f.AddShape("Sheet1", "A6", `{
    "macro": "say_hello",
    "type": "rect",
    "color":
    {
        "line": "#4286F4",
        "fill": "#8eb9ff"
    },
    "paragraph": [
    {
        "text": "Rectangle Shape",
        "font":
        {
            "bold": true,
            "color": "#777777",
            "underline": "sng"
        }
    }],
    "width": 50,
    "height": 20,
    "line":
    {
        "width": 1.5
    }
}`)
```