### PR TITLE
修复非小写扩展名导致的文件保存失败/添加背景图片失败等BUG

### DIFF
--- a/file.go
+++ b/file.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -73,7 +74,7 @@ func (f *File) SaveAs(name string, opts ...Options) error {
 		return ErrMaxFilePathLength
 	}
 	f.Path = name
-	if _, ok := supportedContentTypes[filepath.Ext(f.Path)]; !ok {
+	if _, ok := supportedContentTypes[strings.ToLower(filepath.Ext(f.Path))]; !ok {
 		return ErrWorkbookFileFormat
 	}
 	file, err := os.OpenFile(filepath.Clean(name), os.O_WRONLY|os.O_TRUNC|os.O_CREATE, os.ModePerm)
@@ -116,7 +117,7 @@ func (f *File) WriteTo(w io.Writer, opts ...Options) (int64, error) {
 		f.options = &opts[i]
 	}
 	if len(f.Path) != 0 {
-		contentType, ok := supportedContentTypes[filepath.Ext(f.Path)]
+		contentType, ok := supportedContentTypes[strings.ToLower(filepath.Ext(f.Path))]
 		if !ok {
 			return 0, ErrWorkbookFileFormat
 		}

--- a/picture.go
+++ b/picture.go
@@ -151,7 +151,7 @@ func (f *File) AddPicture(sheet, cell, name string, opts *GraphicOptions) error 
 	if _, err = os.Stat(name); os.IsNotExist(err) {
 		return err
 	}
-	ext, ok := supportedImageTypes[path.Ext(name)]
+	ext, ok := supportedImageTypes[strings.ToLower(path.Ext(name))]
 	if !ok {
 		return ErrImgExt
 	}
@@ -202,7 +202,7 @@ func (f *File) AddPicture(sheet, cell, name string, opts *GraphicOptions) error 
 func (f *File) AddPictureFromBytes(sheet, cell string, pic *Picture) error {
 	var drawingHyperlinkRID int
 	var hyperlinkType string
-	ext, ok := supportedImageTypes[pic.Extension]
+	ext, ok := supportedImageTypes[strings.ToLower(pic.Extension)]
 	if !ok {
 		return ErrImgExt
 	}
@@ -659,7 +659,7 @@ func (f *File) getPicture(row, col int, drawingXML, drawingRelationships string)
 		if err = nil; deTwoCellAnchor.From != nil && deTwoCellAnchor.Pic != nil {
 			if deTwoCellAnchor.From.Col == col && deTwoCellAnchor.From.Row == row {
 				drawRel = f.getDrawingRelationships(drawingRelationships, deTwoCellAnchor.Pic.BlipFill.Blip.Embed)
-				if _, ok = supportedImageTypes[filepath.Ext(drawRel.Target)]; ok {
+				if _, ok = supportedImageTypes[strings.ToLower(filepath.Ext(drawRel.Target))]; ok {
 					pic := Picture{Extension: filepath.Ext(drawRel.Target), Format: &GraphicOptions{}}
 					if buffer, _ := f.Pkg.Load(strings.ReplaceAll(drawRel.Target, "..", "xl")); buffer != nil {
 						pic.File = buffer.([]byte)
@@ -690,7 +690,7 @@ func (f *File) getPicturesFromWsDr(row, col int, drawingRelationships string, ws
 			if anchor.From.Col == col && anchor.From.Row == row {
 				if drawRel = f.getDrawingRelationships(drawingRelationships,
 					anchor.Pic.BlipFill.Blip.Embed); drawRel != nil {
-					if _, ok = supportedImageTypes[filepath.Ext(drawRel.Target)]; ok {
+					if _, ok = supportedImageTypes[strings.ToLower(filepath.Ext(drawRel.Target))]; ok {
 						pic := Picture{Extension: filepath.Ext(drawRel.Target), Format: &GraphicOptions{}}
 						if buffer, _ := f.Pkg.Load(strings.ReplaceAll(drawRel.Target, "..", "xl")); buffer != nil {
 							pic.File = buffer.([]byte)

--- a/sheet.go
+++ b/sheet.go
@@ -525,7 +525,7 @@ func (f *File) SetSheetBackgroundFromBytes(sheet, extension string, picture []by
 // setSheetBackground provides a function to set background picture by given
 // worksheet name, file name extension and image data.
 func (f *File) setSheetBackground(sheet, extension string, file []byte) error {
-	imageType, ok := supportedImageTypes[extension]
+	imageType, ok := supportedImageTypes[strings.ToLower(extension)]
 	if !ok {
 		return ErrImgExt
 	}


### PR DESCRIPTION
## Description
xmlDrawing.go文件中supportedImageTypes和supportedContentTypes两个字典变量的key限定为小写，但使用时未充分考虑大小写问题  
> 如file.go中SaveAs和WriteTo用到supportedContentTypes变量，未考虑扩展名大小写导致文件保存时若扩展名写成类似".XLxs"则保存/写入失败  
> picture.go/sheet.go用到supportedImageTypes变量，存在类似问题可能导致背景图片添加失败

## Related Issue
[ Make case-insensitive for the workbook extension name ](https://github.com/qax-os/excelize/issues/1503)

## Types of changes
- 修复非小写文件扩展名造成保存/写入文件失败的BUG
- 修复非小写图片扩展名造成添加背景图片失败的BUG