### PR TITLE
Normalize the sheet name to fix behavior regression between 2.6.0 & 2.6.1

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -457,6 +457,7 @@ func (f *File) getSheetXMLPath(sheet string) (string, bool) {
 		name string
 		ok   bool
 	)
+	sheet = trimSheetName(sheet)
 	for sheetName, filePath := range f.sheetMap {
 		if strings.EqualFold(sheetName, sheet) {
 			name, ok = filePath, true


### PR DESCRIPTION
# PR Details

## Description

normalize the sheet name as is done elsewhere in the code:
`sheet = trimSheetName(sheet)`

## Related Issue

Closes #1365

## Motivation and Context

Fixing a behavior regression between 2.6.0 and 2.6.1

## How Has This Been Tested

This simple code verifies that it fixes the issue.
```golang
package main

import (
	"fmt"

	"github.com/xuri/excelize/v2"
)

func main() {
	spreadsheet := excelize.NewFile()
	defer spreadsheet.Close()

	sheet := "My Sheet: 1"
	spreadsheet.NewSheet(sheet)

	row := []interface{}{"A1", "B1"}

	if err := spreadsheet.SetSheetRow(sheet, "A1", &row); err != nil {
		fmt.Println(err)
	}

	if err := spreadsheet.SaveAs("mytest.xlsx"); err != nil {
		fmt.Println(err)
	}
}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
