### PR TITLE
worksheet-shape-paragraph-alignment

### DIFF
--- a/shape.go
+++ b/shape.go
@@ -435,6 +435,7 @@ func (f *File) addDrawingShape(sheet, drawingXML, cell string, formatSet *format
 			text = " "
 		}
 		paragraph := &aP{
+			PPr: &aPPr{Alg: getParagraphAligment(p.Alignment)},
 			R: &aR{
 				RPr: aRPr{
 					I:       p.Font.Italic,
@@ -469,6 +470,19 @@ func (f *File) addDrawingShape(sheet, drawingXML, cell string, formatSet *format
 	content.TwoCellAnchor = append(content.TwoCellAnchor, &twoCellAnchor)
 	f.Drawings.Store(drawingXML, content)
 	return err
+}
+
+func getParagraphAligment(code string) string {
+	aligment := "l"
+	aligmentCode := map[string]string{
+		"center": "ctr",
+		"left":   "l",
+		"right":  "r",
+	}
+	if val, ok := aligmentCode[code]; ok {
+		aligment = val
+	}
+	return aligment
 }
 
 // setShapeRef provides a function to set color with hex model by given actual

--- a/xmlChart.go
+++ b/xmlChart.go
@@ -116,7 +116,8 @@ type aP struct {
 // formatting, since they are directly applied to the paragraph and supersede
 // any formatting from styles.
 type aPPr struct {
-	DefRPr aRPr `xml:"a:defRPr"`
+	Alg    string `xml:"algn,attr"`
+	DefRPr aRPr   `xml:"a:defRPr"`
 }
 
 // aSolidFill (Solid Fill) directly maps the solidFill element. This element

--- a/xmlDrawing.go
+++ b/xmlDrawing.go
@@ -489,8 +489,9 @@ type formatShape struct {
 // formatShapeParagraph directly maps the format settings of the paragraph in
 // the shape.
 type formatShapeParagraph struct {
-	Font Font   `json:"font"`
-	Text string `json:"text"`
+	Font      Font   `json:"font"`
+	Text      string `json:"text"`
+	Alignment string `json:"alignment"`
 }
 
 // formatShapeColor directly maps the color settings of the shape.


### PR DESCRIPTION
# PR Details

 adds Alignment functionality to shape paragraph, 

Available options left, center, right

```
_ = f.AddShape("Sheet1", "A6", `{
    "type": "rect",
    "color":
    {
        "line": "#4286F4",
        "fill": "#8eb9ff"
    },
    "paragraph": [
    {
        "text": "Rectangle Shape",
        "font":
        {
            "bold": true,
            "color": "#ffffff"
        },
		"alignment": "right"
    }],
    "width": 250,
    "height": 25,
    "line":
    {
        "width": 1.5
    }
}`)
```

![image](https://user-images.githubusercontent.com/4760084/158073504-fce1cce8-c1eb-49a6-a367-fbe4fcd175d2.png)

