### PR TITLE
Issue 1455 pre generate strings for months

### DIFF
--- a/numfmt.go
+++ b/numfmt.go
@@ -244,8 +244,12 @@ var (
 	monthNamesWelsh = []string{"Ionawr", "Chwefror", "Mawrth", "Ebrill", "Mai", "Mehefin", "Gorffennaf", "Awst", "Medi", "Hydref", "Tachwedd", "Rhagfyr"}
 	// monthNamesWolof list the month names in the Wolof.
 	monthNamesWolof = []string{"Samwiye", "Fewriye", "Maars", "Awril", "Me", "Suwe", "Sullet", "Ut", "Septàmbar", "Oktoobar", "Noowàmbar", "Desàmbar"}
+	// monthNamesWolofAbbr list the month name abbreviations in Wolof, this prevents string concatenation
+	monthNamesWolofAbbr = []string{"Sam.", "Few.", "Maa", "Awr.", "Me", "Suw", "Sul.", "Ut", "Sept.", "Okt.", "Now.", "Des."}
 	// monthNamesXhosa list the month names in the Xhosa.
-	monthNamesXhosa = []string{"Januwari", "Febuwari", "Matshi", "Aprili", "Meyi", "Juni", "Julayi", "Agasti", "Septemba", "Oktobha", "Novemba", "Disemba"}
+	monthNamesXhosa = []string{"uJanuwari", "uFebuwari", "uMatshi", "uAprili", "uMeyi", "uJuni", "uJulayi", "uAgasti", "uSeptemba", "uOktobha", "uNovemba", "uDisemba"}
+	// monthNamesXhosaAbbr list the mont abbreviations in the Xhosa, this prevents string concatenation
+	monthNamesXhosaAbbr = []string{"uJan.", "uFeb.", "uMat.", "uEpr.", "uMey.", "uJun.", "uJul.", "uAg.", "uSep.", "uOkt.", "uNov.", "uDis."}
 	// monthNamesYi list the month names in the Yi.
 	monthNamesYi = []string{"\ua2cd", "\ua44d", "\ua315", "\ua1d6", "\ua26c", "\ua0d8", "\ua3c3", "\ua246", "\ua22c", "\ua2b0", "\ua2b0\ua2aa", "\ua2b0\ua44b"}
 	// monthNamesZulu list the month names in the Zulu.
@@ -621,18 +625,7 @@ func localMonthsNameVietnamese(t time.Time, abbr int) string {
 // localMonthsNameWolof returns the Wolof name of the month.
 func localMonthsNameWolof(t time.Time, abbr int) string {
 	if abbr == 3 {
-		switch int(t.Month()) {
-		case 3, 6:
-			return string([]rune(monthNamesWolof[int(t.Month())-1])[:3])
-		case 5, 8:
-			return string([]rune(monthNamesWolof[int(t.Month())-1])[:2])
-		case 9:
-			return string([]rune(monthNamesWolof[int(t.Month())-1])[:4]) + "."
-		case 11:
-			return "Now."
-		default:
-			return string([]rune(monthNamesWolof[int(t.Month())-1])[:3]) + "."
-		}
+		return monthNamesWolofAbbr[int(t.Month())-1]
 	}
 	if abbr == 4 {
 		return monthNamesWolof[int(t.Month())-1]
@@ -643,17 +636,10 @@ func localMonthsNameWolof(t time.Time, abbr int) string {
 // localMonthsNameXhosa returns the Xhosa name of the month.
 func localMonthsNameXhosa(t time.Time, abbr int) string {
 	if abbr == 3 {
-		switch int(t.Month()) {
-		case 4:
-			return "uEpr."
-		case 8:
-			return "u" + string([]rune(monthNamesXhosa[int(t.Month())-1])[:2]) + "."
-		default:
-			return "u" + string([]rune(monthNamesXhosa[int(t.Month())-1])[:3]) + "."
-		}
+		return monthNamesXhosaAbbr[int(t.Month())-1]
 	}
 	if abbr == 4 {
-		return "u" + monthNamesXhosa[int(t.Month())-1]
+		return monthNamesXhosa[int(t.Month())-1]
 	}
 	return "u"
 }

--- a/numfmt.go
+++ b/numfmt.go
@@ -630,9 +630,7 @@ func localMonthsNameWolof(t time.Time, abbr int) string {
 	if abbr == 4 {
 		return monthNamesWolof[int(t.Month())-1]
 	}
-	//return string([]rune(monthNamesWolof[int(t.Month())-1])[:1])
 	return monthNamesWolof[int(t.Month())-1][:1]
-
 }
 
 // localMonthsNameXhosa returns the Xhosa name of the month.

--- a/numfmt.go
+++ b/numfmt.go
@@ -598,11 +598,11 @@ func localMonthsNameWelsh(t time.Time, abbr int) string {
 	if abbr == 3 {
 		switch int(t.Month()) {
 		case 2, 7:
-			return string([]rune(monthNamesWelsh[int(t.Month())-1])[:5])
+			return monthNamesWelsh[int(t.Month())-1][:5]
 		case 8, 9, 11, 12:
-			return string([]rune(monthNamesWelsh[int(t.Month())-1])[:4])
+			return monthNamesWelsh[int(t.Month())-1][:4]
 		default:
-			return string([]rune(monthNamesWelsh[int(t.Month())-1])[:3])
+			return monthNamesWelsh[int(t.Month())-1][:3]
 		}
 	}
 	if abbr == 4 {
@@ -630,7 +630,9 @@ func localMonthsNameWolof(t time.Time, abbr int) string {
 	if abbr == 4 {
 		return monthNamesWolof[int(t.Month())-1]
 	}
-	return string([]rune(monthNamesWolof[int(t.Month())-1])[:1])
+	//return string([]rune(monthNamesWolof[int(t.Month())-1])[:1])
+	return monthNamesWolof[int(t.Month())-1][:1]
+
 }
 
 // localMonthsNameXhosa returns the Xhosa name of the month.


### PR DESCRIPTION
On reviewing the code I was focussed on I figured I could add a couple of slices and then simplify some the code around getting month name abbreviations. At this point I thought I'd get some input, in case you want to go a different way? Or, if you like this approach if you want to implement for all languages I could go ahead and do that.

I have also removed some of the unnecessary `string([]rune(...` casts that were in place. Doing this prevents these tings from escaping to the heap

Either way, it seemed worth getting some feedback before going any further.

## Description

As an example of the proposed change I've introduced a couple of month abbreviation slices and shown how these could be used to simplify their corresponding functions. The existing tests already cover this code and continue to pass.

## Related Issue

[issue-1455](https://github.com/qax-os/excelize/issues/1455)

## Motivation and Context

This is an attempt to reduce the memory needed by these language functions that have string concatenation involved.

## How Has This Been Tested

The existing tests cover this code and they continue to pass. I do not think extra tests are needed here. Since adding these changes I can see, via `go build -gcflags="-m -l"`, that there is less that escapes to the heap.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
