### PR TITLE
supports directly read file byte data 

### DIFF
--- a/excelize.go
+++ b/excelize.go
@@ -113,6 +113,17 @@ func OpenFile(filename string, opts ...Options) (*File, error) {
 	return f, file.Close()
 }
 
+// OpenFileByte take the file byte data of an spreadsheet file and returns a populated
+// spreadsheet file struct for it.
+//
+func OpenFileByte(b []byte) (*File, error) {
+	f, err := OpenReader(bytes.NewReader(b))
+	if err != nil {
+		return f, err
+	}
+	return f, nil
+}
+
 // newFile is object builder
 func newFile() *File {
 	return &File{

--- a/excelize_test.go
+++ b/excelize_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	_ "embed"
 	"encoding/xml"
 	"fmt"
 	"image/color"
@@ -27,8 +28,23 @@ func TestOpenFile(t *testing.T) {
 	f, err := OpenFile(filepath.Join("test", "Book1.xlsx"))
 	assert.NoError(t, err)
 
+	testOpenFile(t, f)
+}
+
+//go:embed test/Book1.xlsx
+var bookExcel []byte
+
+func TestOpenFileByte(t *testing.T) {
+	// Test update the spreadsheet file
+	f, err := OpenFileByte(bookExcel)
+	assert.NoError(t, err)
+
+	testOpenFile(t, f)
+}
+
+func testOpenFile(t *testing.T, f *File) {
 	// Test get all the rows in a not exists worksheet
-	_, err = f.GetRows("Sheet4")
+	_, err := f.GetRows("Sheet4")
 	assert.EqualError(t, err, "sheet Sheet4 does not exist")
 	// Test get all the rows with invalid sheet name
 	_, err = f.GetRows("Sheet:1")


### PR DESCRIPTION
supports directly read file byte data and returns a populated spreadsheet file struct for it

## Motivation and Context

supports directly read file byte data,  make it convenient to use file by `go:embed`. for example:
<pre>
├── module
│   └── excel
│        ├── Book1.xlsx
│        └── excel.go
</pre>

excel.go read Book1.xlsx  can write like 

```go
//go:embed Book1.xlsx
var bookExcel []byte
f, err := excelize.OpenFileByte(bookExcel)
```

instead of

```go
f, err := excelize.OpenFile("module/excel/Book1.xlsx")
```
