### PR TITLE
Detect invalid characters when setting sheet name, if invalid, report an error

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -11460,19 +11460,20 @@ func (fn *formulaFuncs) SHEET(argsList *list.List) formulaArg {
 		return newErrorFormulaArg(formulaErrorVALUE, "SHEET accepts at most 1 argument")
 	}
 	if argsList.Len() == 0 {
-		return newNumberFormulaArg(float64(fn.f.GetSheetIndex(fn.sheet) + 1))
+		idx, _ := fn.f.GetSheetIndex(fn.sheet)
+		return newNumberFormulaArg(float64(idx + 1))
 	}
 	arg := argsList.Front().Value.(formulaArg)
-	if sheetIdx := fn.f.GetSheetIndex(arg.Value()); sheetIdx != -1 {
+	if sheetIdx, _ := fn.f.GetSheetIndex(arg.Value()); sheetIdx != -1 {
 		return newNumberFormulaArg(float64(sheetIdx + 1))
 	}
 	if arg.cellRanges != nil && arg.cellRanges.Len() > 0 {
-		if sheetIdx := fn.f.GetSheetIndex(arg.cellRanges.Front().Value.(cellRange).From.Sheet); sheetIdx != -1 {
+		if sheetIdx, _ := fn.f.GetSheetIndex(arg.cellRanges.Front().Value.(cellRange).From.Sheet); sheetIdx != -1 {
 			return newNumberFormulaArg(float64(sheetIdx + 1))
 		}
 	}
 	if arg.cellRefs != nil && arg.cellRefs.Len() > 0 {
-		if sheetIdx := fn.f.GetSheetIndex(arg.cellRefs.Front().Value.(cellRef).Sheet); sheetIdx != -1 {
+		if sheetIdx, _ := fn.f.GetSheetIndex(arg.cellRefs.Front().Value.(cellRef).Sheet); sheetIdx != -1 {
 			return newNumberFormulaArg(float64(sheetIdx + 1))
 		}
 	}
@@ -13960,7 +13961,7 @@ func (fn *formulaFuncs) ADDRESS(argsList *list.List) formulaArg {
 	}
 	var sheetText string
 	if argsList.Len() == 5 {
-		sheetText = fmt.Sprintf("%s!", trimSheetName(argsList.Back().Value.(formulaArg).Value()))
+		sheetText = fmt.Sprintf("%s!", argsList.Back().Value.(formulaArg).Value())
 	}
 	formatter := addressFmtMaps[fmt.Sprintf("%d_%s", int(absNum.Number), a1.Value())]
 	addr, err := formatter(int(colNum.Number), int(rowNum.Number))

--- a/calc_test.go
+++ b/calc_test.go
@@ -4389,16 +4389,19 @@ func TestCalcCellValue(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	// Test get calculated cell value on not formula cell.
+	// Test get calculated cell value on not formula cell
 	f := prepareCalcData(cellData)
 	result, err := f.CalcCellValue("Sheet1", "A1")
 	assert.NoError(t, err)
 	assert.Equal(t, "", result)
-	// Test get calculated cell value on not exists worksheet.
+	// Test get calculated cell value on not exists worksheet
 	f = prepareCalcData(cellData)
 	_, err = f.CalcCellValue("SheetN", "A1")
 	assert.EqualError(t, err, "sheet SheetN does not exist")
-	// Test get calculated cell value with not support formula.
+	// Test get calculated cell value with invalid sheet name
+	_, err = f.CalcCellValue("Sheet:1", "A1")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
+	// Test get calculated cell value with not support formula
 	f = prepareCalcData(cellData)
 	assert.NoError(t, f.SetCellFormula("Sheet1", "A1", "=UNSUPPORT(A1)"))
 	_, err = f.CalcCellValue("Sheet1", "A1")

--- a/chart.go
+++ b/chart.go
@@ -940,6 +940,10 @@ func (f *File) AddChart(sheet, cell, opts string, combo ...string) error {
 // and properties set. In Excel a chartsheet is a worksheet that only contains
 // a chart.
 func (f *File) AddChartSheet(sheet, opts string, combo ...string) error {
+	// Check if the worksheet name is valid
+	if !f.CheckSheetNameValid(sheet) {
+		return ErrInvalidSheetName
+	}
 	// Check if the worksheet already exists
 	if f.GetSheetIndex(sheet) != -1 {
 		return ErrExistsWorksheet

--- a/chart.go
+++ b/chart.go
@@ -940,13 +940,13 @@ func (f *File) AddChart(sheet, cell, opts string, combo ...string) error {
 // and properties set. In Excel a chartsheet is a worksheet that only contains
 // a chart.
 func (f *File) AddChartSheet(sheet, opts string, combo ...string) error {
-	// Check if the worksheet name is valid
-	if !f.CheckSheetNameValid(sheet) {
-		return ErrInvalidSheetName
-	}
 	// Check if the worksheet already exists
-	if f.GetSheetIndex(sheet) != -1 {
-		return ErrExistsWorksheet
+	idx, err := f.GetSheetIndex(sheet)
+	if err != nil {
+		return err
+	}
+	if idx != -1 {
+		return ErrExistsSheet
 	}
 	options, comboCharts, err := f.getChartOptions(opts, combo)
 	if err != nil {
@@ -967,7 +967,7 @@ func (f *File) AddChartSheet(sheet, opts string, combo ...string) error {
 	}
 	sheetID++
 	path := "xl/chartsheets/sheet" + strconv.Itoa(sheetID) + ".xml"
-	f.sheetMap[trimSheetName(sheet)] = path
+	f.sheetMap[sheet] = path
 	f.Sheet.Store(path, nil)
 	drawingID := f.countDrawings() + 1
 	chartID := f.countCharts() + 1

--- a/chart_test.go
+++ b/chart_test.go
@@ -406,6 +406,9 @@ func TestChartWithLogarithmicBase(t *testing.T) {
 
 func TestAddChartSheetWithInvalidSheetName(t *testing.T) {
 	f := NewFile()
+	// invalid sheet name, empty name
+	assert.EqualError(t, f.AddChartSheet("", ``), "invalid worksheet name")
+	// invalid sheet name, include :\/?*[]
 	assert.EqualError(t, f.AddChartSheet("Sheet:", ``), "invalid worksheet name")
 	assert.EqualError(t, f.AddChartSheet(`Sheet\`, ``), "invalid worksheet name")
 	assert.EqualError(t, f.AddChartSheet("Sheet/", ``), "invalid worksheet name")
@@ -413,6 +416,7 @@ func TestAddChartSheetWithInvalidSheetName(t *testing.T) {
 	assert.EqualError(t, f.AddChartSheet("Sheet*", ``), "invalid worksheet name")
 	assert.EqualError(t, f.AddChartSheet("Sheet[", ``), "invalid worksheet name")
 	assert.EqualError(t, f.AddChartSheet("Sheet]", ``), "invalid worksheet name")
+	// invalid sheet name, single quotes at the front or at the end
 	assert.EqualError(t, f.AddChartSheet("'Sheet", ``), "invalid worksheet name")
 	assert.EqualError(t, f.AddChartSheet("Sheet'", ``), "invalid worksheet name")
 }

--- a/chart_test.go
+++ b/chart_test.go
@@ -217,6 +217,8 @@ func TestAddChart(t *testing.T) {
 		assert.NoError(t, f.AddChart("Combo Charts", axis, fmt.Sprintf(`{"type":"areaStacked","series":[{"name":"Sheet1!$A$30","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$30:$D$30"},{"name":"Sheet1!$A$31","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$31:$D$31"},{"name":"Sheet1!$A$32","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$32:$D$32"},{"name":"Sheet1!$A$33","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$33:$D$33"}],"format":{"x_scale":1.0,"y_scale":1.0,"x_offset":15,"y_offset":10,"print_obj":true,"lock_aspect_ratio":false,"locked":false},"legend":{"position":"left","show_legend_key":false},"title":{"name":"%s"},"plotarea":{"show_bubble_size":true,"show_cat_name":false,"show_leader_lines":false,"show_percent":true,"show_series_name":true,"show_val":true}}`, props[1]), fmt.Sprintf(`{"type":"%s","series":[{"name":"Sheet1!$A$34","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$34:$D$34"},{"name":"Sheet1!$A$35","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$35:$D$35"},{"name":"Sheet1!$A$36","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$36:$D$36"},{"name":"Sheet1!$A$37","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$37:$D$37"}],"format":{"x_scale":1.0,"y_scale":1.0,"x_offset":15,"y_offset":10,"print_obj":true,"lock_aspect_ratio":false,"locked":false},"legend":{"position":"left","show_legend_key":false},"plotarea":{"show_bubble_size":true,"show_cat_name":false,"show_leader_lines":false,"show_percent":true,"show_series_name":true,"show_val":true}}`, props[0])))
 	}
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestAddChart.xlsx")))
+	// Test with invalid sheet name
+	assert.EqualError(t, f.AddChart("Sheet:1", "A1", `{"type":"col","series":[{"name":"Sheet1!$A$30","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$30:$D$30"}]}`), ErrSheetNameInvalid.Error())
 	// Test with illegal cell reference
 	assert.EqualError(t, f.AddChart("Sheet2", "A", `{"type":"col","series":[{"name":"Sheet1!$A$30","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$30:$D$30"},{"name":"Sheet1!$A$31","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$31:$D$31"},{"name":"Sheet1!$A$32","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$32:$D$32"},{"name":"Sheet1!$A$33","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$33:$D$33"},{"name":"Sheet1!$A$34","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$34:$D$34"},{"name":"Sheet1!$A$35","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$35:$D$35"},{"name":"Sheet1!$A$36","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$36:$D$36"},{"name":"Sheet1!$A$37","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$37:$D$37"}],"format":{"x_scale":1.0,"y_scale":1.0,"x_offset":15,"y_offset":10,"print_obj":true,"lock_aspect_ratio":false,"locked":false},"legend":{"position":"left","show_legend_key":false},"title":{"name":"2D Column Chart"},"plotarea":{"show_bubble_size":true,"show_cat_name":false,"show_leader_lines":false,"show_percent":true,"show_series_name":true,"show_val":true},"show_blanks_as":"zero"}`), newCellNameToCoordinatesError("A", newInvalidCellNameError("A")).Error())
 	// Test with unsupported chart type
@@ -257,14 +259,16 @@ func TestAddChartSheet(t *testing.T) {
 	// Test cell value on chartsheet
 	assert.EqualError(t, f.SetCellValue("Chart1", "A1", true), "sheet Chart1 is not a worksheet")
 	// Test add chartsheet on already existing name sheet
-	assert.EqualError(t, f.AddChartSheet("Sheet1", `{"type":"col3DClustered","series":[{"name":"Sheet1!$A$2","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$2:$D$2"},{"name":"Sheet1!$A$3","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$3:$D$3"},{"name":"Sheet1!$A$4","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$4:$D$4"}],"title":{"name":"Fruit 3D Clustered Column Chart"}}`), ErrExistsWorksheet.Error())
+	assert.EqualError(t, f.AddChartSheet("Sheet1", `{"type":"col3DClustered","series":[{"name":"Sheet1!$A$2","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$2:$D$2"},{"name":"Sheet1!$A$3","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$3:$D$3"},{"name":"Sheet1!$A$4","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$4:$D$4"}],"title":{"name":"Fruit 3D Clustered Column Chart"}}`), ErrExistsSheet.Error())
+	// Test add chartsheet with invalid sheet name
+	assert.EqualError(t, f.AddChartSheet("Sheet:1", "A1", `{"type":"col3DClustered","series":[{"name":"Sheet1!$A$2","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$2:$D$2"},{"name":"Sheet1!$A$3","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$3:$D$3"},{"name":"Sheet1!$A$4","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$4:$D$4"}],"title":{"name":"Fruit 3D Clustered Column Chart"}}`), ErrSheetNameInvalid.Error())
 	// Test with unsupported chart type
 	assert.EqualError(t, f.AddChartSheet("Chart2", `{"type":"unknown","series":[{"name":"Sheet1!$A$2","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$2:$D$2"},{"name":"Sheet1!$A$3","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$3:$D$3"},{"name":"Sheet1!$A$4","categories":"Sheet1!$B$1:$D$1","values":"Sheet1!$B$4:$D$4"}],"title":{"name":"Fruit 3D Clustered Column Chart"}}`), "unsupported chart type unknown")
 
 	assert.NoError(t, f.UpdateLinkedValue())
 
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestAddChartSheet.xlsx")))
-	// Test add chart sheet with unsupported charset content types.
+	// Test add chart sheet with unsupported charset content types
 	f = NewFile()
 	f.ContentTypes = nil
 	f.Pkg.Store(defaultXMLPathContentTypes, MacintoshCyrillicCharset)
@@ -278,11 +282,13 @@ func TestDeleteChart(t *testing.T) {
 	assert.NoError(t, f.AddChart("Sheet1", "P1", `{"type":"col","series":[{"name":"Sheet1!$A$30","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$30:$D$30"},{"name":"Sheet1!$A$31","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$31:$D$31"},{"name":"Sheet1!$A$32","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$32:$D$32"},{"name":"Sheet1!$A$33","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$33:$D$33"},{"name":"Sheet1!$A$34","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$34:$D$34"},{"name":"Sheet1!$A$35","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$35:$D$35"},{"name":"Sheet1!$A$36","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$36:$D$36"},{"name":"Sheet1!$A$37","categories":"Sheet1!$B$29:$D$29","values":"Sheet1!$B$37:$D$37"}],"format":{"x_scale":1.0,"y_scale":1.0,"x_offset":15,"y_offset":10,"print_obj":true,"lock_aspect_ratio":false,"locked":false},"legend":{"position":"left","show_legend_key":false},"title":{"name":"2D Column Chart"},"plotarea":{"show_bubble_size":true,"show_cat_name":false,"show_leader_lines":false,"show_percent":true,"show_series_name":true,"show_val":true},"show_blanks_as":"zero"}`))
 	assert.NoError(t, f.DeleteChart("Sheet1", "P1"))
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestDeleteChart.xlsx")))
-	// Test delete chart on not exists worksheet.
+	// Test delete chart with invalid sheet name
+	assert.EqualError(t, f.DeleteChart("Sheet:1", "P1"), ErrSheetNameInvalid.Error())
+	// Test delete chart on not exists worksheet
 	assert.EqualError(t, f.DeleteChart("SheetN", "A1"), "sheet SheetN does not exist")
-	// Test delete chart with invalid coordinates.
+	// Test delete chart with invalid coordinates
 	assert.EqualError(t, f.DeleteChart("Sheet1", ""), newCellNameToCoordinatesError("", newInvalidCellNameError("")).Error())
-	// Test delete chart on no chart worksheet.
+	// Test delete chart on no chart worksheet
 	assert.NoError(t, NewFile().DeleteChart("Sheet1", "A1"))
 	assert.NoError(t, f.Close())
 }
@@ -402,21 +408,4 @@ func TestChartWithLogarithmicBase(t *testing.T) {
 			}
 		}
 	}
-}
-
-func TestAddChartSheetWithInvalidSheetName(t *testing.T) {
-	f := NewFile()
-	// invalid sheet name, empty name
-	assert.EqualError(t, f.AddChartSheet("", ``), "invalid worksheet name")
-	// invalid sheet name, include :\/?*[]
-	assert.EqualError(t, f.AddChartSheet("Sheet:", ``), "invalid worksheet name")
-	assert.EqualError(t, f.AddChartSheet(`Sheet\`, ``), "invalid worksheet name")
-	assert.EqualError(t, f.AddChartSheet("Sheet/", ``), "invalid worksheet name")
-	assert.EqualError(t, f.AddChartSheet("Sheet?", ``), "invalid worksheet name")
-	assert.EqualError(t, f.AddChartSheet("Sheet*", ``), "invalid worksheet name")
-	assert.EqualError(t, f.AddChartSheet("Sheet[", ``), "invalid worksheet name")
-	assert.EqualError(t, f.AddChartSheet("Sheet]", ``), "invalid worksheet name")
-	// invalid sheet name, single quotes at the front or at the end
-	assert.EqualError(t, f.AddChartSheet("'Sheet", ``), "invalid worksheet name")
-	assert.EqualError(t, f.AddChartSheet("Sheet'", ``), "invalid worksheet name")
 }

--- a/chart_test.go
+++ b/chart_test.go
@@ -403,3 +403,16 @@ func TestChartWithLogarithmicBase(t *testing.T) {
 		}
 	}
 }
+
+func TestAddChartSheetWithInvalidSheetName(t *testing.T) {
+	f := NewFile()
+	assert.EqualError(t, f.AddChartSheet("Sheet:", ``), "invalid worksheet name")
+	assert.EqualError(t, f.AddChartSheet(`Sheet\`, ``), "invalid worksheet name")
+	assert.EqualError(t, f.AddChartSheet("Sheet/", ``), "invalid worksheet name")
+	assert.EqualError(t, f.AddChartSheet("Sheet?", ``), "invalid worksheet name")
+	assert.EqualError(t, f.AddChartSheet("Sheet*", ``), "invalid worksheet name")
+	assert.EqualError(t, f.AddChartSheet("Sheet[", ``), "invalid worksheet name")
+	assert.EqualError(t, f.AddChartSheet("Sheet]", ``), "invalid worksheet name")
+	assert.EqualError(t, f.AddChartSheet("'Sheet", ``), "invalid worksheet name")
+	assert.EqualError(t, f.AddChartSheet("Sheet'", ``), "invalid worksheet name")
+}

--- a/col.go
+++ b/col.go
@@ -208,6 +208,9 @@ func (cols *Cols) rowXMLHandler(rowIterator *rowXMLIterator, xmlElement *xml.Sta
 //	    fmt.Println()
 //	}
 func (f *File) Cols(sheet string) (*Cols, error) {
+	if err := checkSheetName(sheet); err != nil {
+		return nil, err
+	}
 	name, ok := f.getSheetXMLPath(sheet)
 	if !ok {
 		return nil, ErrSheetNotExist{sheet}
@@ -236,7 +239,7 @@ func (f *File) Cols(sheet string) (*Cols, error) {
 		case xml.EndElement:
 			if xmlElement.Name.Local == "sheetData" {
 				colIterator.cols.f = f
-				colIterator.cols.sheet = trimSheetName(sheet)
+				colIterator.cols.sheet = sheet
 				return &colIterator.cols, nil
 			}
 		}

--- a/col_test.go
+++ b/col_test.go
@@ -57,7 +57,13 @@ func TestCols(t *testing.T) {
 	_, err = f.Rows("Sheet1")
 	assert.NoError(t, err)
 
-	// Test columns iterator with unsupported charset shared strings table.
+	// Test columns iterator with invalid sheet name
+	_, err = f.Cols("Sheet:1")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
+	// Test get columns cells with invalid sheet name
+	_, err = f.GetCols("Sheet:1")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
+	// Test columns iterator with unsupported charset shared strings table
 	f.SharedStrings = nil
 	f.Pkg.Store(defaultXMLPathSharedStrings, MacintoshCyrillicCharset)
 	cols, err = f.Cols("Sheet1")
@@ -212,14 +218,18 @@ func TestColumnVisibility(t *testing.T) {
 		assert.Equal(t, true, visible)
 		assert.NoError(t, err)
 
-		// Test get column visible on an inexistent worksheet.
+		// Test get column visible on an inexistent worksheet
 		_, err = f.GetColVisible("SheetN", "F")
 		assert.EqualError(t, err, "sheet SheetN does not exist")
-
-		// Test get column visible with illegal cell reference.
+		// Test get column visible with invalid sheet name
+		_, err = f.GetColVisible("Sheet:1", "F")
+		assert.EqualError(t, err, ErrSheetNameInvalid.Error())
+		// Test get column visible with illegal cell reference
 		_, err = f.GetColVisible("Sheet1", "*")
 		assert.EqualError(t, err, newInvalidColumnNameError("*").Error())
 		assert.EqualError(t, f.SetColVisible("Sheet1", "*", false), newInvalidColumnNameError("*").Error())
+		// Test set column visible with invalid sheet name
+		assert.EqualError(t, f.SetColVisible("Sheet:1", "A", false), ErrSheetNameInvalid.Error())
 
 		f.NewSheet("Sheet3")
 		assert.NoError(t, f.SetColVisible("Sheet3", "E", false))
@@ -254,25 +264,35 @@ func TestOutlineLevel(t *testing.T) {
 	assert.Equal(t, uint8(0), level)
 	assert.EqualError(t, err, "sheet SheetN does not exist")
 
+	// Test column outline level with invalid sheet name
+	_, err = f.GetColOutlineLevel("Sheet:1", "A")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
+
 	assert.NoError(t, f.SetColWidth("Sheet2", "A", "D", 13))
 	assert.EqualError(t, f.SetColWidth("Sheet2", "A", "D", MaxColumnWidth+1), ErrColumnWidth.Error())
+	// Test set column width with invalid sheet name
+	assert.EqualError(t, f.SetColWidth("Sheet:1", "A", "D", 13), ErrSheetNameInvalid.Error())
 
 	assert.NoError(t, f.SetColOutlineLevel("Sheet2", "B", 2))
 	assert.NoError(t, f.SetRowOutlineLevel("Sheet1", 2, 7))
 	assert.EqualError(t, f.SetColOutlineLevel("Sheet1", "D", 8), ErrOutlineLevel.Error())
 	assert.EqualError(t, f.SetRowOutlineLevel("Sheet1", 2, 8), ErrOutlineLevel.Error())
-	// Test set row outline level on not exists worksheet.
+	// Test set row outline level on not exists worksheet
 	assert.EqualError(t, f.SetRowOutlineLevel("SheetN", 1, 4), "sheet SheetN does not exist")
-	// Test get row outline level on not exists worksheet.
+	// Test set row outline level with invalid sheet name
+	assert.EqualError(t, f.SetRowOutlineLevel("Sheet:1", 1, 4), ErrSheetNameInvalid.Error())
+	// Test get row outline level on not exists worksheet
 	_, err = f.GetRowOutlineLevel("SheetN", 1)
 	assert.EqualError(t, err, "sheet SheetN does not exist")
-
-	// Test set and get column outline level with illegal cell reference.
+	// Test get row outline level with invalid sheet name
+	_, err = f.GetRowOutlineLevel("Sheet:1", 1)
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
+	// Test set and get column outline level with illegal cell reference
 	assert.EqualError(t, f.SetColOutlineLevel("Sheet1", "*", 1), newInvalidColumnNameError("*").Error())
 	_, err = f.GetColOutlineLevel("Sheet1", "*")
 	assert.EqualError(t, err, newInvalidColumnNameError("*").Error())
 
-	// Test set column outline level on not exists worksheet.
+	// Test set column outline level on not exists worksheet
 	assert.EqualError(t, f.SetColOutlineLevel("SheetN", "E", 2), "sheet SheetN does not exist")
 
 	assert.EqualError(t, f.SetRowOutlineLevel("Sheet1", 0, 1), newInvalidRowNumberError(0).Error())
@@ -300,22 +320,24 @@ func TestSetColStyle(t *testing.T) {
 	assert.NoError(t, f.SetCellValue("Sheet1", "B2", "Hello"))
 	styleID, err := f.NewStyle(`{"fill":{"type":"pattern","color":["#94d3a2"],"pattern":1}}`)
 	assert.NoError(t, err)
-	// Test set column style on not exists worksheet.
+	// Test set column style on not exists worksheet
 	assert.EqualError(t, f.SetColStyle("SheetN", "E", styleID), "sheet SheetN does not exist")
-	// Test set column style with illegal column name.
+	// Test set column style with illegal column name
 	assert.EqualError(t, f.SetColStyle("Sheet1", "*", styleID), newInvalidColumnNameError("*").Error())
 	assert.EqualError(t, f.SetColStyle("Sheet1", "A:*", styleID), newInvalidColumnNameError("*").Error())
-	// Test set column style with invalid style ID.
+	// Test set column style with invalid style ID
 	assert.EqualError(t, f.SetColStyle("Sheet1", "B", -1), newInvalidStyleID(-1).Error())
-	// Test set column style with not exists style ID.
+	// Test set column style with not exists style ID
 	assert.EqualError(t, f.SetColStyle("Sheet1", "B", 10), newInvalidStyleID(10).Error())
+	// Test set column style with invalid sheet name
+	assert.EqualError(t, f.SetColStyle("Sheet:1", "A", 0), ErrSheetNameInvalid.Error())
 
 	assert.NoError(t, f.SetColStyle("Sheet1", "B", styleID))
 	style, err := f.GetColStyle("Sheet1", "B")
 	assert.NoError(t, err)
 	assert.Equal(t, styleID, style)
 
-	// Test set column style with already exists column with style.
+	// Test set column style with already exists column with style
 	assert.NoError(t, f.SetColStyle("Sheet1", "B", styleID))
 	assert.NoError(t, f.SetColStyle("Sheet1", "D:C", styleID))
 	ws, ok := f.Sheet.Load("xl/worksheets/sheet1.xml")
@@ -325,7 +347,7 @@ func TestSetColStyle(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, styleID, cellStyleID)
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetColStyle.xlsx")))
-	// Test set column style with unsupported charset style sheet.
+	// Test set column style with unsupported charset style sheet
 	f.Styles = nil
 	f.Pkg.Store(defaultXMLPathStyles, MacintoshCyrillicCharset)
 	assert.EqualError(t, f.SetColStyle("Sheet1", "C:F", styleID), "XML syntax error on line 1: invalid UTF-8")
@@ -342,19 +364,21 @@ func TestColWidth(t *testing.T) {
 	assert.Equal(t, defaultColWidth, width)
 	assert.NoError(t, err)
 
-	// Test set and get column width with illegal cell reference.
+	// Test set and get column width with illegal cell reference
 	width, err = f.GetColWidth("Sheet1", "*")
 	assert.Equal(t, defaultColWidth, width)
 	assert.EqualError(t, err, newInvalidColumnNameError("*").Error())
 	assert.EqualError(t, f.SetColWidth("Sheet1", "*", "B", 1), newInvalidColumnNameError("*").Error())
 	assert.EqualError(t, f.SetColWidth("Sheet1", "A", "*", 1), newInvalidColumnNameError("*").Error())
 
-	// Test set column width on not exists worksheet.
+	// Test set column width on not exists worksheet
 	assert.EqualError(t, f.SetColWidth("SheetN", "B", "A", 12), "sheet SheetN does not exist")
-
-	// Test get column width on not exists worksheet.
+	// Test get column width on not exists worksheet
 	_, err = f.GetColWidth("SheetN", "A")
 	assert.EqualError(t, err, "sheet SheetN does not exist")
+	// Test get column width invalid sheet name
+	_, err = f.GetColWidth("Sheet:1", "A")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
 
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestColWidth.xlsx")))
 	convertRowHeightToPixels(0)
@@ -366,12 +390,15 @@ func TestGetColStyle(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, styleID, 0)
 
-	// Test set column style on not exists worksheet.
+	// Test get column style on not exists worksheet
 	_, err = f.GetColStyle("SheetN", "A")
 	assert.EqualError(t, err, "sheet SheetN does not exist")
-	// Test set column style with illegal column name.
+	// Test get column style with illegal column name
 	_, err = f.GetColStyle("Sheet1", "*")
 	assert.EqualError(t, err, newInvalidColumnNameError("*").Error())
+	// Test get column style with invalid sheet name
+	_, err = f.GetColStyle("Sheet:1", "A")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
 }
 
 func TestInsertCols(t *testing.T) {
@@ -386,9 +413,10 @@ func TestInsertCols(t *testing.T) {
 	assert.NoError(t, f.AutoFilter(sheet1, "A2", "B2", `{"column":"B","expression":"x != blanks"}`))
 	assert.NoError(t, f.InsertCols(sheet1, "A", 1))
 
-	// Test insert column with illegal cell reference.
+	// Test insert column with illegal cell reference
 	assert.EqualError(t, f.InsertCols(sheet1, "*", 1), newInvalidColumnNameError("*").Error())
-
+	// Test insert column with invalid sheet name
+	assert.EqualError(t, f.InsertCols("Sheet:1", "A", 1), ErrSheetNameInvalid.Error())
 	assert.EqualError(t, f.InsertCols(sheet1, "A", 0), ErrColumnNumber.Error())
 	assert.EqualError(t, f.InsertCols(sheet1, "A", MaxColumns), ErrColumnNumber.Error())
 	assert.EqualError(t, f.InsertCols(sheet1, "A", MaxColumns-10), ErrColumnNumber.Error())
@@ -411,11 +439,12 @@ func TestRemoveCol(t *testing.T) {
 	assert.NoError(t, f.RemoveCol(sheet1, "A"))
 	assert.NoError(t, f.RemoveCol(sheet1, "A"))
 
-	// Test remove column with illegal cell reference.
+	// Test remove column with illegal cell reference
 	assert.EqualError(t, f.RemoveCol("Sheet1", "*"), newInvalidColumnNameError("*").Error())
-
-	// Test remove column on not exists worksheet.
+	// Test remove column on not exists worksheet
 	assert.EqualError(t, f.RemoveCol("SheetN", "B"), "sheet SheetN does not exist")
+	// Test remove column  with invalid sheet name
+	assert.EqualError(t, f.RemoveCol("Sheet:1", "A"), ErrSheetNameInvalid.Error())
 
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestRemoveCol.xlsx")))
 }

--- a/comment.go
+++ b/comment.go
@@ -143,6 +143,9 @@ func (f *File) AddComment(sheet string, comment Comment) error {
 //
 //	err := f.DeleteComment("Sheet1", "A30")
 func (f *File) DeleteComment(sheet, cell string) error {
+	if err := checkSheetName(sheet); err != nil {
+		return err
+	}
 	sheetXMLPath, ok := f.getSheetXMLPath(sheet)
 	if !ok {
 		return newNoExistSheetError(sheet)

--- a/datavalidation_test.go
+++ b/datavalidation_test.go
@@ -91,6 +91,9 @@ func TestDataValidation(t *testing.T) {
 	// Test get data validation on no exists worksheet
 	_, err = f.GetDataValidations("SheetN")
 	assert.EqualError(t, err, "sheet SheetN does not exist")
+	// Test get data validation with invalid sheet name
+	_, err = f.GetDataValidations("Sheet:1")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
 
 	assert.NoError(t, f.SaveAs(resultFile))
 
@@ -130,7 +133,7 @@ func TestDataValidationError(t *testing.T) {
 
 	assert.NoError(t, f.AddDataValidation("Sheet1", dvRange))
 
-	// Test width invalid data validation formula.
+	// Test width invalid data validation formula
 	prevFormula1 := dvRange.Formula1
 	for _, keys := range [][]string{
 		make([]string, 257),
@@ -156,9 +159,13 @@ func TestDataValidationError(t *testing.T) {
 		DataValidationTypeWhole, DataValidationOperatorGreaterThan), ErrDataValidationRange.Error())
 	assert.NoError(t, f.SaveAs(resultFile))
 
-	// Test add data validation on no exists worksheet.
+	// Test add data validation on no exists worksheet
 	f = NewFile()
 	assert.EqualError(t, f.AddDataValidation("SheetN", nil), "sheet SheetN does not exist")
+
+	// Test add data validation with invalid sheet name
+	f = NewFile()
+	assert.EqualError(t, f.AddDataValidation("Sheet:1", nil), ErrSheetNameInvalid.Error())
 }
 
 func TestDeleteDataValidation(t *testing.T) {
@@ -200,10 +207,11 @@ func TestDeleteDataValidation(t *testing.T) {
 	ws.(*xlsxWorksheet).DataValidations.DataValidation[0].Sqref = "A1:A"
 	assert.EqualError(t, f.DeleteDataValidation("Sheet1", "A1:B2"), newCellNameToCoordinatesError("A", newInvalidCellNameError("A")).Error())
 
-	// Test delete data validation on no exists worksheet.
+	// Test delete data validation on no exists worksheet
 	assert.EqualError(t, f.DeleteDataValidation("SheetN", "A1:B2"), "sheet SheetN does not exist")
-
-	// Test delete all data validations in the worksheet.
+	// Test delete all data validation with invalid sheet name
+	assert.EqualError(t, f.DeleteDataValidation("Sheet:1"), ErrSheetNameInvalid.Error())
+	// Test delete all data validations in the worksheet
 	assert.NoError(t, f.DeleteDataValidation("Sheet1"))
 	assert.Nil(t, ws.(*xlsxWorksheet).DataValidations)
 }

--- a/errors.go
+++ b/errors.go
@@ -113,9 +113,8 @@ var (
 	// ErrCoordinates defined the error message on invalid coordinates tuples
 	// length.
 	ErrCoordinates = errors.New("coordinates length must be 4")
-	// ErrExistsWorksheet defined the error message on given worksheet already
-	// exists.
-	ErrExistsWorksheet = errors.New("the same name worksheet already exists")
+	// ErrExistsSheet defined the error message on given sheet already exists.
+	ErrExistsSheet = errors.New("the same name sheet already exists")
 	// ErrTotalSheetHyperlinks defined the error message on hyperlinks count
 	// overflow.
 	ErrTotalSheetHyperlinks = errors.New("over maximum limit hyperlinks in a worksheet")
@@ -219,6 +218,16 @@ var (
 	// ErrWorkbookPassword defined the error message on receiving the incorrect
 	// workbook password.
 	ErrWorkbookPassword = errors.New("the supplied open workbook password is not correct")
-	// ErrInvalidSheetName defined the error message on receive the invalid worksheet name
-	ErrInvalidSheetName = errors.New("invalid worksheet name")
+	// ErrSheetNameInvalid defined the error message on receive the sheet name
+	// contains invalid characters.
+	ErrSheetNameInvalid = errors.New("the sheet can not contain any of the characters :\\/?*[or]")
+	// ErrSheetNameSingleQuote defined the error message on the first or last
+	// character of the sheet name was a single quote.
+	ErrSheetNameSingleQuote = errors.New("the first or last character of the sheet name can not be a single quote")
+	// ErrSheetNameBlank defined the error message on receive the blank sheet
+	// name.
+	ErrSheetNameBlank = errors.New("the sheet name can not be blank")
+	// ErrSheetNameLength defined the error message on receiving the sheet
+	// name length exceeds the limit.
+	ErrSheetNameLength = fmt.Errorf("the sheet name length exceeds the %d characters limit", MaxSheetNameLength)
 )

--- a/errors.go
+++ b/errors.go
@@ -219,4 +219,6 @@ var (
 	// ErrWorkbookPassword defined the error message on receiving the incorrect
 	// workbook password.
 	ErrWorkbookPassword = errors.New("the supplied open workbook password is not correct")
+	// ErrInvalidSheetName defined the error message on receive the invalid worksheet name
+	ErrInvalidSheetName = errors.New("invalid worksheet name")
 )

--- a/excelize.go
+++ b/excelize.go
@@ -233,6 +233,9 @@ func (f *File) workSheetReader(sheet string) (ws *xlsxWorksheet, err error) {
 		name string
 		ok   bool
 	)
+	if err = checkSheetName(sheet); err != nil {
+		return
+	}
 	if name, ok = f.getSheetXMLPath(sheet); !ok {
 		err = newNoExistSheetError(sheet)
 		return

--- a/merge_test.go
+++ b/merge_test.go
@@ -29,7 +29,8 @@ func TestMergeCell(t *testing.T) {
 	value, err := f.GetCellValue("Sheet1", "H11")
 	assert.Equal(t, "100", value)
 	assert.NoError(t, err)
-	value, err = f.GetCellValue("Sheet2", "A6") // Merged cell ref is single coordinate.
+	// Merged cell ref is single coordinate
+	value, err = f.GetCellValue("Sheet2", "A6")
 	assert.Equal(t, "", value)
 	assert.NoError(t, err)
 	value, err = f.GetCellFormula("Sheet1", "G12")
@@ -64,9 +65,10 @@ func TestMergeCell(t *testing.T) {
 	assert.NoError(t, f.MergeCell("Sheet3", "M8", "Q13"))
 	assert.NoError(t, f.MergeCell("Sheet3", "N10", "O11"))
 
-	// Test get merged cells on not exists worksheet.
+	// Test merge cells on not exists worksheet
 	assert.EqualError(t, f.MergeCell("SheetN", "N10", "O11"), "sheet SheetN does not exist")
-
+	// Test merged cells with invalid sheet name
+	assert.EqualError(t, f.MergeCell("Sheet:1", "N10", "O11"), ErrSheetNameInvalid.Error())
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestMergeCell.xlsx")))
 	assert.NoError(t, f.Close())
 
@@ -137,8 +139,10 @@ func TestGetMergeCells(t *testing.T) {
 		assert.Equal(t, wants[i].start, m.GetStartAxis())
 		assert.Equal(t, wants[i].end, m.GetEndAxis())
 	}
-
-	// Test get merged cells on not exists worksheet.
+	// Test get merged cells with invalid sheet name
+	_, err = f.GetMergeCells("Sheet:1")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
+	// Test get merged cells on not exists worksheet
 	_, err = f.GetMergeCells("SheetN")
 	assert.EqualError(t, err, "sheet SheetN does not exist")
 	assert.NoError(t, f.Close())
@@ -158,7 +162,7 @@ func TestUnmergeCell(t *testing.T) {
 
 	assert.EqualError(t, f.UnmergeCell("Sheet1", "A", "A"), newCellNameToCoordinatesError("A", newInvalidCellNameError("A")).Error())
 
-	// unmerge the mergecell that contains A1
+	// Test unmerge the merged cells that contains A1
 	assert.NoError(t, f.UnmergeCell(sheet1, "A1", "A1"))
 	if len(sheet.MergeCells.Cells) != mergeCellNum-1 {
 		t.FailNow()
@@ -169,8 +173,11 @@ func TestUnmergeCell(t *testing.T) {
 
 	f = NewFile()
 	assert.NoError(t, f.MergeCell("Sheet1", "A2", "B3"))
-	// Test unmerged range reference on not exists worksheet.
+	// Test unmerged range reference on not exists worksheet
 	assert.EqualError(t, f.UnmergeCell("SheetN", "A1", "A1"), "sheet SheetN does not exist")
+
+	// Test unmerge the merged cells with invalid sheet name
+	assert.EqualError(t, f.UnmergeCell("Sheet:1", "A1", "A1"), ErrSheetNameInvalid.Error())
 
 	ws, ok := f.Sheet.Load("xl/worksheets/sheet1.xml")
 	assert.True(t, ok)

--- a/pivotTable_test.go
+++ b/pivotTable_test.go
@@ -225,6 +225,12 @@ func TestAddPivotTable(t *testing.T) {
 		Data:            []PivotTableField{{Data: "Sales", Subtotal: "-", Name: strings.Repeat("s", MaxFieldLength+1)}},
 	}))
 
+	// Test add pivot table with invalid sheet name
+	assert.EqualError(t, f.AddPivotTable(&PivotTableOptions{
+		DataRange:       "Sheet:1!$A$1:$E$31",
+		PivotTableRange: "Sheet:1!$G$2:$M$34",
+		Rows:            []PivotTableField{{Data: "Year"}},
+	}), ErrSheetNameInvalid.Error())
 	// Test adjust range with invalid range
 	_, _, err := f.adjustRange("")
 	assert.EqualError(t, err, ErrParameterRequired.Error())

--- a/rows.go
+++ b/rows.go
@@ -260,6 +260,9 @@ func (rows *Rows) rowXMLHandler(rowIterator *rowXMLIterator, xmlElement *xml.Sta
 //	    fmt.Println(err)
 //	}
 func (f *File) Rows(sheet string) (*Rows, error) {
+	if err := checkSheetName(sheet); err != nil {
+		return nil, err
+	}
 	name, ok := f.getSheetXMLPath(sheet)
 	if !ok {
 		return nil, ErrSheetNotExist{sheet}
@@ -268,7 +271,7 @@ func (f *File) Rows(sheet string) (*Rows, error) {
 		worksheet := ws.(*xlsxWorksheet)
 		worksheet.Lock()
 		defer worksheet.Unlock()
-		// flush data
+		// Flush data
 		output, _ := xml.Marshal(worksheet)
 		f.saveFileList(name, f.replaceNameSpaceBytes(name, output))
 	}

--- a/shape_test.go
+++ b/shape_test.go
@@ -59,7 +59,7 @@ func TestAddShape(t *testing.T) {
 	}`), newCellNameToCoordinatesError("A", newInvalidCellNameError("A")).Error())
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestAddShape1.xlsx")))
 
-	// Test add first shape for given sheet.
+	// Test add first shape for given sheet
 	f = NewFile()
 	assert.NoError(t, f.AddShape("Sheet1", "A1", `{
 		"type": "ellipseRibbon",
@@ -87,11 +87,13 @@ func TestAddShape(t *testing.T) {
 		}
 	}`))
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestAddShape2.xlsx")))
-	// Test add shape with unsupported charset style sheet.
+	// Test add shape with invalid sheet name
+	assert.EqualError(t, f.AddShape("Sheet:1", "A30", `{"type":"rect","paragraph":[{"text":"Rectangle","font":{"color":"CD5C5C"}},{"text":"Shape","font":{"bold":true,"color":"2980B9"}}]}`), ErrSheetNameInvalid.Error())
+	// Test add shape with unsupported charset style sheet
 	f.Styles = nil
 	f.Pkg.Store(defaultXMLPathStyles, MacintoshCyrillicCharset)
 	assert.EqualError(t, f.AddShape("Sheet1", "B30", `{"type":"rect","paragraph":[{"text":"Rectangle"},{}]}`), "XML syntax error on line 1: invalid UTF-8")
-	// Test add shape with unsupported charset content types.
+	// Test add shape with unsupported charset content types
 	f = NewFile()
 	f.ContentTypes = nil
 	f.Pkg.Store(defaultXMLPathContentTypes, MacintoshCyrillicCharset)

--- a/sheet.go
+++ b/sheet.go
@@ -1283,11 +1283,11 @@ func trimSheetName(name string) string {
 				break
 			}
 		}
-		length := len(r)
 		// Make sure the first or last character of the name cannot be a single quote.
 		if r[0] == 39 {
-			r = r[1:length]
+			r = r[1:]
 		}
+		length := len(r)
 		if r[length-1] == 39 {
 			r = r[:length-1]
 		}

--- a/sheet.go
+++ b/sheet.go
@@ -35,18 +35,15 @@ import (
 // name and returns the index of the sheets in the workbook after it appended.
 // Note that when creating a new workbook, the default worksheet named
 // `Sheet1` will be created.
-func (f *File) NewSheet(sheet string) int {
-	// Check if the worksheet name is valid
-	if !f.CheckSheetNameValid(sheet) {
-		return -1
-	}
-	if trimSheetName(sheet) == "" {
-		return -1
+func (f *File) NewSheet(sheet string) (int, error) {
+	var err error
+	if err = checkSheetName(sheet); err != nil {
+		return -1, err
 	}
 	// Check if the worksheet already exists
-	index := f.GetSheetIndex(sheet)
+	index, err := f.GetSheetIndex(sheet)
 	if index != -1 {
-		return index
+		return index, err
 	}
 	f.DeleteSheet(sheet)
 	f.SheetCount++
@@ -239,7 +236,7 @@ func (f *File) setSheet(index int, name string) {
 		},
 	}
 	sheetXMLPath := "xl/worksheets/sheet" + strconv.Itoa(index) + ".xml"
-	f.sheetMap[trimSheetName(name)] = sheetXMLPath
+	f.sheetMap[name] = sheetXMLPath
 	f.Sheet.Store(sheetXMLPath, &ws)
 	f.xmlAttr[sheetXMLPath] = []xml.Attr{NameSpaceSpreadSheet}
 }
@@ -356,12 +353,16 @@ func (f *File) getActiveSheetID() int {
 // this function only changes the name of the sheet and will not update the
 // sheet name in the formula or reference associated with the cell. So there
 // may be problem formula error or reference missing.
-// todo: need change, This function does not appear to have a caller.
-func (f *File) SetSheetName(source, target string) {
-	source = trimSheetName(source)
-	target = trimSheetName(target)
+func (f *File) SetSheetName(source, target string) error {
+	var err error
+	if err = checkSheetName(source); err != nil {
+		return err
+	}
+	if err = checkSheetName(target); err != nil {
+		return err
+	}
 	if strings.EqualFold(target, source) {
-		return
+		return err
 	}
 	wb, _ := f.workbookReader()
 	for k, v := range wb.Sheets.Sheet {
@@ -371,6 +372,7 @@ func (f *File) SetSheetName(source, target string) {
 			delete(f.sheetMap, source)
 		}
 	}
+	return err
 }
 
 // GetSheetName provides a function to get the sheet name of the workbook by
@@ -390,9 +392,8 @@ func (f *File) GetSheetName(index int) (name string) {
 // given sheet name. If given worksheet name is invalid, will return an
 // integer type value -1.
 func (f *File) getSheetID(sheet string) int {
-	sheetName := trimSheetName(sheet)
 	for sheetID, name := range f.GetSheetMap() {
-		if strings.EqualFold(name, sheetName) {
+		if strings.EqualFold(name, sheet) {
 			return sheetID
 		}
 	}
@@ -402,14 +403,16 @@ func (f *File) getSheetID(sheet string) int {
 // GetSheetIndex provides a function to get a sheet index of the workbook by
 // the given sheet name. If the given sheet name is invalid or sheet doesn't
 // exist, it will return an integer type value -1.
-func (f *File) GetSheetIndex(sheet string) int {
-	sheetName := trimSheetName(sheet)
+func (f *File) GetSheetIndex(sheet string) (int, error) {
+	if err := checkSheetName(sheet); err != nil {
+		return -1, err
+	}
 	for index, name := range f.GetSheetList() {
-		if strings.EqualFold(name, sheetName) {
-			return index
+		if strings.EqualFold(name, sheet) {
+			return index, nil
 		}
 	}
-	return -1
+	return -1, nil
 }
 
 // GetSheetMap provides a function to get worksheets, chart sheets, dialog
@@ -479,7 +482,6 @@ func (f *File) getSheetXMLPath(sheet string) (string, bool) {
 		name string
 		ok   bool
 	)
-	sheet = trimSheetName(sheet)
 	for sheetName, filePath := range f.sheetMap {
 		if strings.EqualFold(sheetName, sheet) {
 			name, ok = filePath, true
@@ -535,19 +537,22 @@ func (f *File) setSheetBackground(sheet, extension string, file []byte) error {
 // references such as formulas, charts, and so on. If there is any referenced
 // value of the deleted worksheet, it will cause a file error when you open
 // it. This function will be invalid when only one worksheet is left.
-func (f *File) DeleteSheet(sheet string) {
-	if f.SheetCount == 1 || f.GetSheetIndex(sheet) == -1 {
-		return
+func (f *File) DeleteSheet(sheet string) error {
+	if err := checkSheetName(sheet); err != nil {
+		return err
 	}
-	sheetName := trimSheetName(sheet)
+	if idx, _ := f.GetSheetIndex(sheet); f.SheetCount == 1 || idx == -1 {
+		return nil
+	}
+
 	wb, _ := f.workbookReader()
 	wbRels, _ := f.relsReader(f.getWorkbookRelsPath())
 	activeSheetName := f.GetSheetName(f.GetActiveSheetIndex())
-	deleteLocalSheetID := f.GetSheetIndex(sheet)
+	deleteLocalSheetID, _ := f.GetSheetIndex(sheet)
 	deleteAndAdjustDefinedNames(wb, deleteLocalSheetID)
 
 	for idx, v := range wb.Sheets.Sheet {
-		if !strings.EqualFold(v.Name, sheetName) {
+		if !strings.EqualFold(v.Name, sheet) {
 			continue
 		}
 
@@ -573,7 +578,9 @@ func (f *File) DeleteSheet(sheet string) {
 		delete(f.xmlAttr, sheetXML)
 		f.SheetCount--
 	}
-	f.SetActiveSheet(f.GetSheetIndex(activeSheetName))
+	index, err := f.GetSheetIndex(activeSheetName)
+	f.SetActiveSheet(index)
+	return err
 }
 
 // deleteAndAdjustDefinedNames delete and adjust defined name in the workbook
@@ -688,7 +695,9 @@ func (f *File) copySheet(from, to int) error {
 //
 //	err := f.SetSheetVisible("Sheet1", false)
 func (f *File) SetSheetVisible(sheet string, visible bool) error {
-	sheet = trimSheetName(sheet)
+	if err := checkSheetName(sheet); err != nil {
+		return err
+	}
 	wb, err := f.workbookReader()
 	if err != nil {
 		return err
@@ -862,17 +871,20 @@ func (f *File) SetPanes(sheet, panes string) error {
 // name. For example, get visible state of Sheet1:
 //
 //	f.GetSheetVisible("Sheet1")
-func (f *File) GetSheetVisible(sheet string) bool {
-	name, visible := trimSheetName(sheet), false
+func (f *File) GetSheetVisible(sheet string) (bool, error) {
+	var visible bool
+	if err := checkSheetName(sheet); err != nil {
+		return visible, err
+	}
 	wb, _ := f.workbookReader()
 	for k, v := range wb.Sheets.Sheet {
-		if strings.EqualFold(v.Name, name) {
+		if strings.EqualFold(v.Name, sheet) {
 			if wb.Sheets.Sheet[k].State == "" || wb.Sheets.Sheet[k].State == "visible" {
 				visible = true
 			}
 		}
 	}
-	return visible
+	return visible, nil
 }
 
 // SearchSheet provides a function to get cell reference by given worksheet name,
@@ -894,6 +906,9 @@ func (f *File) SearchSheet(sheet, value string, reg ...bool) ([]string, error) {
 		regSearch bool
 		result    []string
 	)
+	if err := checkSheetName(sheet); err != nil {
+		return result, err
+	}
 	for _, r := range reg {
 		regSearch = r
 	}
@@ -902,7 +917,7 @@ func (f *File) SearchSheet(sheet, value string, reg ...bool) ([]string, error) {
 		return result, ErrSheetNotExist{sheet}
 	}
 	if ws, ok := f.Sheet.Load(name); ok && ws != nil {
-		// flush data
+		// Flush data
 		output, _ := xml.Marshal(ws.(*xlsxWorksheet))
 		f.saveFileList(name, f.replaceNameSpaceBytes(name, output))
 	}
@@ -1056,7 +1071,7 @@ func attrValToBool(name string, attrs []xml.Attr) (val bool, err error) {
 //	                        |
 //	 &F                     | Current workbook's file name
 //	                        |
-//	 &G                     | Drawing object as background
+//	 &G                     | Drawing object as background (Not support currently)
 //	                        |
 //	 &H                     | Shadow text format
 //	                        |
@@ -1172,47 +1187,47 @@ func (f *File) SetHeaderFooter(sheet string, settings *HeaderFooterOptions) erro
 //	    Password:      "password",
 //	    EditScenarios: false,
 //	})
-func (f *File) ProtectSheet(sheet string, settings *SheetProtectionOptions) error {
+func (f *File) ProtectSheet(sheet string, opts *SheetProtectionOptions) error {
 	ws, err := f.workSheetReader(sheet)
 	if err != nil {
 		return err
 	}
-	if settings == nil {
-		settings = &SheetProtectionOptions{
+	if opts == nil {
+		opts = &SheetProtectionOptions{
 			EditObjects:       true,
 			EditScenarios:     true,
 			SelectLockedCells: true,
 		}
 	}
 	ws.SheetProtection = &xlsxSheetProtection{
-		AutoFilter:          settings.AutoFilter,
-		DeleteColumns:       settings.DeleteColumns,
-		DeleteRows:          settings.DeleteRows,
-		FormatCells:         settings.FormatCells,
-		FormatColumns:       settings.FormatColumns,
-		FormatRows:          settings.FormatRows,
-		InsertColumns:       settings.InsertColumns,
-		InsertHyperlinks:    settings.InsertHyperlinks,
-		InsertRows:          settings.InsertRows,
-		Objects:             settings.EditObjects,
-		PivotTables:         settings.PivotTables,
-		Scenarios:           settings.EditScenarios,
-		SelectLockedCells:   settings.SelectLockedCells,
-		SelectUnlockedCells: settings.SelectUnlockedCells,
+		AutoFilter:          opts.AutoFilter,
+		DeleteColumns:       opts.DeleteColumns,
+		DeleteRows:          opts.DeleteRows,
+		FormatCells:         opts.FormatCells,
+		FormatColumns:       opts.FormatColumns,
+		FormatRows:          opts.FormatRows,
+		InsertColumns:       opts.InsertColumns,
+		InsertHyperlinks:    opts.InsertHyperlinks,
+		InsertRows:          opts.InsertRows,
+		Objects:             opts.EditObjects,
+		PivotTables:         opts.PivotTables,
+		Scenarios:           opts.EditScenarios,
+		SelectLockedCells:   opts.SelectLockedCells,
+		SelectUnlockedCells: opts.SelectUnlockedCells,
 		Sheet:               true,
-		Sort:                settings.Sort,
+		Sort:                opts.Sort,
 	}
-	if settings.Password != "" {
-		if settings.AlgorithmName == "" {
-			ws.SheetProtection.Password = genSheetPasswd(settings.Password)
+	if opts.Password != "" {
+		if opts.AlgorithmName == "" {
+			ws.SheetProtection.Password = genSheetPasswd(opts.Password)
 			return err
 		}
-		hashValue, saltValue, err := genISOPasswdHash(settings.Password, settings.AlgorithmName, "", int(sheetProtectionSpinCount))
+		hashValue, saltValue, err := genISOPasswdHash(opts.Password, opts.AlgorithmName, "", int(sheetProtectionSpinCount))
 		if err != nil {
 			return err
 		}
 		ws.SheetProtection.Password = ""
-		ws.SheetProtection.AlgorithmName = settings.AlgorithmName
+		ws.SheetProtection.AlgorithmName = opts.AlgorithmName
 		ws.SheetProtection.SaltValue = saltValue
 		ws.SheetProtection.HashValue = hashValue
 		ws.SheetProtection.SpinCount = int(sheetProtectionSpinCount)
@@ -1251,67 +1266,25 @@ func (f *File) UnprotectSheet(sheet string, password ...string) error {
 	return err
 }
 
-// trimSheetName provides a function to trim invalid characters by given worksheet
-// name.
-// 1、Intercept no more than 31 characters.
-// 2、Delete characters are not included in the name: : \ / ? * [ ].
-// 3、Confirm that the first or last character of the name cannot be a single quote.
-//
-// The Ascii code is shown in the table below
-//
-//  | Decimal | Symbol |
-//  |  ----   | ----   |
-//  | 58      |  :     |
-//  | 92      |  \     |
-//  | 47      |  ?     |
-//  | 42      |  *     |
-//  | 91      |  [     |
-//  | 93      |  ]     |
-//  | 39      |  '     |
-func trimSheetName(name string) string {
-	if strings.ContainsAny(name, ":\\/?*[]") || utf8.RuneCountInString(name) > 31 ||
-		strings.HasSuffix(name, "'") || strings.HasPrefix(name, "'") {
-		r := make([]rune, 0, 31)
-		for _, v := range name {
-			switch v {
-			case 58, 92, 47, 63, 42, 91, 93: // replace :\/?*[]
-				continue
-			default:
-				r = append(r, v)
-			}
-			if len(r) == 31 {
-				break
-			}
-		}
-		// Make sure the first or last character of the name cannot be a single quote.
-		if r[0] == 39 {
-			r = r[1:]
-		}
-		length := len(r)
-		if r[length-1] == 39 {
-			r = r[:length-1]
-		}
-		name = string(r)
+// checkSheetName check whether there are illegal characters in the sheet name.
+// 1. Confirm that the sheet name is not empty
+// 2. Make sure to enter a name with no more than 31 characters
+// 3. Make sure the first or last character of the name cannot be a single quote
+// 4. Verify that the following characters are not included in the name :\/?*[]
+func checkSheetName(name string) error {
+	if name == "" {
+		return ErrSheetNameBlank
 	}
-	return name
-}
-
-// CheckSheetNameValid check whether there are illegal characters in the sheet name.
-// 1、Make sure to enter a name with no more than 31 characters.
-// 2、Verify that the following characters are not included in the name: : \ / ? * [ ].
-// 3、Make sure the first or last character of the name cannot be a single quote.
-// 4、Confirm that the sheet name is not empty.
-func (f *File) CheckSheetNameValid(sheetName string) bool {
-	if sheetName == "" {
-		return false
+	if utf8.RuneCountInString(name) > MaxSheetNameLength {
+		return ErrSheetNameLength
 	}
-	if strings.ContainsAny(sheetName, ":\\/?*[]") || utf8.RuneCountInString(sheetName) > 31 {
-		return false
+	if strings.HasPrefix(name, "'") || strings.HasSuffix(name, "'") {
+		return ErrSheetNameSingleQuote
 	}
-	if strings.HasPrefix(sheetName, "'") || strings.HasSuffix(sheetName, "'") {
-		return false
+	if strings.ContainsAny(name, ":\\/?*[]") {
+		return ErrSheetNameInvalid
 	}
-	return true
+	return nil
 }
 
 // SetPageLayout provides a function to sets worksheet page layout.
@@ -1546,7 +1519,7 @@ func (f *File) SetDefinedName(definedName *DefinedName) error {
 		Data:    definedName.RefersTo,
 	}
 	if definedName.Scope != "" {
-		if sheetIndex := f.GetSheetIndex(definedName.Scope); sheetIndex >= 0 {
+		if sheetIndex, _ := f.GetSheetIndex(definedName.Scope); sheetIndex >= 0 {
 			d.LocalSheetID = &sheetIndex
 		}
 	}
@@ -1626,7 +1599,7 @@ func (f *File) GetDefinedName() []DefinedName {
 // GroupSheets provides a function to group worksheets by given worksheets
 // name. Group worksheets must contain an active worksheet.
 func (f *File) GroupSheets(sheets []string) error {
-	// check an active worksheet in group worksheets
+	// Check an active worksheet in group worksheets
 	var inActiveSheet bool
 	activeSheet := f.GetActiveSheetIndex()
 	sheetMap := f.GetSheetList()

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -498,12 +498,14 @@ func TestSetSheetBackgroundFromBytes(t *testing.T) {
 	assert.EqualError(t, f.SetSheetBackgroundFromBytes("Sheet1", ".svg", nil), ErrParameterInvalid.Error())
 }
 
-func TestSheetNameValid(t *testing.T) {
+func TestSheetName(t *testing.T) {
 	f := NewFile()
+	// valid sheet name
 	assert.Equal(t, true, f.CheckSheetNameValid("Sheet1"))
+	assert.Equal(t, true, f.CheckSheetNameValid("She'et1"))
+	// invalid sheet name, empty name
 	assert.Equal(t, false, f.CheckSheetNameValid(""))
-	assert.Equal(t, false, f.CheckSheetNameValid("'Sheet"))
-	assert.Equal(t, false, f.CheckSheetNameValid("Sheet'"))
+	// invalid sheet name, include :\/?*[]
 	assert.Equal(t, false, f.CheckSheetNameValid("Sheet:"))
 	assert.Equal(t, false, f.CheckSheetNameValid(`Sheet\`))
 	assert.Equal(t, false, f.CheckSheetNameValid("Sheet/"))
@@ -511,5 +513,8 @@ func TestSheetNameValid(t *testing.T) {
 	assert.Equal(t, false, f.CheckSheetNameValid("Sheet*"))
 	assert.Equal(t, false, f.CheckSheetNameValid("Sheet["))
 	assert.Equal(t, false, f.CheckSheetNameValid("Sheet]"))
+	// invalid sheet name, single quotes at the front or at the end
+	assert.Equal(t, false, f.CheckSheetNameValid("'Sheet"))
+	assert.Equal(t, false, f.CheckSheetNameValid("Sheet'"))
 
 }

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -16,28 +16,27 @@ import (
 func TestNewSheet(t *testing.T) {
 	f := NewFile()
 	f.NewSheet("Sheet2")
-	sheetID := f.NewSheet("sheet2")
+	sheetID, err := f.NewSheet("sheet2")
+	assert.NoError(t, err)
 	f.SetActiveSheet(sheetID)
-	// delete original sheet
-	f.DeleteSheet(f.GetSheetName(f.GetSheetIndex("Sheet1")))
+	// Test delete original sheet
+	idx, err := f.GetSheetIndex("Sheet1")
+	assert.NoError(t, err)
+	f.DeleteSheet(f.GetSheetName(idx))
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestNewSheet.xlsx")))
-	// create new worksheet with already exists name
-	assert.Equal(t, f.GetSheetIndex("Sheet2"), f.NewSheet("Sheet2"))
-	// create new worksheet with empty sheet name
-	assert.Equal(t, -1, f.NewSheet(":\\/?*[]"))
-	// create new worksheet with invalid characters or does not comply with the rules
-	assert.Equal(t, -1, f.NewSheet("Sheet:"))
-	assert.Equal(t, -1, f.NewSheet(`Sheet\`))
-	assert.Equal(t, -1, f.NewSheet("Sheet/"))
-	assert.Equal(t, -1, f.NewSheet("Sheet?"))
-	assert.Equal(t, -1, f.NewSheet("Sheet*"))
-	assert.Equal(t, -1, f.NewSheet("Sheet["))
-	assert.Equal(t, -1, f.NewSheet("Sheet]"))
-	assert.Equal(t, -1, f.NewSheet("'Sheet"))
-	assert.Equal(t, -1, f.NewSheet("Sheet'"))
+	// Test create new worksheet with already exists name
+	sheetID, err = f.NewSheet("Sheet2")
+	assert.NoError(t, err)
+	idx, err = f.GetSheetIndex("Sheet2")
+	assert.NoError(t, err)
+	assert.Equal(t, idx, sheetID)
+	// Test create new worksheet with empty sheet name
+	sheetID, err = f.NewSheet(":\\/?*[]")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
+	assert.Equal(t, -1, sheetID)
 }
 
-func TestSetPane(t *testing.T) {
+func TestSetPanes(t *testing.T) {
 	f := NewFile()
 	assert.NoError(t, f.SetPanes("Sheet1", `{"freeze":false,"split":false}`))
 	f.NewSheet("Panes 2")
@@ -48,6 +47,8 @@ func TestSetPane(t *testing.T) {
 	assert.NoError(t, f.SetPanes("Panes 4", `{"freeze":true,"split":false,"x_split":0,"y_split":9,"top_left_cell":"A34","active_pane":"bottomLeft","panes":[{"sqref":"A11:XFD11","active_cell":"A11","pane":"bottomLeft"}]}`))
 	assert.EqualError(t, f.SetPanes("Panes 4", ""), "unexpected end of JSON input")
 	assert.EqualError(t, f.SetPanes("SheetN", ""), "sheet SheetN does not exist")
+	// Test set panes with invalid sheet name
+	assert.EqualError(t, f.SetPanes("Sheet:1", `{"freeze":false,"split":false}`), ErrSheetNameInvalid.Error())
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetPane.xlsx")))
 	// Test add pane on empty sheet views worksheet
 	f = NewFile()
@@ -62,11 +63,14 @@ func TestSearchSheet(t *testing.T) {
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	// Test search in a not exists worksheet.
+	// Test search in a not exists worksheet
 	_, err = f.SearchSheet("Sheet4", "")
 	assert.EqualError(t, err, "sheet Sheet4 does not exist")
+	// Test search sheet with invalid sheet name
+	_, err = f.SearchSheet("Sheet:1", "")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
 	var expected []string
-	// Test search a not exists value.
+	// Test search a not exists value
 	result, err := f.SearchSheet("Sheet1", "X")
 	assert.NoError(t, err)
 	assert.EqualValues(t, expected, result)
@@ -130,23 +134,30 @@ func TestSetPageLayout(t *testing.T) {
 	opts, err := f.GetPageLayout("Sheet1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, opts)
-	// Test set page layout on not exists worksheet.
+	// Test set page layout on not exists worksheet
 	assert.EqualError(t, f.SetPageLayout("SheetN", nil), "sheet SheetN does not exist")
+	// Test set page layout with invalid sheet name
+	assert.EqualError(t, f.SetPageLayout("Sheet:1", nil), ErrSheetNameInvalid.Error())
 }
 
 func TestGetPageLayout(t *testing.T) {
 	f := NewFile()
-	// Test get page layout on not exists worksheet.
+	// Test get page layout on not exists worksheet
 	_, err := f.GetPageLayout("SheetN")
 	assert.EqualError(t, err, "sheet SheetN does not exist")
+	// Test get page layout with invalid sheet name
+	_, err = f.GetPageLayout("Sheet:1")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
 }
 
 func TestSetHeaderFooter(t *testing.T) {
 	f := NewFile()
 	assert.NoError(t, f.SetCellStr("Sheet1", "A1", "Test SetHeaderFooter"))
-	// Test set header and footer on not exists worksheet.
+	// Test set header and footer on not exists worksheet
 	assert.EqualError(t, f.SetHeaderFooter("SheetN", nil), "sheet SheetN does not exist")
-	// Test set header and footer with illegal setting.
+	// Test Sheet:1 with invalid sheet name
+	assert.EqualError(t, f.SetHeaderFooter("Sheet:1", nil), ErrSheetNameInvalid.Error())
+	// Test set header and footer with illegal setting
 	assert.EqualError(t, f.SetHeaderFooter("Sheet1", &HeaderFooterOptions{
 		OddHeader: strings.Repeat("c", MaxFieldLength+1),
 	}), newFieldLengthError("OddHeader").Error())
@@ -200,13 +211,13 @@ func TestDefinedName(t *testing.T) {
 	assert.Exactly(t, "Sheet1!$A$2:$D$5", f.GetDefinedName()[0].RefersTo)
 	assert.Exactly(t, 1, len(f.GetDefinedName()))
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestDefinedName.xlsx")))
-	// Test set defined name with unsupported charset workbook.
+	// Test set defined name with unsupported charset workbook
 	f.WorkBook = nil
 	f.Pkg.Store(defaultXMLPathWorkbook, MacintoshCyrillicCharset)
 	assert.EqualError(t, f.SetDefinedName(&DefinedName{
 		Name: "Amount", RefersTo: "Sheet1!$A$2:$D$5",
 	}), "XML syntax error on line 1: invalid UTF-8")
-	// Test delete defined name with unsupported charset workbook.
+	// Test delete defined name with unsupported charset workbook
 	f.WorkBook = nil
 	f.Pkg.Store(defaultXMLPathWorkbook, MacintoshCyrillicCharset)
 	assert.EqualError(t, f.DeleteDefinedName(&DefinedName{Name: "Amount"}),
@@ -221,6 +232,8 @@ func TestGroupSheets(t *testing.T) {
 	}
 	assert.EqualError(t, f.GroupSheets([]string{"Sheet1", "SheetN"}), "sheet SheetN does not exist")
 	assert.EqualError(t, f.GroupSheets([]string{"Sheet2", "Sheet3"}), "group worksheet must contain an active worksheet")
+	// Test group sheets with invalid sheet name
+	assert.EqualError(t, f.GroupSheets([]string{"Sheet:1", "Sheet1"}), ErrSheetNameInvalid.Error())
 	assert.NoError(t, f.GroupSheets([]string{"Sheet1", "Sheet2"}))
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestGroupSheets.xlsx")))
 }
@@ -242,6 +255,8 @@ func TestInsertPageBreak(t *testing.T) {
 	assert.NoError(t, f.InsertPageBreak("Sheet1", "C3"))
 	assert.EqualError(t, f.InsertPageBreak("Sheet1", "A"), newCellNameToCoordinatesError("A", newInvalidCellNameError("A")).Error())
 	assert.EqualError(t, f.InsertPageBreak("SheetN", "C3"), "sheet SheetN does not exist")
+	// Test insert page break with invalid sheet name
+	assert.EqualError(t, f.InsertPageBreak("Sheet:1", "C3"), ErrSheetNameInvalid.Error())
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestInsertPageBreak.xlsx")))
 }
 
@@ -268,6 +283,8 @@ func TestRemovePageBreak(t *testing.T) {
 
 	assert.EqualError(t, f.RemovePageBreak("Sheet1", "A"), newCellNameToCoordinatesError("A", newInvalidCellNameError("A")).Error())
 	assert.EqualError(t, f.RemovePageBreak("SheetN", "C3"), "sheet SheetN does not exist")
+	// Test remove page break with invalid sheet name
+	assert.EqualError(t, f.RemovePageBreak("Sheet:1", "A3"), ErrSheetNameInvalid.Error())
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestRemovePageBreak.xlsx")))
 }
 
@@ -315,7 +332,8 @@ func TestSetActiveSheet(t *testing.T) {
 
 	f = NewFile()
 	f.WorkBook.BookViews = nil
-	idx := f.NewSheet("Sheet2")
+	idx, err := f.NewSheet("Sheet2")
+	assert.NoError(t, err)
 	ws, ok = f.Sheet.Load("xl/worksheets/sheet2.xml")
 	assert.True(t, ok)
 	ws.(*xlsxWorksheet).SheetViews = &xlsxSheetViews{SheetView: []xlsxSheetView{}}
@@ -324,9 +342,11 @@ func TestSetActiveSheet(t *testing.T) {
 
 func TestSetSheetName(t *testing.T) {
 	f := NewFile()
-	// Test set worksheet with the same name.
-	f.SetSheetName("Sheet1", "Sheet1")
+	// Test set worksheet with the same name
+	assert.NoError(t, f.SetSheetName("Sheet1", "Sheet1"))
 	assert.Equal(t, "Sheet1", f.GetSheetName(0))
+	// Test set sheet name with invalid sheet name
+	assert.EqualError(t, f.SetSheetName("Sheet:1", "Sheet1"), ErrSheetNameInvalid.Error())
 }
 
 func TestWorksheetWriter(t *testing.T) {
@@ -358,7 +378,9 @@ func TestGetWorkbookRelsPath(t *testing.T) {
 
 func TestDeleteSheet(t *testing.T) {
 	f := NewFile()
-	f.SetActiveSheet(f.NewSheet("Sheet2"))
+	idx, err := f.NewSheet("Sheet2")
+	assert.NoError(t, err)
+	f.SetActiveSheet(idx)
 	f.NewSheet("Sheet3")
 	f.DeleteSheet("Sheet1")
 	assert.Equal(t, "Sheet2", f.GetSheetName(f.GetActiveSheetIndex()))
@@ -373,8 +395,10 @@ func TestDeleteSheet(t *testing.T) {
 	assert.NoError(t, f.AutoFilter("Sheet1", "A1", "A1", ""))
 	assert.NoError(t, f.AutoFilter("Sheet2", "A1", "A1", ""))
 	assert.NoError(t, f.AutoFilter("Sheet3", "A1", "A1", ""))
-	f.DeleteSheet("Sheet2")
-	f.DeleteSheet("Sheet1")
+	assert.NoError(t, f.DeleteSheet("Sheet2"))
+	assert.NoError(t, f.DeleteSheet("Sheet1"))
+	// Test delete sheet with invalid sheet name
+	assert.EqualError(t, f.DeleteSheet("Sheet:1"), ErrSheetNameInvalid.Error())
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestDeleteSheet2.xlsx")))
 }
 
@@ -392,12 +416,30 @@ func TestGetSheetID(t *testing.T) {
 
 func TestSetSheetVisible(t *testing.T) {
 	f := NewFile()
+	// Test set sheet visible with invalid sheet name
+	assert.EqualError(t, f.SetSheetVisible("Sheet:1", false), ErrSheetNameInvalid.Error())
 	f.WorkBook.Sheets.Sheet[0].Name = "SheetN"
 	assert.EqualError(t, f.SetSheetVisible("Sheet1", false), "sheet SheetN does not exist")
-	// Test set sheet visible with unsupported charset workbook.
+	// Test set sheet visible with unsupported charset workbook
 	f.WorkBook = nil
 	f.Pkg.Store(defaultXMLPathWorkbook, MacintoshCyrillicCharset)
 	assert.EqualError(t, f.SetSheetVisible("Sheet1", false), "XML syntax error on line 1: invalid UTF-8")
+}
+
+func TestGetSheetVisible(t *testing.T) {
+	f := NewFile()
+	// Test get sheet visible with invalid sheet name
+	visible, err := f.GetSheetVisible("Sheet:1")
+	assert.Equal(t, false, visible)
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
+}
+
+func TestGetSheetIndex(t *testing.T) {
+	f := NewFile()
+	// Test get sheet index with invalid sheet name
+	idx, err := f.GetSheetIndex("Sheet:1")
+	assert.Equal(t, -1, idx)
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
 }
 
 func TestSetContentTypes(t *testing.T) {
@@ -492,29 +534,34 @@ func TestSetSheetBackgroundFromBytes(t *testing.T) {
 		assert.NoError(t, img.Close())
 		assert.NoError(t, f.SetSheetBackgroundFromBytes(imageTypes, imageTypes, content))
 	}
+	// Test set worksheet background with invalid sheet name
+	img, err := os.Open(filepath.Join("test", "images", "excel.png"))
+	assert.NoError(t, err)
+	content, err := io.ReadAll(img)
+	assert.NoError(t, err)
+	assert.EqualError(t, f.SetSheetBackgroundFromBytes("Sheet:1", ".png", content), ErrSheetNameInvalid.Error())
+
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetSheetBackgroundFromBytes.xlsx")))
 	assert.NoError(t, f.Close())
 
 	assert.EqualError(t, f.SetSheetBackgroundFromBytes("Sheet1", ".svg", nil), ErrParameterInvalid.Error())
 }
 
-func TestSheetName(t *testing.T) {
-	f := NewFile()
-	// valid sheet name
-	assert.Equal(t, true, f.CheckSheetNameValid("Sheet1"))
-	assert.Equal(t, true, f.CheckSheetNameValid("She'et1"))
-	// invalid sheet name, empty name
-	assert.Equal(t, false, f.CheckSheetNameValid(""))
-	// invalid sheet name, include :\/?*[]
-	assert.Equal(t, false, f.CheckSheetNameValid("Sheet:"))
-	assert.Equal(t, false, f.CheckSheetNameValid(`Sheet\`))
-	assert.Equal(t, false, f.CheckSheetNameValid("Sheet/"))
-	assert.Equal(t, false, f.CheckSheetNameValid("Sheet?"))
-	assert.Equal(t, false, f.CheckSheetNameValid("Sheet*"))
-	assert.Equal(t, false, f.CheckSheetNameValid("Sheet["))
-	assert.Equal(t, false, f.CheckSheetNameValid("Sheet]"))
-	// invalid sheet name, single quotes at the front or at the end
-	assert.Equal(t, false, f.CheckSheetNameValid("'Sheet"))
-	assert.Equal(t, false, f.CheckSheetNameValid("Sheet'"))
-
+func TestCheckSheetName(t *testing.T) {
+	// Test valid sheet name
+	assert.NoError(t, checkSheetName("Sheet1"))
+	assert.NoError(t, checkSheetName("She'et1"))
+	// Test invalid sheet name, empty name
+	assert.EqualError(t, checkSheetName(""), ErrSheetNameBlank.Error())
+	// Test invalid sheet name, include :\/?*[]
+	assert.EqualError(t, checkSheetName("Sheet:"), ErrSheetNameInvalid.Error())
+	assert.EqualError(t, checkSheetName(`Sheet\`), ErrSheetNameInvalid.Error())
+	assert.EqualError(t, checkSheetName("Sheet/"), ErrSheetNameInvalid.Error())
+	assert.EqualError(t, checkSheetName("Sheet?"), ErrSheetNameInvalid.Error())
+	assert.EqualError(t, checkSheetName("Sheet*"), ErrSheetNameInvalid.Error())
+	assert.EqualError(t, checkSheetName("Sheet["), ErrSheetNameInvalid.Error())
+	assert.EqualError(t, checkSheetName("Sheet]"), ErrSheetNameInvalid.Error())
+	// Test invalid sheet name, single quotes at the front or at the end
+	assert.EqualError(t, checkSheetName("'Sheet"), ErrSheetNameSingleQuote.Error())
+	assert.EqualError(t, checkSheetName("Sheet'"), ErrSheetNameSingleQuote.Error())
 }

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -25,6 +25,16 @@ func TestNewSheet(t *testing.T) {
 	assert.Equal(t, f.GetSheetIndex("Sheet2"), f.NewSheet("Sheet2"))
 	// create new worksheet with empty sheet name
 	assert.Equal(t, -1, f.NewSheet(":\\/?*[]"))
+	// create new worksheet with invalid characters or does not comply with the rules
+	assert.Equal(t, -1, f.NewSheet("Sheet:"))
+	assert.Equal(t, -1, f.NewSheet(`Sheet\`))
+	assert.Equal(t, -1, f.NewSheet("Sheet/"))
+	assert.Equal(t, -1, f.NewSheet("Sheet?"))
+	assert.Equal(t, -1, f.NewSheet("Sheet*"))
+	assert.Equal(t, -1, f.NewSheet("Sheet["))
+	assert.Equal(t, -1, f.NewSheet("Sheet]"))
+	assert.Equal(t, -1, f.NewSheet("'Sheet"))
+	assert.Equal(t, -1, f.NewSheet("Sheet'"))
 }
 
 func TestSetPane(t *testing.T) {
@@ -486,4 +496,20 @@ func TestSetSheetBackgroundFromBytes(t *testing.T) {
 	assert.NoError(t, f.Close())
 
 	assert.EqualError(t, f.SetSheetBackgroundFromBytes("Sheet1", ".svg", nil), ErrParameterInvalid.Error())
+}
+
+func TestSheetNameValid(t *testing.T) {
+	f := NewFile()
+	assert.Equal(t, true, f.CheckSheetNameValid("Sheet1"))
+	assert.Equal(t, false, f.CheckSheetNameValid(""))
+	assert.Equal(t, false, f.CheckSheetNameValid("'Sheet"))
+	assert.Equal(t, false, f.CheckSheetNameValid("Sheet'"))
+	assert.Equal(t, false, f.CheckSheetNameValid("Sheet:"))
+	assert.Equal(t, false, f.CheckSheetNameValid(`Sheet\`))
+	assert.Equal(t, false, f.CheckSheetNameValid("Sheet/"))
+	assert.Equal(t, false, f.CheckSheetNameValid("Sheet?"))
+	assert.Equal(t, false, f.CheckSheetNameValid("Sheet*"))
+	assert.Equal(t, false, f.CheckSheetNameValid("Sheet["))
+	assert.Equal(t, false, f.CheckSheetNameValid("Sheet]"))
+
 }

--- a/sheetpr_test.go
+++ b/sheetpr_test.go
@@ -27,15 +27,20 @@ func TestSetPageMargins(t *testing.T) {
 	opts, err := f.GetPageMargins("Sheet1")
 	assert.NoError(t, err)
 	assert.Equal(t, expected, opts)
-	// Test set page margins on not exists worksheet.
+	// Test set page margins on not exists worksheet
 	assert.EqualError(t, f.SetPageMargins("SheetN", nil), "sheet SheetN does not exist")
+	// Test set page margins with invalid sheet name
+	assert.EqualError(t, f.SetPageMargins("Sheet:1", nil), ErrSheetNameInvalid.Error())
 }
 
 func TestGetPageMargins(t *testing.T) {
 	f := NewFile()
-	// Test get page margins on not exists worksheet.
+	// Test get page margins on not exists worksheet
 	_, err := f.GetPageMargins("SheetN")
 	assert.EqualError(t, err, "sheet SheetN does not exist")
+	// Test get page margins with invalid sheet name
+	_, err = f.GetPageMargins("Sheet:1")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
 }
 
 func TestSetSheetProps(t *testing.T) {
@@ -80,13 +85,18 @@ func TestSetSheetProps(t *testing.T) {
 	ws.(*xlsxWorksheet).SheetPr = nil
 	assert.NoError(t, f.SetSheetProps("Sheet1", &SheetPropsOptions{TabColorTint: float64Ptr(1)}))
 
-	// Test SetSheetProps on not exists worksheet.
+	// Test set worksheet properties on not exists worksheet
 	assert.EqualError(t, f.SetSheetProps("SheetN", nil), "sheet SheetN does not exist")
+	// Test set worksheet properties with invalid sheet name
+	assert.EqualError(t, f.SetSheetProps("Sheet:1", nil), ErrSheetNameInvalid.Error())
 }
 
 func TestGetSheetProps(t *testing.T) {
 	f := NewFile()
-	// Test GetSheetProps on not exists worksheet.
+	// Test get worksheet properties on not exists worksheet
 	_, err := f.GetSheetProps("SheetN")
 	assert.EqualError(t, err, "sheet SheetN does not exist")
+	// Test get worksheet properties with invalid sheet name
+	_, err = f.GetSheetProps("Sheet:1")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
 }

--- a/sparkline_test.go
+++ b/sparkline_test.go
@@ -214,7 +214,7 @@ func TestAddSparkline(t *testing.T) {
 		Negative: true,
 	}))
 
-	// Save spreadsheet by the given path.
+	// Save spreadsheet by the given path
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestAddSparkline.xlsx")))
 
 	// Test error exceptions
@@ -224,6 +224,14 @@ func TestAddSparkline(t *testing.T) {
 	}), "sheet SheetN does not exist")
 
 	assert.EqualError(t, f.AddSparkline("Sheet1", nil), ErrParameterRequired.Error())
+
+	// Test add sparkline with invalid sheet name
+	assert.EqualError(t, f.AddSparkline("Sheet:1", &SparklineOptions{
+		Location: []string{"F3"},
+		Range:    []string{"Sheet2!A3:E3"},
+		Type:     "win_loss",
+		Negative: true,
+	}), ErrSheetNameInvalid.Error())
 
 	assert.EqualError(t, f.AddSparkline("Sheet1", &SparklineOptions{
 		Range: []string{"Sheet2!A3:E3"},

--- a/stream.go
+++ b/stream.go
@@ -102,6 +102,9 @@ type StreamWriter struct {
 //	    excelize.Cell{Value: 1}},
 //	    excelize.RowOpts{StyleID: styleID, Height: 20, Hidden: false});
 func (f *File) NewStreamWriter(sheet string) (*StreamWriter, error) {
+	if err := checkSheetName(sheet); err != nil {
+		return nil, err
+	}
 	sheetID := f.getSheetID(sheet)
 	if sheetID == -1 {
 		return nil, newNoExistSheetError(sheet)
@@ -219,8 +222,8 @@ func (sw *StreamWriter) AddTable(hCell, vCell, opts string) error {
 	sheetRelationshipsTableXML := "../tables/table" + strconv.Itoa(tableID) + ".xml"
 	tableXML := strings.ReplaceAll(sheetRelationshipsTableXML, "..", "xl")
 
-	// Add first table for given sheet.
-	sheetPath := sw.file.sheetMap[trimSheetName(sw.Sheet)]
+	// Add first table for given sheet
+	sheetPath := sw.file.sheetMap[sw.Sheet]
 	sheetRels := "xl/worksheets/_rels/" + strings.TrimPrefix(sheetPath, "xl/worksheets/") + ".rels"
 	rID := sw.file.addRels(sheetRels, SourceRelationshipTable, sheetRelationshipsTableXML, "")
 
@@ -661,7 +664,7 @@ func (sw *StreamWriter) Flush() error {
 		return err
 	}
 
-	sheetPath := sw.file.sheetMap[trimSheetName(sw.Sheet)]
+	sheetPath := sw.file.sheetMap[sw.Sheet]
 	sw.file.Sheet.Delete(sheetPath)
 	delete(sw.file.checked, sheetPath)
 	sw.file.Pkg.Delete(sheetPath)

--- a/stream_test.go
+++ b/stream_test.go
@@ -257,6 +257,9 @@ func TestNewStreamWriter(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = file.NewStreamWriter("SheetN")
 	assert.EqualError(t, err, "sheet SheetN does not exist")
+	// Test new stream write with invalid sheet name
+	_, err = file.NewStreamWriter("Sheet:1")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
 }
 
 func TestStreamMarshalAttrs(t *testing.T) {

--- a/styles.go
+++ b/styles.go
@@ -1101,11 +1101,25 @@ func parseFormatStyleSet(style interface{}) (*Style, error) {
 	return &fs, err
 }
 
-// NewStyle provides a function to create the style for cells by given
-// structure pointer or JSON. This function is concurrency safe. Note that the
-// color field uses RGB color code.
+// NewStyle provides a function to create the style for cells by given structure
+// pointer or JSON. This function is concurrency safe. Note that
+// the 'Font.Color' field uses an RGB color represented in 'RRGGBB' hexadecimal
+// notation.
 //
-// The following shows the border styles sorted by excelize index number:
+// The following table shows the border types used in 'Border.Type' supported by
+// excelize:
+//
+//	 Type         | Description
+//	--------------+------------------
+//	 left         | Left border
+//	 top          | Top border
+//	 right        | Right border
+//	 bottom       | Bottom border
+//	 diagonalDown | Diagonal down border
+//	 diagonalUp   | Diagonal up border
+//
+// The following table shows the border styles used in 'Border.Style' supported
+// by excelize index number:
 //
 //	 Index | Name          | Weight | Style
 //	-------+---------------+--------+-------------
@@ -1124,7 +1138,8 @@ func parseFormatStyleSet(style interface{}) (*Style, error) {
 //	 12    | Dash Dot Dot  | 2      | - . . - . .
 //	 13    | SlantDash Dot | 2      | / - . / - .
 //
-// The following shows the borders in the order shown in the Excel dialog:
+// The following table shows the border styles used in 'Border.Style' in the
+// order shown in the Excel dialog:
 //
 //	 Index | Style       | Index | Style
 //	-------+-------------+-------+-------------
@@ -1136,7 +1151,8 @@ func parseFormatStyleSet(style interface{}) (*Style, error) {
 //	 3     | - - - - - - | 5     | -----------
 //	 1     | ----------- | 6     | ===========
 //
-// The following shows the shading styles sorted by excelize index number:
+// The following table shows the shading styles used in 'Fill.Shading' supported
+// by excelize index number:
 //
 //	 Index | Style           | Index | Style
 //	-------+-----------------+-------+-----------------
@@ -1144,7 +1160,8 @@ func parseFormatStyleSet(style interface{}) (*Style, error) {
 //	 1     | Vertical        | 4     | From corner
 //	 2     | Diagonal Up     | 5     | From center
 //
-// The following shows the patterns styles sorted by excelize index number:
+// The following table shows the pattern styles used in 'Fill.Pattern' supported
+// by excelize index number:
 //
 //	 Index | Style           | Index | Style
 //	-------+-----------------+-------+-----------------
@@ -1159,7 +1176,8 @@ func parseFormatStyleSet(style interface{}) (*Style, error) {
 //	 8     | darkUp          | 18    | gray0625
 //	 9     | darkGrid        |       |
 //
-// The following the type of horizontal alignment in cells:
+// The following table shows the type of cells' horizontal alignment used
+// in 'Alignment.Horizontal':
 //
 //	 Style
 //	------------------
@@ -1171,7 +1189,8 @@ func parseFormatStyleSet(style interface{}) (*Style, error) {
 //	 centerContinuous
 //	 distributed
 //
-// The following the type of vertical alignment in cells:
+// The following table shows the type of cells' vertical alignment used in
+// 'Alignment.Vertical':
 //
 //	 Style
 //	------------------
@@ -1180,7 +1199,8 @@ func parseFormatStyleSet(style interface{}) (*Style, error) {
 //	 justify
 //	 distributed
 //
-// The following the type of font underline style:
+// The following table shows the type of font underline style used in
+// 'Font.Underline':
 //
 //	 Style
 //	------------------

--- a/styles_test.go
+++ b/styles_test.go
@@ -201,6 +201,9 @@ func TestGetConditionalFormats(t *testing.T) {
 	f := NewFile()
 	_, err := f.GetConditionalFormats("SheetN")
 	assert.EqualError(t, err, "sheet SheetN does not exist")
+	// Test get conditional formats with invalid sheet name
+	_, err = f.GetConditionalFormats("Sheet:1")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
 }
 
 func TestUnsetConditionalFormat(t *testing.T) {
@@ -211,9 +214,11 @@ func TestUnsetConditionalFormat(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, f.SetConditionalFormat("Sheet1", "A1:A10", fmt.Sprintf(`[{"type":"cell","criteria":">","format":%d,"value":"6"}]`, format)))
 	assert.NoError(t, f.UnsetConditionalFormat("Sheet1", "A1:A10"))
-	// Test unset conditional format on not exists worksheet.
+	// Test unset conditional format on not exists worksheet
 	assert.EqualError(t, f.UnsetConditionalFormat("SheetN", "A1:A10"), "sheet SheetN does not exist")
-	// Save spreadsheet by the given path.
+	// Test unset conditional format with invalid sheet name
+	assert.EqualError(t, f.UnsetConditionalFormat("Sheet:1", "A1:A10"), ErrSheetNameInvalid.Error())
+	// Save spreadsheet by the given path
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestUnsetConditionalFormat.xlsx")))
 }
 
@@ -240,7 +245,7 @@ func TestNewStyle(t *testing.T) {
 	_, err = f.NewStyle(&Style{Font: &Font{Size: MaxFontSize + 1}})
 	assert.EqualError(t, err, ErrFontSize.Error())
 
-	// Test create numeric custom style.
+	// Test create numeric custom style
 	numFmt := "####;####"
 	f.Styles.NumFmts = nil
 	styleID, err = f.NewStyle(&Style{
@@ -256,7 +261,7 @@ func TestNewStyle(t *testing.T) {
 	nf := f.Styles.CellXfs.Xf[styleID]
 	assert.Equal(t, 164, *nf.NumFmtID)
 
-	// Test create currency custom style.
+	// Test create currency custom style
 	f.Styles.NumFmts = nil
 	styleID, err = f.NewStyle(&Style{
 		Lang:   "ko-kr",
@@ -273,7 +278,7 @@ func TestNewStyle(t *testing.T) {
 	nf = f.Styles.CellXfs.Xf[styleID]
 	assert.Equal(t, 32, *nf.NumFmtID)
 
-	// Test set build-in scientific number format.
+	// Test set build-in scientific number format
 	styleID, err = f.NewStyle(&Style{NumFmt: 11})
 	assert.NoError(t, err)
 	assert.NoError(t, f.SetCellStyle("Sheet1", "A1", "B1", styleID))
@@ -283,7 +288,7 @@ func TestNewStyle(t *testing.T) {
 	assert.Equal(t, [][]string{{"1.23E+00", "1.23E+00"}}, rows)
 
 	f = NewFile()
-	// Test currency number format.
+	// Test currency number format
 	customNumFmt := "[$$-409]#,##0.00"
 	style1, err := f.NewStyle(&Style{CustomNumFmt: &customNumFmt})
 	assert.NoError(t, err)
@@ -309,7 +314,7 @@ func TestNewStyle(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, style5)
 
-	// Test create style with unsupported charset style sheet.
+	// Test create style with unsupported charset style sheet
 	f.Styles = nil
 	f.Pkg.Store(defaultXMLPathStyles, MacintoshCyrillicCharset)
 	_, err = f.NewStyle(&Style{NumFmt: 165})
@@ -318,7 +323,7 @@ func TestNewStyle(t *testing.T) {
 
 func TestNewConditionalStyle(t *testing.T) {
 	f := NewFile()
-	// Test create conditional style with unsupported charset style sheet.
+	// Test create conditional style with unsupported charset style sheet
 	f.Styles = nil
 	f.Pkg.Store(defaultXMLPathStyles, MacintoshCyrillicCharset)
 	_, err := f.NewConditionalStyle(`{"font":{"color":"#9A0511"},"fill":{"type":"pattern","color":["#FEC7CE"],"pattern":1}}`)
@@ -330,7 +335,7 @@ func TestGetDefaultFont(t *testing.T) {
 	s, err := f.GetDefaultFont()
 	assert.NoError(t, err)
 	assert.Equal(t, s, "Calibri", "Default font should be Calibri")
-	// Test get default font with unsupported charset style sheet.
+	// Test get default font with unsupported charset style sheet
 	f.Styles = nil
 	f.Pkg.Store(defaultXMLPathStyles, MacintoshCyrillicCharset)
 	_, err = f.GetDefaultFont()
@@ -346,7 +351,7 @@ func TestSetDefaultFont(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, s, "Arial", "Default font should change to Arial")
 	assert.Equal(t, *styles.CellStyles.CellStyle[0].CustomBuiltIn, true)
-	// Test set default font with unsupported charset style sheet.
+	// Test set default font with unsupported charset style sheet
 	f.Styles = nil
 	f.Pkg.Store(defaultXMLPathStyles, MacintoshCyrillicCharset)
 	assert.EqualError(t, f.SetDefaultFont("Arial"), "XML syntax error on line 1: invalid UTF-8")
@@ -354,7 +359,7 @@ func TestSetDefaultFont(t *testing.T) {
 
 func TestStylesReader(t *testing.T) {
 	f := NewFile()
-	// Test read styles with unsupported charset.
+	// Test read styles with unsupported charset
 	f.Styles = nil
 	f.Pkg.Store(defaultXMLPathStyles, MacintoshCyrillicCharset)
 	styles, err := f.stylesReader()
@@ -364,7 +369,7 @@ func TestStylesReader(t *testing.T) {
 
 func TestThemeReader(t *testing.T) {
 	f := NewFile()
-	// Test read theme with unsupported charset.
+	// Test read theme with unsupported charset
 	f.Pkg.Store(defaultXMLPathTheme, MacintoshCyrillicCharset)
 	theme, err := f.themeReader()
 	assert.EqualError(t, err, "XML syntax error on line 1: invalid UTF-8")

--- a/table.go
+++ b/table.go
@@ -304,7 +304,10 @@ func (f *File) AutoFilter(sheet, hCell, vCell, opts string) error {
 	if err != nil {
 		return err
 	}
-	sheetID := f.GetSheetIndex(sheet)
+	sheetID, err := f.GetSheetIndex(sheet)
+	if err != nil {
+		return err
+	}
 	filterRange := fmt.Sprintf("'%s'!%s", sheet, ref)
 	d := xlsxDefinedName{
 		Name:         filterDB,

--- a/table_test.go
+++ b/table_test.go
@@ -10,36 +10,24 @@ import (
 
 func TestAddTable(t *testing.T) {
 	f, err := prepareTestBook1()
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+	assert.NoError(t, err)
+	assert.NoError(t, f.AddTable("Sheet1", "B26", "A21", `{}`))
+	assert.NoError(t, f.AddTable("Sheet2", "A2", "B5", `{"table_name":"table","table_style":"TableStyleMedium2", "show_first_column":true,"show_last_column":true,"show_row_stripes":false,"show_column_stripes":true}`))
+	assert.NoError(t, f.AddTable("Sheet2", "F1", "F1", `{"table_style":"TableStyleMedium8"}`))
 
-	err = f.AddTable("Sheet1", "B26", "A21", `{}`)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-
-	err = f.AddTable("Sheet2", "A2", "B5", `{"table_name":"table","table_style":"TableStyleMedium2", "show_first_column":true,"show_last_column":true,"show_row_stripes":false,"show_column_stripes":true}`)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-
-	err = f.AddTable("Sheet2", "F1", "F1", `{"table_style":"TableStyleMedium8"}`)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-
-	// Test add table in not exist worksheet.
+	// Test add table in not exist worksheet
 	assert.EqualError(t, f.AddTable("SheetN", "B26", "A21", `{}`), "sheet SheetN does not exist")
-	// Test add table with illegal options.
+	// Test add table with illegal options
 	assert.EqualError(t, f.AddTable("Sheet1", "B26", "A21", `{x}`), "invalid character 'x' looking for beginning of object key string")
-	// Test add table with illegal cell reference.
+	// Test add table with illegal cell reference
 	assert.EqualError(t, f.AddTable("Sheet1", "A", "B1", `{}`), newCellNameToCoordinatesError("A", newInvalidCellNameError("A")).Error())
 	assert.EqualError(t, f.AddTable("Sheet1", "A1", "B", `{}`), newCellNameToCoordinatesError("B", newInvalidCellNameError("B")).Error())
 
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestAddTable.xlsx")))
 
-	// Test addTable with illegal cell reference.
+	// Test add table with invalid sheet name
+	assert.EqualError(t, f.AddTable("Sheet:1", "B26", "A21", `{}`), ErrSheetNameInvalid.Error())
+	// Test addTable with illegal cell reference
 	f = NewFile()
 	assert.EqualError(t, f.addTable("sheet1", "", 0, 0, 0, 0, 0, nil), "invalid cell reference [0, 0]")
 	assert.EqualError(t, f.addTable("sheet1", "", 1, 1, 0, 0, 0, nil), "invalid cell reference [0, 0]")
@@ -53,12 +41,8 @@ func TestSetTableHeader(t *testing.T) {
 
 func TestAutoFilter(t *testing.T) {
 	outFile := filepath.Join("test", "TestAutoFilter%d.xlsx")
-
 	f, err := prepareTestBook1()
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-
+	assert.NoError(t, err)
 	formats := []string{
 		``,
 		`{"column":"B","expression":"x != blanks"}`,
@@ -69,7 +53,6 @@ func TestAutoFilter(t *testing.T) {
 		`{"column":"B","expression":"x == 1 or x == 2"}`,
 		`{"column":"B","expression":"x == 1 or x == 2*"}`,
 	}
-
 	for i, format := range formats {
 		t.Run(fmt.Sprintf("Expression%d", i+1), func(t *testing.T) {
 			err = f.AutoFilter("Sheet1", "D4", "B1", format)
@@ -78,10 +61,12 @@ func TestAutoFilter(t *testing.T) {
 		})
 	}
 
-	// Test add auto filter with illegal cell reference.
+	// Test add auto filter with invalid sheet name
+	assert.EqualError(t, f.AutoFilter("Sheet:1", "A1", "B1", ""), ErrSheetNameInvalid.Error())
+	// Test add auto filter with illegal cell reference
 	assert.EqualError(t, f.AutoFilter("Sheet1", "A", "B1", ""), newCellNameToCoordinatesError("A", newInvalidCellNameError("A")).Error())
 	assert.EqualError(t, f.AutoFilter("Sheet1", "A1", "B", ""), newCellNameToCoordinatesError("B", newInvalidCellNameError("B")).Error())
-	// Test add auto filter with unsupported charset workbook.
+	// Test add auto filter with unsupported charset workbook
 	f.WorkBook = nil
 	f.Pkg.Store(defaultXMLPathWorkbook, MacintoshCyrillicCharset)
 	assert.EqualError(t, f.AutoFilter("Sheet1", "D4", "B1", formats[0]), "XML syntax error on line 1: invalid UTF-8")
@@ -132,10 +117,10 @@ func TestAutoFilterError(t *testing.T) {
 
 func TestParseFilterTokens(t *testing.T) {
 	f := NewFile()
-	// Test with unknown operator.
+	// Test with unknown operator
 	_, _, err := f.parseFilterTokens("", []string{"", "!"})
 	assert.EqualError(t, err, "unknown operator: !")
-	// Test invalid operator in context.
+	// Test invalid operator in context
 	_, _, err = f.parseFilterTokens("", []string{"", "<", "x != blanks"})
 	assert.EqualError(t, err, "the operator '<' in expression '' is not valid in relation to Blanks/NonBlanks'")
 }

--- a/workbook.go
+++ b/workbook.go
@@ -64,7 +64,7 @@ func (f *File) GetWorkbookProps() (WorkbookPropsOptions, error) {
 func (f *File) setWorkbook(name string, sheetID, rid int) {
 	wb, _ := f.workbookReader()
 	wb.Sheets.Sheet = append(wb.Sheets.Sheet, xlsxSheet{
-		Name:    trimSheetName(name),
+		Name:    name,
 		SheetID: sheetID,
 		ID:      "rId" + strconv.Itoa(rid),
 	})

--- a/xmlComments.go
+++ b/xmlComments.go
@@ -77,6 +77,6 @@ type Comment struct {
 	Author   string        `json:"author"`
 	AuthorID int           `json:"author_id"`
 	Cell     string        `json:"cell"`
-	Text     string        `json:"string"`
+	Text     string        `json:"text"`
 	Runs     []RichTextRun `json:"runs"`
 }

--- a/xmlDrawing.go
+++ b/xmlDrawing.go
@@ -19,58 +19,30 @@ import (
 // Source relationship and namespace list, associated prefixes and schema in which it was
 // introduced.
 var (
-	SourceRelationship                      = xml.Attr{Name: xml.Name{Local: "r", Space: "xmlns"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"}
-	SourceRelationshipCompatibility         = xml.Attr{Name: xml.Name{Local: "mc", Space: "xmlns"}, Value: "http://schemas.openxmlformats.org/markup-compatibility/2006"}
-	SourceRelationshipChart20070802         = xml.Attr{Name: xml.Name{Local: "c14", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/drawing/2007/8/2/chart"}
-	SourceRelationshipChart2014             = xml.Attr{Name: xml.Name{Local: "c16", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/drawing/2014/chart"}
-	SourceRelationshipChart201506           = xml.Attr{Name: xml.Name{Local: "c16r2", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/drawing/2015/06/chart"}
-	NameSpaceSpreadSheet                    = xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
-	NameSpaceSpreadSheetX14                 = xml.Attr{Name: xml.Name{Local: "x14", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"}
+	NameSpaceDocumentPropertiesVariantTypes = xml.Attr{Name: xml.Name{Local: "vt", Space: "xmlns"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"}
+	NameSpaceDrawing2016SVG                 = xml.Attr{Name: xml.Name{Local: "asvg", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/drawing/2016/SVG/main"}
 	NameSpaceDrawingML                      = xml.Attr{Name: xml.Name{Local: "a", Space: "xmlns"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/main"}
 	NameSpaceDrawingMLChart                 = xml.Attr{Name: xml.Name{Local: "c", Space: "xmlns"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/chart"}
 	NameSpaceDrawingMLSpreadSheet           = xml.Attr{Name: xml.Name{Local: "xdr", Space: "xmlns"}, Value: "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"}
-	NameSpaceDrawing2016SVG                 = xml.Attr{Name: xml.Name{Local: "asvg", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/drawing/2016/SVG/main"}
-	NameSpaceSpreadSheetX15                 = xml.Attr{Name: xml.Name{Local: "x15", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/spreadsheetml/2010/11/main"}
-	NameSpaceSpreadSheetExcel2006Main       = xml.Attr{Name: xml.Name{Local: "xne", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/excel/2006/main"}
 	NameSpaceMacExcel2008Main               = xml.Attr{Name: xml.Name{Local: "mx", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/mac/excel/2008/main"}
-	NameSpaceDocumentPropertiesVariantTypes = xml.Attr{Name: xml.Name{Local: "vt", Space: "xmlns"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"}
+	NameSpaceSpreadSheet                    = xml.Attr{Name: xml.Name{Local: "xmlns"}, Value: "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+	NameSpaceSpreadSheetExcel2006Main       = xml.Attr{Name: xml.Name{Local: "xne", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/excel/2006/main"}
+	NameSpaceSpreadSheetX14                 = xml.Attr{Name: xml.Name{Local: "x14", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"}
+	NameSpaceSpreadSheetX15                 = xml.Attr{Name: xml.Name{Local: "x15", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/spreadsheetml/2010/11/main"}
+	SourceRelationship                      = xml.Attr{Name: xml.Name{Local: "r", Space: "xmlns"}, Value: "http://schemas.openxmlformats.org/officeDocument/2006/relationships"}
+	SourceRelationshipChart20070802         = xml.Attr{Name: xml.Name{Local: "c14", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/drawing/2007/8/2/chart"}
+	SourceRelationshipChart2014             = xml.Attr{Name: xml.Name{Local: "c16", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/drawing/2014/chart"}
+	SourceRelationshipChart201506           = xml.Attr{Name: xml.Name{Local: "c16r2", Space: "xmlns"}, Value: "http://schemas.microsoft.com/office/drawing/2015/06/chart"}
+	SourceRelationshipCompatibility         = xml.Attr{Name: xml.Name{Local: "mc", Space: "xmlns"}, Value: "http://schemas.openxmlformats.org/markup-compatibility/2006"}
 )
 
 // Source relationship and namespace.
 const (
-	SourceRelationshipOfficeDocument             = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
-	SourceRelationshipChart                      = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"
-	SourceRelationshipComments                   = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments"
-	SourceRelationshipImage                      = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
-	SourceRelationshipTable                      = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table"
-	SourceRelationshipDrawingML                  = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing"
-	SourceRelationshipDrawingVML                 = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing"
-	SourceRelationshipHyperLink                  = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
-	SourceRelationshipWorkSheet                  = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
-	SourceRelationshipChartsheet                 = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet"
-	SourceRelationshipDialogsheet                = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/dialogsheet"
-	SourceRelationshipPivotTable                 = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable"
-	SourceRelationshipPivotCache                 = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition"
-	SourceRelationshipSharedStrings              = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"
-	SourceRelationshipVBAProject                 = "http://schemas.microsoft.com/office/2006/relationships/vbaProject"
-	NameSpaceXML                                 = "http://www.w3.org/XML/1998/namespace"
-	NameSpaceXMLSchemaInstance                   = "http://www.w3.org/2001/XMLSchema-instance"
-	StrictSourceRelationship                     = "http://purl.oclc.org/ooxml/officeDocument/relationships"
-	StrictSourceRelationshipOfficeDocument       = "http://purl.oclc.org/ooxml/officeDocument/relationships/officeDocument"
-	StrictSourceRelationshipChart                = "http://purl.oclc.org/ooxml/officeDocument/relationships/chart"
-	StrictSourceRelationshipComments             = "http://purl.oclc.org/ooxml/officeDocument/relationships/comments"
-	StrictSourceRelationshipImage                = "http://purl.oclc.org/ooxml/officeDocument/relationships/image"
-	StrictNameSpaceSpreadSheet                   = "http://purl.oclc.org/ooxml/spreadsheetml/main"
-	NameSpaceDublinCore                          = "http://purl.org/dc/elements/1.1/"
-	NameSpaceDublinCoreTerms                     = "http://purl.org/dc/terms/"
-	NameSpaceDublinCoreMetadataInitiative        = "http://purl.org/dc/dcmitype/"
+	ContentTypeAddinMacro                        = "application/vnd.ms-excel.addin.macroEnabled.main+xml"
 	ContentTypeDrawing                           = "application/vnd.openxmlformats-officedocument.drawing+xml"
 	ContentTypeDrawingML                         = "application/vnd.openxmlformats-officedocument.drawingml.chart+xml"
-	ContentTypeSheetML                           = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"
-	ContentTypeTemplate                          = "application/vnd.openxmlformats-officedocument.spreadsheetml.template.main+xml"
-	ContentTypeAddinMacro                        = "application/vnd.ms-excel.addin.macroEnabled.main+xml"
 	ContentTypeMacro                             = "application/vnd.ms-excel.sheet.macroEnabled.main+xml"
-	ContentTypeTemplateMacro                     = "application/vnd.ms-excel.template.macroEnabled.main+xml"
+	ContentTypeSheetML                           = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"
 	ContentTypeSpreadSheetMLChartsheet           = "application/vnd.openxmlformats-officedocument.spreadsheetml.chartsheet+xml"
 	ContentTypeSpreadSheetMLComments             = "application/vnd.openxmlformats-officedocument.spreadsheetml.comments+xml"
 	ContentTypeSpreadSheetMLPivotCacheDefinition = "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"
@@ -78,44 +50,73 @@ const (
 	ContentTypeSpreadSheetMLSharedStrings        = "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"
 	ContentTypeSpreadSheetMLTable                = "application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml"
 	ContentTypeSpreadSheetMLWorksheet            = "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"
+	ContentTypeTemplate                          = "application/vnd.openxmlformats-officedocument.spreadsheetml.template.main+xml"
+	ContentTypeTemplateMacro                     = "application/vnd.ms-excel.template.macroEnabled.main+xml"
 	ContentTypeVBA                               = "application/vnd.ms-office.vbaProject"
 	ContentTypeVML                               = "application/vnd.openxmlformats-officedocument.vmlDrawing"
+	NameSpaceDublinCore                          = "http://purl.org/dc/elements/1.1/"
+	NameSpaceDublinCoreMetadataInitiative        = "http://purl.org/dc/dcmitype/"
+	NameSpaceDublinCoreTerms                     = "http://purl.org/dc/terms/"
+	NameSpaceXML                                 = "http://www.w3.org/XML/1998/namespace"
+	NameSpaceXMLSchemaInstance                   = "http://www.w3.org/2001/XMLSchema-instance"
+	SourceRelationshipChart                      = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart"
+	SourceRelationshipChartsheet                 = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet"
+	SourceRelationshipComments                   = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments"
+	SourceRelationshipDialogsheet                = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/dialogsheet"
+	SourceRelationshipDrawingML                  = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing"
+	SourceRelationshipDrawingVML                 = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing"
+	SourceRelationshipHyperLink                  = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
+	SourceRelationshipImage                      = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
+	SourceRelationshipOfficeDocument             = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+	SourceRelationshipPivotCache                 = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition"
+	SourceRelationshipPivotTable                 = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable"
+	SourceRelationshipSharedStrings              = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"
+	SourceRelationshipTable                      = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table"
+	SourceRelationshipVBAProject                 = "http://schemas.microsoft.com/office/2006/relationships/vbaProject"
+	SourceRelationshipWorkSheet                  = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
+	StrictNameSpaceSpreadSheet                   = "http://purl.oclc.org/ooxml/spreadsheetml/main"
+	StrictSourceRelationship                     = "http://purl.oclc.org/ooxml/officeDocument/relationships"
+	StrictSourceRelationshipChart                = "http://purl.oclc.org/ooxml/officeDocument/relationships/chart"
+	StrictSourceRelationshipComments             = "http://purl.oclc.org/ooxml/officeDocument/relationships/comments"
+	StrictSourceRelationshipImage                = "http://purl.oclc.org/ooxml/officeDocument/relationships/image"
+	StrictSourceRelationshipOfficeDocument       = "http://purl.oclc.org/ooxml/officeDocument/relationships/officeDocument"
 	// ExtURIConditionalFormattings is the extLst child element
 	// ([ISO/IEC29500-1:2016] section 18.2.10) of the worksheet element
 	// ([ISO/IEC29500-1:2016] section 18.3.1.99) is extended by the addition of
 	// new child ext elements ([ISO/IEC29500-1:2016] section 18.2.7)
 	ExtURIConditionalFormattings = "{78C0D931-6437-407D-A8EE-F0AAD7539E65}"
 	ExtURIDataValidations        = "{CCE6A557-97BC-4B89-ADB6-D9C93CAAB3DF}"
-	ExtURISparklineGroups        = "{05C60535-1F16-4fd2-B633-F4F36F0B64E0}"
-	ExtURISlicerListX14          = "{A8765BA9-456A-4DAB-B4F3-ACF838C121DE}"
-	ExtURISlicerCachesListX14    = "{BBE1A952-AA13-448e-AADC-164F8A28A991}"
-	ExtURISlicerListX15          = "{3A4CF648-6AED-40f4-86FF-DC5316D8AED3}"
-	ExtURIProtectedRanges        = "{FC87AEE6-9EDD-4A0A-B7FB-166176984837}"
-	ExtURIIgnoredErrors          = "{01252117-D84E-4E92-8308-4BE1C098FCBB}"
-	ExtURIWebExtensions          = "{F7C9EE02-42E1-4005-9D12-6889AFFD525C}"
-	ExtURITimelineRefs           = "{7E03D99C-DC04-49d9-9315-930204A7B6E9}"
 	ExtURIDrawingBlip            = "{28A0092B-C50C-407E-A947-70E740481C1C}"
+	ExtURIIgnoredErrors          = "{01252117-D84E-4E92-8308-4BE1C098FCBB}"
 	ExtURIMacExcelMX             = "{64002731-A6B0-56B0-2670-7721B7C09600}"
+	ExtURIProtectedRanges        = "{FC87AEE6-9EDD-4A0A-B7FB-166176984837}"
+	ExtURISlicerCachesListX14    = "{BBE1A952-AA13-448e-AADC-164F8A28A991}"
+	ExtURISlicerListX14          = "{A8765BA9-456A-4DAB-B4F3-ACF838C121DE}"
+	ExtURISlicerListX15          = "{3A4CF648-6AED-40f4-86FF-DC5316D8AED3}"
+	ExtURISparklineGroups        = "{05C60535-1F16-4fd2-B633-F4F36F0B64E0}"
 	ExtURISVG                    = "{96DAC541-7B7A-43D3-8B79-37D633B846F1}"
+	ExtURITimelineRefs           = "{7E03D99C-DC04-49d9-9315-930204A7B6E9}"
+	ExtURIWebExtensions          = "{F7C9EE02-42E1-4005-9D12-6889AFFD525C}"
 )
 
 // Excel specifications and limits
 const (
-	UnzipSizeLimit       = 1000 << 24
-	StreamChunkSize      = 1 << 24
+	MaxCellStyles        = 64000
+	MaxColumns           = 16384
+	MaxColumnWidth       = 255
+	MaxFieldLength       = 255
+	MaxFilePathLength    = 207
 	MaxFontFamilyLength  = 31
 	MaxFontSize          = 409
-	MaxFilePathLength    = 207
-	MaxFieldLength       = 255
-	MaxColumnWidth       = 255
 	MaxRowHeight         = 409
-	MaxCellStyles        = 64000
-	MinFontSize          = 1
-	TotalRows            = 1048576
+	MaxSheetNameLength   = 31
 	MinColumns           = 1
-	MaxColumns           = 16384
-	TotalSheetHyperlinks = 65529
+	MinFontSize          = 1
+	StreamChunkSize      = 1 << 24
 	TotalCellChars       = 32767
+	TotalRows            = 1048576
+	TotalSheetHyperlinks = 65529
+	UnzipSizeLimit       = 1000 << 24
 	// pivotTableVersion should be greater than 3. One or more of the
 	// PivotTables chosen are created in a version of Excel earlier than
 	// Excel 2007 or in compatibility mode. Slicer can only be used with


### PR DESCRIPTION
# PR Details

Add the detection of invalid characters in the sheet name, and if it is invalid, it will report an error

## Description

Add the detection of invalid characters in the sheet name, and if it is invalid, it will report an error

## Related Issue

#1425 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

run test `TestAddChartSheetWithInvalidSheetName`
run test `TestNewSheet`
run test `TestSheetName `

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
