### PR TITLE
1476: Support double-byte chars for LEFT(),RIGHT(), LEN() and MID().

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"unicode/utf8"
 	"unsafe"
 
 	"github.com/xuri/efp"
@@ -13446,11 +13447,11 @@ func (fn *formulaFuncs) leftRight(name string, argsList *list.List) formulaArg {
 		}
 		numChars = int(numArg.Number)
 	}
-	if len(text) > numChars {
+	if utf8.RuneCountInString(text) > numChars {
 		if name == "LEFT" || name == "LEFTB" {
-			return newStringFormulaArg(text[:numChars])
+			return newStringFormulaArg(string([]rune(text)[:numChars]))
 		}
-		return newStringFormulaArg(text[len(text)-numChars:])
+		return newStringFormulaArg(string([]rune(text)[utf8.RuneCountInString(text)-numChars:]))
 	}
 	return newStringFormulaArg(text)
 }
@@ -13463,7 +13464,7 @@ func (fn *formulaFuncs) LEN(argsList *list.List) formulaArg {
 	if argsList.Len() != 1 {
 		return newErrorFormulaArg(formulaErrorVALUE, "LEN requires 1 string argument")
 	}
-	return newStringFormulaArg(strconv.Itoa(len(argsList.Front().Value.(formulaArg).String)))
+	return newStringFormulaArg(strconv.Itoa(utf8.RuneCountInString(argsList.Front().Value.(formulaArg).String)))
 }
 
 // LENB returns the number of bytes used to represent the characters in a text
@@ -13529,7 +13530,7 @@ func (fn *formulaFuncs) mid(name string, argsList *list.List) formulaArg {
 	if startNum < 0 {
 		return newErrorFormulaArg(formulaErrorVALUE, formulaErrorVALUE)
 	}
-	textLen := len(text)
+	textLen := utf8.RuneCountInString(text)
 	if startNum > textLen {
 		return newStringFormulaArg("")
 	}

--- a/calc.go
+++ b/calc.go
@@ -13511,9 +13511,7 @@ func (fn *formulaFuncs) MIDB(argsList *list.List) formulaArg {
 	return fn.mid("MIDB", argsList)
 }
 
-// mid is an implementation of the formula functions MID and MIDB. TODO:
-// support DBCS include Japanese, Chinese (Simplified), Chinese
-// (Traditional), and Korean.
+// mid is an implementation of the formula functions MID and MIDB.
 func (fn *formulaFuncs) mid(name string, argsList *list.List) formulaArg {
 	if argsList.Len() != 3 {
 		return newErrorFormulaArg(formulaErrorVALUE, fmt.Sprintf("%s requires 3 arguments", name))

--- a/calc_test.go
+++ b/calc_test.go
@@ -1697,6 +1697,11 @@ func TestCalcCellValue(t *testing.T) {
 		"=LEFT(\"Original Text\",0)":  "",
 		"=LEFT(\"Original Text\",13)": "Original Text",
 		"=LEFT(\"Original Text\",20)": "Original Text",
+		"=LEFT(\"オリジナルテキスト\")":        "オ",
+		"=LEFT(\"オリジナルテキスト\",2)":      "オリ",
+		"=LEFT(\"オリジナルテキスト\",5)":      "オリジナル",
+		"=LEFT(\"オリジナルテキスト\",7)":      "オリジナルテキ",
+		"=LEFT(\"オリジナルテキスト\",20)":     "オリジナルテキスト",
 		// LEFTB
 		"=LEFTB(\"Original Text\")":    "O",
 		"=LEFTB(\"Original Text\",4)":  "Orig",
@@ -1751,6 +1756,11 @@ func TestCalcCellValue(t *testing.T) {
 		"=RIGHT(\"Original Text\",0)":  "",
 		"=RIGHT(\"Original Text\",13)": "Original Text",
 		"=RIGHT(\"Original Text\",20)": "Original Text",
+		"=RIGHT(\"オリジナルテキスト\")":        "ト",
+		"=RIGHT(\"オリジナルテキスト\",2)":      "スト",
+		"=RIGHT(\"オリジナルテキスト\",4)":      "テキスト",
+		"=RIGHT(\"オリジナルテキスト\",7)":      "ジナルテキスト",
+		"=RIGHT(\"オリジナルテキスト\",20)":     "オリジナルテキスト",
 		// RIGHTB
 		"=RIGHTB(\"Original Text\")":    "t",
 		"=RIGHTB(\"Original Text\",4)":  "Text",


### PR DESCRIPTION
# PR Details
Support double-byte characters support for string functions such as LEFT().

## Description
Added double bytes chars support by using utf counting.

## Related Issue
#1476 

## Motivation and Context
I was using Excel sheet that has Japanese names in it, but those formulas were not supported at the moment,

## How Has This Been Tested
Added testing

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
