### PR TITLE
refactor: replace strings.Replace with strings.ReplaceAll

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -1360,7 +1360,7 @@ func (f *File) parseToken(sheet string, token efp.Token, opdStack, optStack *Sta
 // parseReference parse reference and extract values by given reference
 // characters and default sheet name.
 func (f *File) parseReference(sheet, reference string) (arg formulaArg, err error) {
-	reference = strings.Replace(reference, "$", "", -1)
+	reference = strings.ReplaceAll(reference, "$", "")
 	refs, cellRanges, cellRefs := list.New(), list.New(), list.New()
 	for _, ref := range strings.Split(reference, ":") {
 		tokens := strings.Split(ref, "!")
@@ -2065,13 +2065,13 @@ func cmplx2str(num complex128, suffix string) string {
 	c = strings.TrimSuffix(c, "+0i")
 	c = strings.TrimSuffix(c, "-0i")
 	c = strings.NewReplacer("+1i", "+i", "-1i", "-i").Replace(c)
-	c = strings.Replace(c, "i", suffix, -1)
+	c = strings.ReplaceAll(c, "i", suffix)
 	return c
 }
 
 // str2cmplx convert complex number string characters.
 func str2cmplx(c string) string {
-	c = strings.Replace(c, "j", "i", -1)
+	c = strings.ReplaceAll(c, "j", "i")
 	if c == "i" {
 		c = "1i"
 	}
@@ -13489,7 +13489,7 @@ func (fn *formulaFuncs) SUBSTITUTE(argsList *list.List) formulaArg {
 	text, oldText := argsList.Front().Value.(formulaArg), argsList.Front().Next().Value.(formulaArg)
 	newText, instanceNum := argsList.Front().Next().Next().Value.(formulaArg), 0
 	if argsList.Len() == 3 {
-		return newStringFormulaArg(strings.Replace(text.Value(), oldText.Value(), newText.Value(), -1))
+		return newStringFormulaArg(strings.ReplaceAll(text.Value(), oldText.Value(), newText.Value()))
 	}
 	instanceNumArg := argsList.Back().Value.(formulaArg).ToNumber()
 	if instanceNumArg.Type != ArgNumber {
@@ -14804,7 +14804,7 @@ func (fn *formulaFuncs) ENCODEURL(argsList *list.List) formulaArg {
 		return newErrorFormulaArg(formulaErrorVALUE, "ENCODEURL requires 1 argument")
 	}
 	token := argsList.Front().Value.(formulaArg).Value()
-	return newStringFormulaArg(strings.Replace(url.QueryEscape(token), "+", "%20", -1))
+	return newStringFormulaArg(strings.ReplaceAll(url.QueryEscape(token), "+", "%20"))
 }
 
 // Financial Functions

--- a/chart.go
+++ b/chart.go
@@ -1001,7 +1001,7 @@ func (f *File) DeleteChart(sheet, cell string) (err error) {
 	if ws.Drawing == nil {
 		return
 	}
-	drawingXML := strings.Replace(f.getSheetRelationshipsTargetByID(sheet, ws.Drawing.RID), "..", "xl", -1)
+	drawingXML := strings.ReplaceAll(f.getSheetRelationshipsTargetByID(sheet, ws.Drawing.RID), "..", "xl")
 	return f.deleteDrawing(col, row, drawingXML, "Chart")
 }
 

--- a/comment.go
+++ b/comment.go
@@ -112,7 +112,7 @@ func (f *File) AddComment(sheet, cell, format string) error {
 		// The worksheet already has a comments relationships, use the relationships drawing ../drawings/vmlDrawing%d.vml.
 		sheetRelationshipsDrawingVML = f.getSheetRelationshipsTargetByID(sheet, ws.LegacyDrawing.RID)
 		commentID, _ = strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(sheetRelationshipsDrawingVML, "../drawings/vmlDrawing"), ".vml"))
-		drawingVML = strings.Replace(sheetRelationshipsDrawingVML, "..", "xl", -1)
+		drawingVML = strings.ReplaceAll(sheetRelationshipsDrawingVML, "..", "xl")
 	} else {
 		// Add first comment for given sheet.
 		sheetRels := "xl/worksheets/_rels/" + strings.TrimPrefix(f.sheetMap[trimSheetName(sheet)], "xl/worksheets/") + ".rels"

--- a/drawing.go
+++ b/drawing.go
@@ -30,7 +30,7 @@ func (f *File) prepareDrawing(ws *xlsxWorksheet, drawingID int, sheet, drawingXM
 		// The worksheet already has a picture or chart relationships, use the relationships drawing ../drawings/drawing%d.xml.
 		sheetRelationshipsDrawingXML = f.getSheetRelationshipsTargetByID(sheet, ws.Drawing.RID)
 		drawingID, _ = strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(sheetRelationshipsDrawingXML, "../drawings/drawing"), ".xml"))
-		drawingXML = strings.Replace(sheetRelationshipsDrawingXML, "..", "xl", -1)
+		drawingXML = strings.ReplaceAll(sheetRelationshipsDrawingXML, "..", "xl")
 	} else {
 		// Add first picture for given sheet.
 		sheetRels := "xl/worksheets/_rels/" + strings.TrimPrefix(f.sheetMap[trimSheetName(sheet)], "xl/worksheets/") + ".rels"

--- a/lib.go
+++ b/lib.go
@@ -43,7 +43,7 @@ func (f *File) ReadZipReader(r *zip.Reader) (map[string][]byte, int, error) {
 		if unzipSize > f.options.UnzipSizeLimit {
 			return fileList, worksheets, newUnzipSizeLimitError(f.options.UnzipSizeLimit)
 		}
-		fileName := strings.Replace(v.Name, "\\", "/", -1)
+		fileName := strings.ReplaceAll(v.Name, "\\", "/")
 		if partName, ok := docPart[strings.ToLower(fileName)]; ok {
 			fileName = partName
 		}
@@ -284,7 +284,7 @@ func CoordinatesToCellName(col, row int, abs ...bool) (string, error) {
 // areaRefToCoordinates provides a function to convert area reference to a
 // pair of coordinates.
 func areaRefToCoordinates(ref string) ([]int, error) {
-	rng := strings.Split(strings.Replace(ref, "$", "", -1), ":")
+	rng := strings.Split(strings.ReplaceAll(ref, "$", ""), ":")
 	if len(rng) < 2 {
 		return nil, ErrParameterInvalid
 	}

--- a/picture.go
+++ b/picture.go
@@ -508,12 +508,12 @@ func (f *File) GetPicture(sheet, cell string) (string, []byte, error) {
 		return "", nil, err
 	}
 	target := f.getSheetRelationshipsTargetByID(sheet, ws.Drawing.RID)
-	drawingXML := strings.Replace(target, "..", "xl", -1)
+	drawingXML := strings.ReplaceAll(target, "..", "xl")
 	if _, ok := f.Pkg.Load(drawingXML); !ok {
 		return "", nil, err
 	}
-	drawingRelationships := strings.Replace(
-		strings.Replace(target, "../drawings", "xl/drawings/_rels", -1), ".xml", ".xml.rels", -1)
+	drawingRelationships := strings.ReplaceAll(
+		strings.ReplaceAll(target, "../drawings", "xl/drawings/_rels"), ".xml", ".xml.rels")
 
 	return f.getPicture(row, col, drawingXML, drawingRelationships)
 }
@@ -535,7 +535,7 @@ func (f *File) DeletePicture(sheet, cell string) (err error) {
 	if ws.Drawing == nil {
 		return
 	}
-	drawingXML := strings.Replace(f.getSheetRelationshipsTargetByID(sheet, ws.Drawing.RID), "..", "xl", -1)
+	drawingXML := strings.ReplaceAll(f.getSheetRelationshipsTargetByID(sheet, ws.Drawing.RID), "..", "xl")
 	return f.deleteDrawing(col, row, drawingXML, "Pic")
 }
 
@@ -573,7 +573,7 @@ func (f *File) getPicture(row, col int, drawingXML, drawingRelationships string)
 				drawRel = f.getDrawingRelationships(drawingRelationships, deTwoCellAnchor.Pic.BlipFill.Blip.Embed)
 				if _, ok = supportedImageTypes[filepath.Ext(drawRel.Target)]; ok {
 					ret = filepath.Base(drawRel.Target)
-					if buffer, _ := f.Pkg.Load(strings.Replace(drawRel.Target, "..", "xl", -1)); buffer != nil {
+					if buffer, _ := f.Pkg.Load(strings.ReplaceAll(drawRel.Target, "..", "xl")); buffer != nil {
 						buf = buffer.([]byte)
 					}
 					return
@@ -602,7 +602,7 @@ func (f *File) getPictureFromWsDr(row, col int, drawingRelationships string, wsD
 					anchor.Pic.BlipFill.Blip.Embed); drawRel != nil {
 					if _, ok = supportedImageTypes[filepath.Ext(drawRel.Target)]; ok {
 						ret = filepath.Base(drawRel.Target)
-						if buffer, _ := f.Pkg.Load(strings.Replace(drawRel.Target, "..", "xl", -1)); buffer != nil {
+						if buffer, _ := f.Pkg.Load(strings.ReplaceAll(drawRel.Target, "..", "xl")); buffer != nil {
 							buf = buffer.([]byte)
 						}
 						return

--- a/pivotTable.go
+++ b/pivotTable.go
@@ -141,7 +141,7 @@ func (f *File) AddPivotTable(opt *PivotTableOption) error {
 	pivotCacheID := f.countPivotCache() + 1
 
 	sheetRelationshipsPivotTableXML := "../pivotTables/pivotTable" + strconv.Itoa(pivotTableID) + ".xml"
-	pivotTableXML := strings.Replace(sheetRelationshipsPivotTableXML, "..", "xl", -1)
+	pivotTableXML := strings.ReplaceAll(sheetRelationshipsPivotTableXML, "..", "xl")
 	pivotCacheXML := "xl/pivotCache/pivotCacheDefinition" + strconv.Itoa(pivotCacheID) + ".xml"
 	err = f.addPivotCache(pivotCacheXML, opt)
 	if err != nil {
@@ -206,7 +206,7 @@ func (f *File) adjustRange(rangeStr string) (string, []int, error) {
 	if len(rng) != 2 {
 		return "", []int{}, ErrParameterInvalid
 	}
-	trimRng := strings.Replace(rng[1], "$", "", -1)
+	trimRng := strings.ReplaceAll(rng[1], "$", "")
 	coordinates, err := areaRefToCoordinates(trimRng)
 	if err != nil {
 		return rng[0], []int{}, err

--- a/shape.go
+++ b/shape.go
@@ -297,7 +297,7 @@ func (f *File) AddShape(sheet, cell, format string) error {
 		// The worksheet already has a shape or chart relationships, use the relationships drawing ../drawings/drawing%d.xml.
 		sheetRelationshipsDrawingXML = f.getSheetRelationshipsTargetByID(sheet, ws.Drawing.RID)
 		drawingID, _ = strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(sheetRelationshipsDrawingXML, "../drawings/drawing"), ".xml"))
-		drawingXML = strings.Replace(sheetRelationshipsDrawingXML, "..", "xl", -1)
+		drawingXML = strings.ReplaceAll(sheetRelationshipsDrawingXML, "..", "xl")
 	} else {
 		// Add first shape for given sheet.
 		sheetRels := "xl/worksheets/_rels/" + strings.TrimPrefix(f.sheetMap[trimSheetName(sheet)], "xl/worksheets/") + ".rels"
@@ -448,7 +448,7 @@ func (f *File) addDrawingShape(sheet, drawingXML, cell string, formatSet *format
 				Lang: "en-US",
 			},
 		}
-		srgbClr := strings.Replace(strings.ToUpper(p.Font.Color), "#", "", -1)
+		srgbClr := strings.ReplaceAll(strings.ToUpper(p.Font.Color), "#", "")
 		if len(srgbClr) == 6 {
 			paragraph.R.RPr.SolidFill = &aSolidFill{
 				SrgbClr: &attrValString{
@@ -484,7 +484,7 @@ func setShapeRef(color string, i int) *aRef {
 	return &aRef{
 		Idx: i,
 		SrgbClr: &attrValString{
-			Val: stringPtr(strings.Replace(strings.ToUpper(color), "#", "", -1)),
+			Val: stringPtr(strings.ReplaceAll(strings.ToUpper(color), "#", "")),
 		},
 	}
 }

--- a/sheet.go
+++ b/sheet.go
@@ -99,9 +99,9 @@ func (f *File) contentTypesWriter() {
 // and /xl/worksheets/sheet%d.xml
 func (f *File) getWorksheetPath(relTarget string) (path string) {
 	path = filepath.ToSlash(strings.TrimPrefix(
-		strings.Replace(filepath.Clean(fmt.Sprintf("%s/%s", filepath.Dir(f.getWorkbookPath()), relTarget)), "\\", "/", -1), "/"))
+		strings.ReplaceAll(filepath.Clean(fmt.Sprintf("%s/%s", filepath.Dir(f.getWorkbookPath()), relTarget)), "\\", "/"), "/"))
 	if strings.HasPrefix(relTarget, "/") {
-		path = filepath.ToSlash(strings.TrimPrefix(strings.Replace(filepath.Clean(relTarget), "\\", "/", -1), "/"))
+		path = filepath.ToSlash(strings.TrimPrefix(strings.ReplaceAll(filepath.Clean(relTarget), "\\", "/"), "/"))
 	}
 	return path
 }

--- a/stream.go
+++ b/stream.go
@@ -206,7 +206,7 @@ func (sw *StreamWriter) AddTable(hCell, vCell, format string) error {
 	}
 
 	sheetRelationshipsTableXML := "../tables/table" + strconv.Itoa(tableID) + ".xml"
-	tableXML := strings.Replace(sheetRelationshipsTableXML, "..", "xl", -1)
+	tableXML := strings.ReplaceAll(sheetRelationshipsTableXML, "..", "xl")
 
 	// Add first table for given sheet.
 	sheetPath := sw.File.sheetMap[trimSheetName(sw.Sheet)]

--- a/styles.go
+++ b/styles.go
@@ -2123,7 +2123,7 @@ func newNumFmt(styleSheet *xlsxStyleSheet, style *Style) int {
 		if !currency {
 			return setLangNumFmt(styleSheet, style)
 		}
-		fc = strings.Replace(fc, "0.00", dp, -1)
+		fc = strings.ReplaceAll(fc, "0.00", dp)
 		if style.NegRed {
 			fc = fc + ";[Red]" + fc
 		}
@@ -3018,7 +3018,7 @@ func drawConfFmtExp(p int, ct string, format *formatConditional) *xlsxCfRule {
 // getPaletteColor provides a function to convert the RBG color by given
 // string.
 func getPaletteColor(color string) string {
-	return "FF" + strings.Replace(strings.ToUpper(color), "#", "", -1)
+	return "FF" + strings.ReplaceAll(strings.ToUpper(color), "#", "")
 }
 
 // themeReader provides a function to get the pointer to the xl/theme/theme1.xml

--- a/table.go
+++ b/table.go
@@ -83,7 +83,7 @@ func (f *File) AddTable(sheet, hCell, vCell, format string) error {
 
 	tableID := f.countTables() + 1
 	sheetRelationshipsTableXML := "../tables/table" + strconv.Itoa(tableID) + ".xml"
-	tableXML := strings.Replace(sheetRelationshipsTableXML, "..", "xl", -1)
+	tableXML := strings.ReplaceAll(sheetRelationshipsTableXML, "..", "xl")
 	// Add first table for given sheet.
 	sheetRels := "xl/worksheets/_rels/" + strings.TrimPrefix(f.sheetMap[trimSheetName(sheet)], "xl/worksheets/") + ".rels"
 	rID := f.addRels(sheetRels, SourceRelationshipTable, sheetRelationshipsTableXML, "")


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace `strings.Replace(s, old, new, -1)` with `strings.ReplaceAll(s, old, new)`. `strings.ReplaceAll` is a wrapper function for `strings.Replace`, but `strings.ReplaceAll` is more readable and removes the hardcoded `-1`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We have been using `strings.ReplaceAll` in other files already before this PR. This PR just makes the code more explicit when we want to do a full string replacement. 

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
~ ❯ go version                                              
go version go1.18.2 linux/amd64

~ ❯ uname -a
Linux ThinkPad-L14 5.18.3-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 09 Jun 2022 16:14:10 +0000 x86_64 GNU/Linux

~ ❯ go test -v -race ./...
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
