### PR TITLE
#1299 don't write nil values in SetRow

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -327,6 +327,9 @@ func (sw *StreamWriter) SetRow(axis string, values []interface{}, opts ...RowOpt
 	}
 	fmt.Fprintf(&sw.rawData, `<row r="%d"%s>`, row, attrs)
 	for i, val := range values {
+		if val == nil {
+			continue
+		}
 		axis, err := CoordinatesToCellName(col+i, row)
 		if err != nil {
 			return err

--- a/stream_test.go
+++ b/stream_test.go
@@ -209,6 +209,17 @@ func TestSetRow(t *testing.T) {
 	assert.EqualError(t, streamWriter.SetRow("A", []interface{}{}), newCellNameToCoordinatesError("A", newInvalidCellNameError("A")).Error())
 }
 
+func TestSetRowNilValues(t *testing.T) {
+	file := NewFile()
+	streamWriter, err := file.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+	streamWriter.SetRow("A1", []interface{}{nil, nil, Cell{Value: "foo"}})
+	streamWriter.Flush()
+	ws, err := file.workSheetReader("Sheet1")
+	assert.NoError(t, err)
+	assert.NotEqual(t, ws.SheetData.Row[0].C[0].XMLName.Local, "c")
+}
+
 func TestSetCellValFunc(t *testing.T) {
 	f := NewFile()
 	sw, err := f.NewStreamWriter("Sheet1")


### PR DESCRIPTION
# PR Details

In `SetRow`, ignore `nil` values when writing to XML file.

## Description

- In `SetRow`, skip `nil` values when writing
- Add a test to enforce this behavior

## Related Issue

#1299

## Motivation and Context

Before this change, when setting `nil` values using `SetRow`, Excelize would create empty `<c>` elements. These elements are seen by Excel as separate cells with a style separate from the row-level style. Which breaks row-level styling.

## How Has This Been Tested

A test was added to check the parsed XML output.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
