### PR TITLE
Fixes #756 remove empty string when set cell value to nil in Stream W…

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -536,7 +536,7 @@ func (sw *StreamWriter) setCellValFunc(c *xlsxC, val interface{}) error {
 	case bool:
 		c.T, c.V = setCellBool(val)
 	case nil:
-		c.setCellValue("")
+		return err
 	case []RichTextRun:
 		c.T, c.IS = "inlineStr", &xlsxSI{}
 		c.IS.R, err = setRichText(val)


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Not setting empty string when set cell value to nil in Stream Writer
## Description

<!--- Describe your changes in detail -->
Not setting cell value to `c.setCellValue("")` (empty string) when  `setCellValFunc(c *xlsxC, val interface{})` val param accept `nil` value

## Related Issue

#756
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Excel that generated with Stream Writer can use excel function like `ISBLANK()`, `COUNTA()` etc.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
