### PR TITLE
bugfix: sheet name is case-insensitive

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -376,7 +376,7 @@ func (f *File) GetSheetName(index int) (name string) {
 // integer type value -1.
 func (f *File) getSheetID(name string) int {
 	for sheetID, sheet := range f.GetSheetMap() {
-		if sheet == trimSheetName(name) {
+		if strings.EqualFold(sheet, trimSheetName(name)) {
 			return sheetID
 		}
 	}

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -465,6 +465,13 @@ func TestDeleteAndAdjustDefinedNames(t *testing.T) {
 	deleteAndAdjustDefinedNames(&xlsxWorkbook{}, 0)
 }
 
+func TestGetSheetID(t *testing.T) {
+	file := NewFile()
+	file.NewSheet("Sheet1")
+	id := file.getSheetID("sheet1")
+	assert.NotEqual(t, -1, id)
+}
+
 func BenchmarkNewSheet(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -497,11 +504,4 @@ func newSheetWithSave() {
 		_ = file.SetCellInt("sheet1", "A"+strconv.Itoa(i+1), i)
 	}
 	_ = file.Save()
-}
-
-func TestFile_getSheetID_CaseInsensitivity(t *testing.T) {
-	file := NewFile()
-	file.NewSheet("Sheet1")
-	id := file.getSheetID("sheet1")
-	assert.NotEqual(t, -1, id)
 }

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -498,3 +498,10 @@ func newSheetWithSave() {
 	}
 	_ = file.Save()
 }
+
+func TestFile_getSheetID_CaseInsensitivity(t *testing.T) {
+	file := NewFile()
+	file.NewSheet("Sheet1")
+	id := file.getSheetID("sheet1")
+	assert.NotEqual(t, -1, id)
+}


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
File.getSheetID is case-insensitive now, dealing with bugs with code below:

```go
// 若 sheet 不存在，则创建 sheet
index := ef.GetSheetIndex(sheetName)
if index == -1 {
    ef.NewSheet(sheetName)
}

// 打开 sheet
writer, err := ef.NewStreamWriter(sheetName)
if err != nil {
    err = errors.WithStack(err)
    return
}
```

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#1269

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
getSheetID should behave like GetSheetIndex, I mean case-insensitivity.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

test case named `TestFile_getSheetID_CaseInsensitivity`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
