### PR TITLE
Fix corrupted utf-8 strings after trimming cell values

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -397,8 +397,9 @@ func (f *File) SetCellStr(sheet, cell, value string) error {
 // setCellString provides a function to set string type to shared string
 // table.
 func (f *File) setCellString(value string) (t, v string, err error) {
-	if len(value) > TotalCellChars {
-		value = string([]rune(value)[:TotalCellChars])
+	value_runes := []rune(value)
+	if len(value_runes) > TotalCellChars {
+		value = string(value_runes[:TotalCellChars])
 	}
 	t = "s"
 	var si int
@@ -458,8 +459,9 @@ func (f *File) setSharedString(val string) (int, error) {
 
 // trimCellValue provides a function to set string type to cell.
 func trimCellValue(value string) (v string, ns xml.Attr) {
-	if len(value) > TotalCellChars {
-		value = string([]rune(value)[:TotalCellChars])
+	value_runes := []rune(value)
+	if len(value_runes) > TotalCellChars {
+		value = string(value_runes[:TotalCellChars])
 	}
 	if len(value) > 0 {
 		prefix, suffix := value[0], value[len(value)-1]

--- a/cell.go
+++ b/cell.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // CellType is the type of cell value type.
@@ -397,9 +398,8 @@ func (f *File) SetCellStr(sheet, cell, value string) error {
 // setCellString provides a function to set string type to shared string
 // table.
 func (f *File) setCellString(value string) (t, v string, err error) {
-	value_runes := []rune(value)
-	if len(value_runes) > TotalCellChars {
-		value = string(value_runes[:TotalCellChars])
+	if utf8.RuneCountInString(value) > TotalCellChars {
+		value = string([]rune(value)[:TotalCellChars])
 	}
 	t = "s"
 	var si int
@@ -459,9 +459,8 @@ func (f *File) setSharedString(val string) (int, error) {
 
 // trimCellValue provides a function to set string type to cell.
 func trimCellValue(value string) (v string, ns xml.Attr) {
-	value_runes := []rune(value)
-	if len(value_runes) > TotalCellChars {
-		value = string(value_runes[:TotalCellChars])
+	if utf8.RuneCountInString(value) > TotalCellChars {
+		value = string([]rune(value)[:TotalCellChars])
 	}
 	if len(value) > 0 {
 		prefix, suffix := value[0], value[len(value)-1]

--- a/cell.go
+++ b/cell.go
@@ -398,7 +398,7 @@ func (f *File) SetCellStr(sheet, cell, value string) error {
 // table.
 func (f *File) setCellString(value string) (t, v string, err error) {
 	if len(value) > TotalCellChars {
-		value = value[:TotalCellChars]
+		value = string([]rune(value)[:TotalCellChars])
 	}
 	t = "s"
 	var si int
@@ -459,7 +459,7 @@ func (f *File) setSharedString(val string) (int, error) {
 // trimCellValue provides a function to set string type to cell.
 func trimCellValue(value string) (v string, ns xml.Attr) {
 	if len(value) > TotalCellChars {
-		value = value[:TotalCellChars]
+		value = string([]rune(value)[:TotalCellChars])
 	}
 	if len(value) > 0 {
 		prefix, suffix := value[0], value[len(value)-1]

--- a/cell_test.go
+++ b/cell_test.go
@@ -176,6 +176,18 @@ func TestSetCellFloat(t *testing.T) {
 	assert.EqualError(t, f.SetCellFloat("Sheet:1", "A1", 123.42, -1, 64), ErrSheetNameInvalid.Error())
 }
 
+func TestSetLongUtf8CellValues(t *testing.T) {
+	f := NewFile()
+	long_value := strings.Repeat("Ы", TotalCellChars+1)
+	err := f.SetCellValue("Sheet1", "A1", long_value)
+	assert.NoError(t, err)
+
+	v, err := f.GetCellValue("Sheet1", "A1")
+	assert.NoError(t, err)
+	assert.NotEqual(t, long_value, v)
+	assert.Equal(t, TotalCellChars, len([]rune(v)))
+}
+
 func TestSetCellValue(t *testing.T) {
 	f := NewFile()
 	assert.EqualError(t, f.SetCellValue("Sheet1", "A", time.Now().UTC()), newCellNameToCoordinatesError("A", newInvalidCellNameError("A")).Error())

--- a/cell_test.go
+++ b/cell_test.go
@@ -176,15 +176,16 @@ func TestSetCellFloat(t *testing.T) {
 	assert.EqualError(t, f.SetCellFloat("Sheet:1", "A1", 123.42, -1, 64), ErrSheetNameInvalid.Error())
 }
 
-func TestSetLongUtf8CellValues(t *testing.T) {
+func TestSetCellValuesMultiByte(t *testing.T) {
+	value := strings.Repeat("\u042B", TotalCellChars+1)
+
 	f := NewFile()
-	long_value := strings.Repeat("Ы", TotalCellChars+1)
-	err := f.SetCellValue("Sheet1", "A1", long_value)
+	err := f.SetCellValue("Sheet1", "A1", value)
 	assert.NoError(t, err)
 
 	v, err := f.GetCellValue("Sheet1", "A1")
 	assert.NoError(t, err)
-	assert.NotEqual(t, long_value, v)
+	assert.NotEqual(t, value, v)
 	assert.Equal(t, TotalCellChars, len([]rune(v)))
 }
 


### PR DESCRIPTION
Usage value[:TotalCellChars] is incorrect. If value contains utf-8 string it may corrupt the last symbol in value.

# PR Details

Bug fix of slicing strings in Go

## Description

Excel has upper limit of character count which is 32767, but excelize checks value length by bytes instead by characters.
If I put utf-8 value (repeated 17000 times two-bytes symbol "Ы", for example) to a cell, excelize won't show any error, but file will be corrupted. Excel will show error on this file. Mac Numbers doesn't show any error, but empty cell and half-empty file.

## Related Issue

[<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->](https://github.com/qax-os/excelize/issues/1518)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
