### PR TITLE
#1448 Enhances the performance of checkCellInRangeRef and merging cells.

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -1408,41 +1408,41 @@ func (f *File) mergeCellsParser(ws *xlsxWorksheet, cell string) (string, error) 
 }
 
 func CellNameToCoordinatesCacheFunc(capacity int) func(string) (int, int, error) {
-  cache := make(map[string][2]int, capacity)
+	cache := make(map[string][2]int, capacity)
 
-  return func(cell string) (int, int, error) {
-    if pos, ok := cache[cell]; ok {
-      return pos[0], pos[1], nil
-    }
+	return func(cell string) (int, int, error) {
+		if pos, ok := cache[cell]; ok {
+			return pos[0], pos[1], nil
+		}
 
-    col, row, err := CellNameToCoordinates(cell)
-    if err != nil {
-      return 0, 0, err
-    }
+		col, row, err := CellNameToCoordinates(cell)
+		if err != nil {
+			return 0, 0, err
+		}
 
-    cache[cell] = [2]int{col, row}
-    return col, row, nil
-  }
+		cache[cell] = [2]int{col, row}
+		return col, row, nil
+	}
 }
 
 var CellNameToCoordinatesCache = CellNameToCoordinatesCacheFunc(1024)
 
 func rangeRefToCoordinatesCacheFunc(capacity int) func(string) ([]int, error) {
-  cache := make(map[string][]int, capacity)
+	cache := make(map[string][]int, capacity)
 
-  return func(rangeRef string) ([]int, error) {
-    if coords, ok := cache[rangeRef]; ok {
-      return coords, nil
-    }
+	return func(rangeRef string) ([]int, error) {
+		if coords, ok := cache[rangeRef]; ok {
+			return coords, nil
+		}
 
-    coords, err := rangeRefToCoordinates(rangeRef)
-    if err != nil {
-      return nil, err
-    }
+		coords, err := rangeRefToCoordinates(rangeRef)
+		if err != nil {
+			return nil, err
+		}
 
-    cache[rangeRef] = coords
-    return coords, nil
-  }
+		cache[rangeRef] = coords
+		return coords, nil
+	}
 }
 
 var rangeRefToCoordinatesCache = rangeRefToCoordinatesCacheFunc(1024)
@@ -1455,9 +1455,9 @@ func (f *File) checkCellInRangeRef(cell, rangeRef string) (bool, error) {
 		return false, err
 	}
 
-  if strings.Count(rangeRef, ":") != 1 {
-    return false, err
-  }
+	if strings.Count(rangeRef, ":") != 1 {
+		return false, err
+	}
 	coordinates, err := rangeRefToCoordinatesCache(rangeRef)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
# PR Details

Enhances the performance of checkCellInRangeRef and merging cells.

## Description

Enhances the performance of checkCellInRangeRef and merging cells.

## Related Issue

Slow Performance when there are lots of merge cells & calculations #1448

## Motivation and Context

Slow Performance when there are lots of merge cells & calculations #1448

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run `go test`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
