### PR TITLE
Fix cpu usage problem of stream writer when merging cells

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -34,7 +34,7 @@ type StreamWriter struct {
 	worksheet       *xlsxWorksheet
 	rawData         bufferedWriter
 	mergeCellsCount int
-	mergeCells      string
+	mergeCells      strings.Builder
 	tableParts      string
 }
 
@@ -417,7 +417,11 @@ func (sw *StreamWriter) MergeCell(hCell, vCell string) error {
 		return err
 	}
 	sw.mergeCellsCount++
-	sw.mergeCells += fmt.Sprintf(`<mergeCell ref="%s:%s"/>`, hCell, vCell)
+	_, _ = sw.mergeCells.WriteString(`<mergeCell ref="`)
+	_, _ = sw.mergeCells.WriteString(hCell)
+	_, _ = sw.mergeCells.WriteString(`:`)
+	_, _ = sw.mergeCells.WriteString(vCell)
+	_, _ = sw.mergeCells.WriteString(`"/>`)
 	return nil
 }
 
@@ -526,10 +530,15 @@ func (sw *StreamWriter) Flush() error {
 	}
 	_, _ = sw.rawData.WriteString(`</sheetData>`)
 	bulkAppendFields(&sw.rawData, sw.worksheet, 8, 15)
+	mergeCells := strings.Builder{}
 	if sw.mergeCellsCount > 0 {
-		sw.mergeCells = fmt.Sprintf(`<mergeCells count="%d">%s</mergeCells>`, sw.mergeCellsCount, sw.mergeCells)
+		_, _ = mergeCells.WriteString(`<mergeCells count="`)
+		_, _ = mergeCells.WriteString(strconv.Itoa(sw.mergeCellsCount))
+		_, _ = mergeCells.WriteString(`">`)
+		_, _ = mergeCells.WriteString(sw.mergeCells.String())
+		_, _ = mergeCells.WriteString(`</mergeCells>`)
 	}
-	_, _ = sw.rawData.WriteString(sw.mergeCells)
+	_, _ = sw.rawData.WriteString(sw.mergeCells.String())
 	bulkAppendFields(&sw.rawData, sw.worksheet, 17, 38)
 	_, _ = sw.rawData.WriteString(sw.tableParts)
 	bulkAppendFields(&sw.rawData, sw.worksheet, 40, 40)

--- a/stream.go
+++ b/stream.go
@@ -538,7 +538,7 @@ func (sw *StreamWriter) Flush() error {
 		_, _ = mergeCells.WriteString(sw.mergeCells.String())
 		_, _ = mergeCells.WriteString(`</mergeCells>`)
 	}
-	_, _ = sw.rawData.WriteString(sw.mergeCells.String())
+	_, _ = sw.rawData.WriteString(mergeCells.String())
 	bulkAppendFields(&sw.rawData, sw.worksheet, 17, 38)
 	_, _ = sw.rawData.WriteString(sw.tableParts)
 	bulkAppendFields(&sw.rawData, sw.worksheet, 40, 40)


### PR DESCRIPTION
# PR Details

Fix cpu usage problem of stream writer when merging cells

## Description

The pr replace the megerCells field with type stringBuilder in streamWriter struct

## Related Issue

## Motivation and Context

I find a problem that very high rate of cpu utilization appeard while streamWriter is merging cells. After pprof show the problem, I think maybe in the contact (+=) function, cpu operate the memory over and over again. So after replace the string with stringBuilder, cpu utilization reduce to quater of before in my prodction-project.
 
## How Has This Been Tested

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
