### PR TITLE
Fix binary string regex

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -729,16 +729,7 @@ func bstrUnmarshal(s string) (result string) {
 		}
 		if bstrExp.MatchString(subStr) {
 			cursor = match[1]
-			v, err := strconv.Unquote(`"\u` + s[match[0]+2:match[1]-1] + `"`)
-			if err != nil {
-				if l > match[1]+6 && bstrEscapeExp.MatchString(s[match[1]:match[1]+6]) {
-					result += subStr[:6]
-					cursor = match[1] + 6
-					continue
-				}
-				result += subStr
-				continue
-			}
+			v, _ := strconv.Unquote(`"\u` + s[match[0]+2:match[1]-1] + `"`)
 			result += v
 		}
 	}
@@ -769,12 +760,10 @@ func bstrMarshal(s string) (result string) {
 		}
 		if bstrExp.MatchString(subStr) {
 			cursor = match[1]
-			_, err := strconv.Unquote(`"\u` + s[match[0]+2:match[1]-1] + `"`)
-			if err == nil {
+			if _, err := strconv.Unquote(`"\u` + s[match[0]+2:match[1]-1] + `"`); err == nil {
 				result += "_x005F" + subStr
 				continue
 			}
-			result += subStr
 		}
 	}
 	if cursor < l {

--- a/lib.go
+++ b/lib.go
@@ -702,8 +702,8 @@ func isNumeric(s string) (bool, int, float64) {
 }
 
 var (
-	bstrExp       = regexp.MustCompile(`_x[a-zA-Z\d]{4}_`)
-	bstrEscapeExp = regexp.MustCompile(`x[a-zA-Z\d]{4}_`)
+	bstrExp       = regexp.MustCompile(`_x[a-fA-F\d]{4}_`)
+	bstrEscapeExp = regexp.MustCompile(`x[a-fA-F\d]{4}_`)
 )
 
 // bstrUnmarshal parses the binary basic string, this will trim escaped string

--- a/lib_test.go
+++ b/lib_test.go
@@ -314,6 +314,7 @@ func TestBstrUnmarshal(t *testing.T) {
 		"_x005F__x0008_******":        "_\b******",
 		"******_x005F__x0008_":        "******_\b",
 		"******_x005F__x0008_******":  "******_\b******",
+		"_x000x_x005F_x000x_":         "_x000x_x000x_",
 	}
 	for bstr, expected := range bstrs {
 		assert.Equal(t, expected, bstrUnmarshal(bstr), bstr)

--- a/lib_test.go
+++ b/lib_test.go
@@ -305,18 +305,18 @@ func TestBstrUnmarshal(t *testing.T) {
 		"*_x0008_*":                   "*\b*",
 		"*_x4F60__x597D_":             "*你好",
 		"*_xG000_":                    "*_xG000_",
-		"*_xG05F_x0001_*":             "*_xG05F*",
+		"*_xG05F_x0001_*":             "*_xG05F\x01*",
 		"*_x005F__x0008_*":            "*_\b*",
 		"*_x005F_x0001_*":             "*_x0001_*",
 		"*_x005f_x005F__x0008_*":      "*_x005F_\b*",
-		"*_x005F_x005F_xG05F_x0006_*": "*_x005F_xG05F*",
+		"*_x005F_x005F_xG05F_x0006_*": "*_x005F_xG05F\x06*",
 		"*_x005F_x005F_x005F_x0006_*": "*_x005F_x0006_*",
 		"_x005F__x0008_******":        "_\b******",
 		"******_x005F__x0008_":        "******_\b",
 		"******_x005F__x0008_******":  "******_\b******",
 	}
 	for bstr, expected := range bstrs {
-		assert.Equal(t, expected, bstrUnmarshal(bstr))
+		assert.Equal(t, expected, bstrUnmarshal(bstr), bstr)
 	}
 }
 


### PR DESCRIPTION
# PR Details

Change regex value for "bstrUnmarshal" function in "lib.go" file.

## Description

The value of the regex "_x[a-zA-Z\d]{4}_" has been changed to "_x[a-fA-F\d]{4}_" because hexadecimal values only contain the characters A-F.

## Related Issue
https://github.com/qax-os/excelize/issues/1414

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
