### PR TITLE
Fix panic formattedValue when style is negative

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -1319,7 +1319,7 @@ func (f *File) formattedValue(s int, v string, raw bool) (string, error) {
 	if styleSheet.CellXfs == nil {
 		return v, err
 	}
-	if s >= len(styleSheet.CellXfs.Xf) {
+	if s >= len(styleSheet.CellXfs.Xf) || s < 0 {
 		return v, err
 	}
 	var numFmtID int

--- a/cell_test.go
+++ b/cell_test.go
@@ -2,6 +2,7 @@ package excelize
 
 import (
 	"fmt"
+	_ "image/jpeg"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -10,8 +11,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	_ "image/jpeg"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -755,7 +754,13 @@ func TestFormattedValue(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "43528", result)
 
+	// S is too large
 	result, err = f.formattedValue(15, "43528", false)
+	assert.NoError(t, err)
+	assert.Equal(t, "43528", result)
+
+	// S is too small
+	result, err = f.formattedValue(-15, "43528", false)
 	assert.NoError(t, err)
 	assert.Equal(t, "43528", result)
 


### PR DESCRIPTION
Fix #1432

`formattedValue` can crash if `s` is negative, fixed and add UT.

# PR Details

Fix index out of range error (happened on a real file)

## Description

Check negative index in `formattedValue`

## Related Issue

#1432

## Motivation and Context

Library panic

## How Has This Been Tested
UT + verification against real document
## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
