### PR TITLE
Added function SetSheetCol to replicate SetSheetRow behavior for columns

### DIFF
--- a/excelize_test.go
+++ b/excelize_test.go
@@ -1150,7 +1150,7 @@ func TestSetSheetRow(t *testing.T) {
 
 	assert.EqualError(t, f.SetSheetRow("Sheet1", "", &[]interface{}{"cell", nil, 2}),
 		newCellNameToCoordinatesError("", newInvalidCellNameError("")).Error())
-		
+
 	assert.EqualError(t, f.SetSheetRow("Sheet1", "B27", []interface{}{}), ErrParameterInvalid.Error())
 	assert.EqualError(t, f.SetSheetRow("Sheet1", "B27", &f), ErrParameterInvalid.Error())
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetSheetRow.xlsx")))

--- a/excelize_test.go
+++ b/excelize_test.go
@@ -1123,6 +1123,23 @@ func TestSharedStrings(t *testing.T) {
 	assert.NoError(t, f.Close())
 }
 
+func TestSetSheetCol(t *testing.T) {
+	f, err := OpenFile(filepath.Join("test", "Book1.xlsx"))
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	assert.NoError(t, f.SetSheetCol("Sheet1", "B27", &[]interface{}{"cell", nil, int32(42), float64(42), time.Now().UTC()}))
+
+	assert.EqualError(t, f.SetSheetCol("Sheet1", "", &[]interface{}{"cell", nil, 2}),
+		newCellNameToCoordinatesError("", newInvalidCellNameError("")).Error())
+
+	assert.EqualError(t, f.SetSheetCol("Sheet1", "B27", []interface{}{}), ErrParameterInvalid.Error())
+	assert.EqualError(t, f.SetSheetCol("Sheet1", "B27", &f), ErrParameterInvalid.Error())
+	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetSheetCol.xlsx")))
+	assert.NoError(t, f.Close())
+}
+
 func TestSetSheetRow(t *testing.T) {
 	f, err := OpenFile(filepath.Join("test", "Book1.xlsx"))
 	if !assert.NoError(t, err) {
@@ -1133,7 +1150,7 @@ func TestSetSheetRow(t *testing.T) {
 
 	assert.EqualError(t, f.SetSheetRow("Sheet1", "", &[]interface{}{"cell", nil, 2}),
 		newCellNameToCoordinatesError("", newInvalidCellNameError("")).Error())
-
+		
 	assert.EqualError(t, f.SetSheetRow("Sheet1", "B27", []interface{}{}), ErrParameterInvalid.Error())
 	assert.EqualError(t, f.SetSheetRow("Sheet1", "B27", &f), ErrParameterInvalid.Error())
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetSheetRow.xlsx")))


### PR DESCRIPTION
# PR Details

Added the function SetSheetCol to replicate SetSheetRow behavior for columns.

## Description

Added function SetSheetCol to make it easy 

## Related Issue

N/A

## Motivation and Context

Currently, there is an easy function SetSheetRow to set a list of values in a row. But there was no easy function to set a list of values in a column. This means users who want to set a list of columns have to do it manually or write their own helper function. 

## How Has This Been Tested

Added test cases that mirror SetSheetRow. 

Tested manually with Go script and got desired output
```
package main

import (
	"github.com/xuri/excelize/v2"
)

func main() {
	f := excelize.NewFile()
	defer f.SaveAs("testSetSheetCol.xlsx")
	f.NewSheet("Results")
	f.SetSheetCol("Results", "A1", &[]interface{}{"A", "B", "C", "D"})
	return 
}
```

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
