### PR TITLE
repair:The xml alias does not take effect

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -655,10 +655,20 @@ func (sw *StreamWriter) Flush() error {
 // names order range.
 func bulkAppendFields(w io.Writer, ws *xlsxWorksheet, from, to int) {
 	s := reflect.ValueOf(ws).Elem()
+	t := reflect.TypeOf(ws).Elem()
 	enc := xml.NewEncoder(w)
 	for i := 0; i < s.NumField(); i++ {
 		if from <= i && i <= to {
-			_ = enc.Encode(s.Field(i).Interface())
+			local := t.Field(i).Tag.Get("xml")
+			if local == "" {
+				_ = enc.Encode(s.Field(i).Interface())
+			} else {
+				_ = enc.EncodeElement(s.Field(i).Interface(), xml.StartElement{
+					Name: xml.Name{
+						Local: local,
+					},
+				})
+			}
 		}
 	}
 }


### PR DESCRIPTION
> The following code paging element is aliased as`<rowBreaks>`, but it is coded as`<xlsxBreaks>`

# Recurrence method demo

```go
package main

import (
	"fmt"
	"github.com/xuri/excelize/v2"
	"math/rand"
)

func main() {
	file := excelize.NewFile()
	defer func() {
		if err := file.Close(); err != nil {
			fmt.Println(err)
		}
	}()

	streamWriter, err := file.NewStreamWriter("Sheet1")
	if err != nil {
		fmt.Println(err)
	}

	cell, err := excelize.CoordinatesToCellName(1, 20)
	if err != nil {
		fmt.Println(err)
	}

	err = streamWriter.File.InsertPageBreak("Sheet1", cell)
	if err != nil {
		fmt.Println(err)
	}

	for rowID := 1; rowID <= 50; rowID++ {
		row := make([]interface{}, 5)
		for colID := 0; colID < 5; colID++ {
			row[colID] = rand.Intn(640000)
		}
		cell, _ := excelize.CoordinatesToCellName(1, rowID)
		if err := streamWriter.SetRow(cell, row); err != nil {
			fmt.Println(err)
		}
		if rowID%20 == 0 {
			err = streamWriter.File.InsertPageBreak("Sheet1", cell)
			if err != nil {
				fmt.Println(err)
			}
		}
	}

	if err := streamWriter.Flush(); err != nil {
		fmt.Println(err)
	}

	if err := file.SaveAs("Book1.xlsx"); err != nil {
		fmt.Println(err)
	}
}
```
