### PR TITLE
add support for more tabColor options and split RGB #1283

### DIFF
--- a/sheetpr.go
+++ b/sheetpr.go
@@ -33,12 +33,35 @@ type (
 	Published bool
 	// FitToPage is a SheetPrOption
 	FitToPage bool
-	// TabColor is a SheetPrOption
-	TabColor string
+	// TabColorIndexed is a TabColor option, within SheetPrOption
+	TabColorIndexed int
+	// TabColorRGB is a TabColor option, within SheetPrOption
+	TabColorRGB string
+	// TabColorTheme is a TabColor option, within SheetPrOption
+	TabColorTheme int
+	// TabColorTint is a TabColor option, within SheetPrOption
+	TabColorTint float64
 	// AutoPageBreaks is a SheetPrOption
 	AutoPageBreaks bool
 	// OutlineSummaryBelow is an outlinePr, within SheetPr option
 	OutlineSummaryBelow bool
+)
+
+const (
+	TabColorThemeLight1 int = iota // Inverted compared to the spec because that's how Excel maps them
+	TabColorThemeDark1
+	TabColorThemeLight2
+	TabColorThemeDark2
+	TabColorThemeAccent1
+	TabColorThemeAccent2
+	TabColorThemeAccent3
+	TabColorThemeAccent4
+	TabColorThemeAccent5
+	TabColorThemeAccent6
+	TabColorThemeHyperlink
+	TabColorThemeFollowedHyperlink
+
+	TabColorUnsetValue int = -1
 )
 
 // setSheetPrOption implements the SheetPrOption interface.
@@ -129,9 +152,28 @@ func (o *FitToPage) getSheetPrOption(pr *xlsxSheetPr) {
 	*o = FitToPage(pr.PageSetUpPr.FitToPage)
 }
 
+// setSheetPrOption implements the SheetPrOption interface and sets the
+// TabColor Indexed.
+func (o TabColorIndexed) setSheetPrOption(pr *xlsxSheetPr) {
+	if pr.TabColor == nil {
+		pr.TabColor = new(xlsxTabColor)
+	}
+	pr.TabColor.Indexed = int(o)
+}
+
+// getSheetPrOption implements the SheetPrOptionPtr interface and gets the
+// TabColor Indexed. Defaults to -1 if no indexed has been set.
+func (o *TabColorIndexed) getSheetPrOption(pr *xlsxSheetPr) {
+	if pr == nil || pr.TabColor == nil {
+		*o = TabColorIndexed(TabColorUnsetValue)
+		return
+	}
+	*o = TabColorIndexed(pr.TabColor.Indexed)
+}
+
 // setSheetPrOption implements the SheetPrOption interface and specifies a
 // stable name of the sheet.
