### PR TITLE
#1310 existing comment shapes should be load only once

### DIFF
--- a/comment.go
+++ b/comment.go
@@ -178,6 +178,21 @@ func (f *File) addDrawingVML(commentID int, drawingVML, cell string, lineCount, 
 				},
 			},
 		}
+		// load exist comment shapes from xl/drawings/vmlDrawing%d.vml (only once)
+		d := f.decodeVMLDrawingReader(drawingVML)
+		if d != nil {
+			for _, v := range d.Shape {
+				s := xlsxShape{
+					ID:          "_x0000_s1025",
+					Type:        "#_x0000_t202",
+					Style:       "position:absolute;73.5pt;width:108pt;height:59.25pt;z-index:1;visibility:hidden",
+					Fillcolor:   "#fbf6d6",
+					Strokecolor: "#edeaa1",
+					Val:         v.Val,
+				}
+				vml.Shape = append(vml.Shape, s)
+			}
+		}
 	}
 	sp := encodeShape{
 		Fill: &vFill{
@@ -221,20 +236,6 @@ func (f *File) addDrawingVML(commentID int, drawingVML, cell string, lineCount, 
 		Fillcolor:   "#fbf6d6",
 		Strokecolor: "#edeaa1",
 		Val:         string(s[13 : len(s)-14]),
-	}
-	d := f.decodeVMLDrawingReader(drawingVML)
-	if d != nil {
-		for _, v := range d.Shape {
-			s := xlsxShape{
-				ID:          "_x0000_s1025",
-				Type:        "#_x0000_t202",
-				Style:       "position:absolute;73.5pt;width:108pt;height:59.25pt;z-index:1;visibility:hidden",
-				Fillcolor:   "#fbf6d6",
-				Strokecolor: "#edeaa1",
-				Val:         v.Val,
-			}
-			vml.Shape = append(vml.Shape, s)
-		}
 	}
 	vml.Shape = append(vml.Shape, shape)
 	f.VMLDrawing[drawingVML] = vml


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

fix for #1310 :  existing comment shapes should be load only once

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
