### PR TITLE
Fix DeleteComment slice bounds out of range

### DIFF
--- a/comment.go
+++ b/comment.go
@@ -156,17 +156,20 @@ func (f *File) DeleteComment(sheet, cell string) (err error) {
 	}
 	commentsXML = strings.TrimPrefix(commentsXML, "/")
 	if comments := f.commentsReader(commentsXML); comments != nil {
-		for i, cmt := range comments.CommentList.Comment {
-			if cmt.Ref == cell {
-				if len(comments.CommentList.Comment) > 1 {
-					comments.CommentList.Comment = append(
-						comments.CommentList.Comment[:i],
-						comments.CommentList.Comment[i+1:]...,
-					)
-					continue
-				}
-				comments.CommentList.Comment = nil
+		for i := 0; i < len(comments.CommentList.Comment); i++ {
+			cmt := comments.CommentList.Comment[i]
+			if cmt.Ref != cell {
+				continue
 			}
+			if len(comments.CommentList.Comment) > 1 {
+				comments.CommentList.Comment = append(
+					comments.CommentList.Comment[:i],
+					comments.CommentList.Comment[i+1:]...,
+				)
+				i--
+				continue
+			}
+			comments.CommentList.Comment = nil
 		}
 		f.Comments[commentsXML] = comments
 	}

--- a/comment_test.go
+++ b/comment_test.go
@@ -55,15 +55,19 @@ func TestDeleteComment(t *testing.T) {
 	assert.NoError(t, f.AddComment("Sheet2", "A40", `{"author":"Excelize: ","text":"This is a comment1."}`))
 	assert.NoError(t, f.AddComment("Sheet2", "A41", `{"author":"Excelize: ","text":"This is a comment2."}`))
 	assert.NoError(t, f.AddComment("Sheet2", "C41", `{"author":"Excelize: ","text":"This is a comment3."}`))
+	assert.NoError(t, f.AddComment("Sheet2", "C41", `{"author":"Excelize: ","text":"This is a comment3-1."}`))
+	assert.NoError(t, f.AddComment("Sheet2", "C42", `{"author":"Excelize: ","text":"This is a comment4."}`))
+	assert.NoError(t, f.AddComment("Sheet2", "C41", `{"author":"Excelize: ","text":"This is a comment3-2."}`))
 
 	assert.NoError(t, f.DeleteComment("Sheet2", "A40"))
 
-	assert.EqualValues(t, 2, len(f.GetComments()["Sheet2"]))
+	assert.EqualValues(t, 5, len(f.GetComments()["Sheet2"]))
 	assert.EqualValues(t, len(NewFile().GetComments()), 0)
 
 	// Test delete all comments in a worksheet
 	assert.NoError(t, f.DeleteComment("Sheet2", "A41"))
 	assert.NoError(t, f.DeleteComment("Sheet2", "C41"))
+	assert.NoError(t, f.DeleteComment("Sheet2", "C42"))
 	assert.EqualValues(t, 0, len(f.GetComments()["Sheet2"]))
 	// Test delete comment on not exists worksheet
 	assert.EqualError(t, f.DeleteComment("SheetN", "A1"), "sheet SheetN does not exist")


### PR DESCRIPTION
## Description
Modify slice length while range will cause "slice bounds out of range" error.

## How Has This Been Tested
Test by TestDeleteComment function in comment_test.go