-func (o TabColor) setSheetPrOption(pr *xlsxSheetPr) {
+func (o TabColorRGB) setSheetPrOption(pr *xlsxSheetPr) {
 	if pr.TabColor == nil {
 		if string(o) == "" {
 			return
@@ -143,12 +185,50 @@ func (o TabColor) setSheetPrOption(pr *xlsxSheetPr) {
 
 // getSheetPrOption implements the SheetPrOptionPtr interface and get the
 // stable name of the sheet.
-func (o *TabColor) getSheetPrOption(pr *xlsxSheetPr) {
+func (o *TabColorRGB) getSheetPrOption(pr *xlsxSheetPr) {
 	if pr == nil || pr.TabColor == nil {
 		*o = ""
 		return
 	}
-	*o = TabColor(strings.TrimPrefix(pr.TabColor.RGB, "FF"))
+	*o = TabColorRGB(strings.TrimPrefix(pr.TabColor.RGB, "FF"))
+}
+
+// setSheetPrOption implements the SheetPrOption interface and sets the
+// TabColor Theme. Warning: it does not create a clrScheme!
+func (o TabColorTheme) setSheetPrOption(pr *xlsxSheetPr) {
+	if pr.TabColor == nil {
+		pr.TabColor = new(xlsxTabColor)
+	}
+	pr.TabColor.Theme = int(o)
+}
+
+// getSheetPrOption implements the SheetPrOptionPtr interface and gets the
+// TabColor Theme. Defaults to -1 if no theme has been set.
+func (o *TabColorTheme) getSheetPrOption(pr *xlsxSheetPr) {
+	if pr == nil || pr.TabColor == nil {
+		*o = TabColorTheme(TabColorUnsetValue)
+		return
+	}
+	*o = TabColorTheme(pr.TabColor.Theme)
+}
+
+// setSheetPrOption implements the SheetPrOption interface and sets the
+// TabColor Tint.
+func (o TabColorTint) setSheetPrOption(pr *xlsxSheetPr) {
+	if pr.TabColor == nil {
+		pr.TabColor = new(xlsxTabColor)
+	}
+	pr.TabColor.Tint = float64(o)
+}
+
+// getSheetPrOption implements the SheetPrOptionPtr interface and gets the
+// TabColor Tint. Defaults to 0.0 if no tint has been set.
+func (o *TabColorTint) getSheetPrOption(pr *xlsxSheetPr) {
+	if pr == nil || pr.TabColor == nil {
+		*o = 0.0
+		return
+	}
+	*o = TabColorTint(pr.TabColor.Tint)
 }
 
 // setSheetPrOption implements the SheetPrOption interface.

--- a/sheetpr_test.go
+++ b/sheetpr_test.go
@@ -13,7 +13,10 @@ var _ = []SheetPrOption{
 	EnableFormatConditionsCalculation(false),
 	Published(false),
 	FitToPage(true),
-	TabColor("#FFFF00"),
+	TabColorIndexed(42),
+	TabColorRGB("#FFFF00"),
+	TabColorTheme(TabColorThemeLight2),
+	TabColorTint(0.5),
 	AutoPageBreaks(true),
 	OutlineSummaryBelow(true),
 }
@@ -23,7 +26,10 @@ var _ = []SheetPrOptionPtr{
 	(*EnableFormatConditionsCalculation)(nil),
 	(*Published)(nil),
 	(*FitToPage)(nil),
-	(*TabColor)(nil),
+	(*TabColorIndexed)(nil),
+	(*TabColorRGB)(nil),
+	(*TabColorTheme)(nil),
+	(*TabColorTint)(nil),
 	(*AutoPageBreaks)(nil),
 	(*OutlineSummaryBelow)(nil),
 }
@@ -37,7 +43,10 @@ func ExampleFile_SetSheetPrOptions() {
 		EnableFormatConditionsCalculation(false),
 		Published(false),
 		FitToPage(true),
-		TabColor("#FFFF00"),
+		TabColorIndexed(42),
+		TabColorRGB("#FFFF00"),
+		TabColorTheme(TabColorThemeLight2),
+		TabColorTint(0.5),
 		AutoPageBreaks(true),
 		OutlineSummaryBelow(false),
 	); err != nil {
@@ -55,7 +64,10 @@ func ExampleFile_GetSheetPrOptions() {
 		enableFormatConditionsCalculation EnableFormatConditionsCalculation
 		published                         Published
 		fitToPage                         FitToPage
-		tabColor                          TabColor
+		tabColorIndexed                   TabColorIndexed
+		tabColorRGB                       TabColorRGB
+		tabColorTheme                     TabColorTheme
+		tabColorTint                      TabColorTint
 		autoPageBreaks                    AutoPageBreaks
 		outlineSummaryBelow               OutlineSummaryBelow
 	)
@@ -65,7 +77,10 @@ func ExampleFile_GetSheetPrOptions() {
 		&enableFormatConditionsCalculation,
 		&published,
 		&fitToPage,
-		&tabColor,
+		&tabColorIndexed,
+		&tabColorRGB,
+		&tabColorTheme,
+		&tabColorTint,
 		&autoPageBreaks,
 		&outlineSummaryBelow,
 	); err != nil {
@@ -76,7 +91,10 @@ func ExampleFile_GetSheetPrOptions() {
 	fmt.Println("- enableFormatConditionsCalculation:", enableFormatConditionsCalculation)
 	fmt.Println("- published:", published)
 	fmt.Println("- fitToPage:", fitToPage)
-	fmt.Printf("- tabColor: %q\n", tabColor)
+	fmt.Printf("- tabColorIndexed: %d\n", tabColorIndexed)
+	fmt.Printf("- tabColorRGB: %q\n", tabColorRGB)
+	fmt.Printf("- tabColorTheme: %d\n", tabColorTheme)
+	fmt.Printf("- tabColorTint: %f\n", tabColorTint)
 	fmt.Println("- autoPageBreaks:", autoPageBreaks)
 	fmt.Println("- outlineSummaryBelow:", outlineSummaryBelow)
 	// Output:
@@ -85,7 +103,10 @@ func ExampleFile_GetSheetPrOptions() {
 	// - enableFormatConditionsCalculation: true
 	// - published: true
 	// - fitToPage: false
-	// - tabColor: ""
+	// - tabColorIndexed: -1
+	// - tabColorRGB: ""
+	// - tabColorTheme: -1
+	// - tabColorTint: 0.000000
 	// - autoPageBreaks: false
 	// - outlineSummaryBelow: true
 }
@@ -101,7 +122,10 @@ func TestSheetPrOptions(t *testing.T) {
 		{new(EnableFormatConditionsCalculation), EnableFormatConditionsCalculation(false)},
 		{new(Published), Published(false)},
 		{new(FitToPage), FitToPage(true)},
-		{new(TabColor), TabColor("FFFF00")},
+		{new(TabColorIndexed), TabColorIndexed(42)},
+		{new(TabColorRGB), TabColorRGB("FFFF00")},
+		{new(TabColorTheme), TabColorTheme(TabColorThemeLight2)},
+		{new(TabColorTint), TabColorTint(0.5)},
 		{new(AutoPageBreaks), AutoPageBreaks(true)},
 		{new(OutlineSummaryBelow), OutlineSummaryBelow(false)},
 	}
@@ -154,7 +178,7 @@ func TestSheetPrOptions(t *testing.T) {
 
 func TestSetSheetPrOptions(t *testing.T) {
 	f := NewFile()
-	assert.NoError(t, f.SetSheetPrOptions("Sheet1", TabColor("")))
+	assert.NoError(t, f.SetSheetPrOptions("Sheet1", TabColorRGB("")))
 	// Test SetSheetPrOptions on not exists worksheet.
 	assert.EqualError(t, f.SetSheetPrOptions("SheetN"), "sheet SheetN is not exist")
 }


### PR DESCRIPTION
This commit renames `TabColor` into `TabColorRGB` (but keeps an alias
for backwards compatibility), as well as adds support for more tab color
  options (Theme, Indexed and Tint).

Signed-off-by: Thomas Charbonnel <github@charbonnel.email>

# Add support for more TabColor options

## Description

The following changes were made:
- Rename `TabColor` into `TabColorRGB`
- Add `TabColorTheme` as well as an enum for all its values
- Add `TabColorIndexed` as well as a default const for when it is unset
- Add `TabColorTint` as well as a default const for when it is unset

## Related Issue

#1283 

## Motivation and Context

The current version of Excelize only supports TabColor of type "RGB". Excel can set tab colors based on other dimensions (see [here](https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.spreadsheet.tabcolor?view=openxml-2.8.1)).

## How Has This Been Tested

By adding tests to the existing tests for worksheet options in `sheetpr_test.go`
All the tests passed on Linux (Fedora 34, go1.16.13)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
