### PR TITLE
optimize all regexp calls

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -193,6 +193,24 @@ var (
 			return fmt.Sprintf("R[%d]C[%d]", row, col), nil
 		},
 	}
+	formularFormats = []*regexp.Regexp{
+		regexp.MustCompile(`^(\d+)$`),
+		regexp.MustCompile(`^=(.*)$`),
+		regexp.MustCompile(`^<>(.*)$`),
+		regexp.MustCompile(`^<=(.*)$`),
+		regexp.MustCompile(`^>=(.*)$`),
+		regexp.MustCompile(`^<(.*)$`),
+		regexp.MustCompile(`^>(.*)$`),
+	}
+	formularCriterias = []byte{
+		criteriaEq,
+		criteriaEq,
+		criteriaNe,
+		criteriaLe,
+		criteriaGe,
+		criteriaL,
+		criteriaG,
+	}
 )
 
 // calcContext defines the formula execution context.
@@ -1654,33 +1672,11 @@ func formulaCriteriaParser(exp string) (fc *formulaCriteria) {
 	if exp == "" {
 		return
 	}
-	if match := regexp.MustCompile(`^(\d+)$`).FindStringSubmatch(exp); len(match) > 1 {
-		fc.Type, fc.Condition = criteriaEq, match[1]
-		return
-	}
-	if match := regexp.MustCompile(`^=(.*)$`).FindStringSubmatch(exp); len(match) > 1 {
-		fc.Type, fc.Condition = criteriaEq, match[1]
-		return
-	}
-	if match := regexp.MustCompile(`^<>(.*)$`).FindStringSubmatch(exp); len(match) > 1 {
-		fc.Type, fc.Condition = criteriaNe, match[1]
-		return
-	}
-	if match := regexp.MustCompile(`^<=(.*)$`).FindStringSubmatch(exp); len(match) > 1 {
-		fc.Type, fc.Condition = criteriaLe, match[1]
-		return
-	}
-	if match := regexp.MustCompile(`^>=(.*)$`).FindStringSubmatch(exp); len(match) > 1 {
-		fc.Type, fc.Condition = criteriaGe, match[1]
-		return
-	}
-	if match := regexp.MustCompile(`^<(.*)$`).FindStringSubmatch(exp); len(match) > 1 {
-		fc.Type, fc.Condition = criteriaL, match[1]
-		return
-	}
-	if match := regexp.MustCompile(`^>(.*)$`).FindStringSubmatch(exp); len(match) > 1 {
-		fc.Type, fc.Condition = criteriaG, match[1]
-		return
+	for i, re := range formularFormats {
+		if match := re.FindStringSubmatch(exp); len(match) > 1 {
+			fc.Type, fc.Condition = formularCriterias[i], match[1]
+			return
+		}
 	}
 	if strings.Contains(exp, "?") {
 		exp = strings.ReplaceAll(exp, "?", ".")

--- a/sheet.go
+++ b/sheet.go
@@ -977,6 +977,7 @@ func (f *File) searchSheet(name, value string, regSearch bool) (result []string,
 	if sst, err = f.sharedStringsReader(); err != nil {
 		return
 	}
+	regex := regexp.MustCompile(value)
 	decoder := f.xmlNewDecoder(bytes.NewReader(f.readBytes(name)))
 	for {
 		var token xml.Token
@@ -1001,7 +1002,6 @@ func (f *File) searchSheet(name, value string, regSearch bool) (result []string,
 				_ = decoder.DecodeElement(&colCell, &xmlElement)
 				val, _ := colCell.getValueFrom(f, sst, false)
 				if regSearch {
-					regex := regexp.MustCompile(value)
 					if !regex.MatchString(val) {
 						continue
 					}


### PR DESCRIPTION
# PR Details

This PR is optimizing all regexp calls to improve overall performance.

## Description

In one of my projects, I saw quite many regexp in allocs and heap from pprof data. I checked the code and see there are many places calling `regexp.MustCompile` in sub-functions or for loop. This caused quite many resource usage and should be avoid. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Solve the performance problem.

## How Has This Been Tested

Tested locally and all test cases are **PASS**.
```
Running tool: /usr/local/opt/go/libexec/bin/go test -timeout 6000s -coverprofile=/var/folders/08/y7_js76j22s0q5xtbmy4_v_w0000gq/T/vscode-go3BXe22/go-code-cover github.com/xuri/excelize/v2 -v -count=1

=== RUN   TestAdjustMergeCells
--- PASS: TestAdjustMergeCells (0.00s)
=== RUN   TestAdjustAutoFilter
--- PASS: TestAdjustAutoFilter (0.00s)
=== RUN   TestAdjustTable
--- PASS: TestAdjustTable (0.01s)
=== RUN   TestAdjustHelper
--- PASS: TestAdjustHelper (0.00s)
=== RUN   TestAdjustCalcChain
--- PASS: TestAdjustCalcChain (0.00s)
=== RUN   TestAdjustCols
--- PASS: TestAdjustCols (0.01s)
=== RUN   TestCalcCellValue
--- PASS: TestCalcCellValue (24.97s)
=== RUN   TestCalcWithDefinedName
--- PASS: TestCalcWithDefinedName (0.00s)
=== RUN   TestCalcISBLANK
--- PASS: TestCalcISBLANK (0.00s)
=== RUN   TestCalcAND
--- PASS: TestCalcAND (0.00s)
=== RUN   TestCalcOR
--- PASS: TestCalcOR (0.00s)
=== RUN   TestCalcDet
--- PASS: TestCalcDet (0.00s)
=== RUN   TestCalcToBool
--- PASS: TestCalcToBool (0.00s)
=== RUN   TestCalcToList
--- PASS: TestCalcToList (0.00s)
=== RUN   TestCalcCompareFormulaArg
--- PASS: TestCalcCompareFormulaArg (0.00s)
=== RUN   TestCalcMatchPattern
--- PASS: TestCalcMatchPattern (0.00s)
=== RUN   TestCalcTRANSPOSE
--- PASS: TestCalcTRANSPOSE (0.00s)
=== RUN   TestCalcVLOOKUP
--- PASS: TestCalcVLOOKUP (0.00s)
=== RUN   TestCalcBoolean
--- PASS: TestCalcBoolean (0.00s)
=== RUN   TestCalcMAXMIN
--- PASS: TestCalcMAXMIN (0.00s)
=== RUN   TestCalcAVERAGEIF
--- PASS: TestCalcAVERAGEIF (0.00s)
=== RUN   TestCalcCOVAR
--- PASS: TestCalcCOVAR (0.00s)
=== RUN   TestCalcDatabase
--- PASS: TestCalcDatabase (0.01s)
=== RUN   TestCalcFORMULATEXT
--- PASS: TestCalcFORMULATEXT (1.57s)
=== RUN   TestCalcGROWTHandTREND
--- PASS: TestCalcGROWTHandTREND (0.00s)
=== RUN   TestCalcHLOOKUP
--- PASS: TestCalcHLOOKUP (0.00s)
=== RUN   TestCalcCHITESTandCHISQdotTEST
--- PASS: TestCalcCHITESTandCHISQdotTEST (0.00s)
=== RUN   TestCalcFTEST
--- PASS: TestCalcFTEST (0.00s)
=== RUN   TestCalcIRR
--- PASS: TestCalcIRR (0.00s)
=== RUN   TestCalcMAXMINIFS
--- PASS: TestCalcMAXMINIFS (0.00s)
=== RUN   TestCalcMIRR
--- PASS: TestCalcMIRR (0.00s)
=== RUN   TestCalcSUMIFSAndAVERAGEIFS
--- PASS: TestCalcSUMIFSAndAVERAGEIFS (0.00s)
=== RUN   TestCalcXIRR
--- PASS: TestCalcXIRR (0.00s)
=== RUN   TestCalcXLOOKUP
--- PASS: TestCalcXLOOKUP (0.01s)
=== RUN   TestCalcXNPV
--- PASS: TestCalcXNPV (0.00s)
=== RUN   TestCalcMATCH
--- PASS: TestCalcMATCH (0.00s)
=== RUN   TestCalcISFORMULA
--- PASS: TestCalcISFORMULA (0.00s)
=== RUN   TestCalcMODE
--- PASS: TestCalcMODE (0.00s)
=== RUN   TestCalcPEARSON
--- PASS: TestCalcPEARSON (0.00s)
=== RUN   TestCalcRSQ
--- PASS: TestCalcRSQ (0.00s)
=== RUN   TestCalcSLOP
--- PASS: TestCalcSLOP (0.00s)
=== RUN   TestCalcSHEET
--- PASS: TestCalcSHEET (0.00s)
=== RUN   TestCalcSHEETS
--- PASS: TestCalcSHEETS (0.00s)
=== RUN   TestCalcSTEY
--- PASS: TestCalcSTEY (0.00s)
=== RUN   TestCalcTTEST
--- PASS: TestCalcTTEST (0.00s)
=== RUN   TestCalcNETWORKDAYSandWORKDAY
--- PASS: TestCalcNETWORKDAYSandWORKDAY (0.01s)
=== RUN   TestCalcZTEST
--- PASS: TestCalcZTEST (0.00s)
=== RUN   TestStrToDate
--- PASS: TestStrToDate (0.00s)
=== RUN   TestGetYearDays
--- PASS: TestGetYearDays (0.00s)
=== RUN   TestCalcGetBetaHelperContFrac
--- PASS: TestCalcGetBetaHelperContFrac (0.00s)
=== RUN   TestCalcGetBetaDistPDF
--- PASS: TestCalcGetBetaDistPDF (0.00s)
=== RUN   TestCalcD1mach
--- PASS: TestCalcD1mach (0.00s)
=== RUN   TestCalcChebyshevInit
--- PASS: TestCalcChebyshevInit (0.00s)
=== RUN   TestCalcChebyshevEval
--- PASS: TestCalcChebyshevEval (0.00s)
=== RUN   TestCalcLgammacor
--- PASS: TestCalcLgammacor (0.00s)
=== RUN   TestCalcLgammaerr
--- PASS: TestCalcLgammaerr (0.00s)
=== RUN   TestCalcLogBeta
--- PASS: TestCalcLogBeta (0.00s)
=== RUN   TestCalcBetainvProbIterator
--- PASS: TestCalcBetainvProbIterator (0.00s)
=== RUN   TestNestedFunctionsWithOperators
--- PASS: TestNestedFunctionsWithOperators (0.00s)
=== RUN   TestFormulaArgToToken
--- PASS: TestFormulaArgToToken (0.00s)
=== RUN   TestPrepareTrendGrowth
--- PASS: TestPrepareTrendGrowth (0.00s)
=== RUN   TestCalcColRowQRDecomposition
--- PASS: TestCalcColRowQRDecomposition (0.00s)
=== RUN   TestCalcCellResolver
--- PASS: TestCalcCellResolver (0.00s)
=== RUN   TestCalcChainReader
--- PASS: TestCalcChainReader (0.00s)
=== RUN   TestDeleteCalcChain
--- PASS: TestDeleteCalcChain (0.00s)
=== RUN   TestConcurrency
--- PASS: TestConcurrency (0.06s)
=== RUN   TestCheckCellInRangeRef
--- PASS: TestCheckCellInRangeRef (0.00s)
=== RUN   TestSetCellFloat
=== RUN   TestSetCellFloat/with_no_decimal
=== RUN   TestSetCellFloat/with_a_decimal_and_precision_limit
=== RUN   TestSetCellFloat/with_a_decimal_and_no_limit
--- PASS: TestSetCellFloat (0.00s)
    --- PASS: TestSetCellFloat/with_no_decimal (0.00s)
    --- PASS: TestSetCellFloat/with_a_decimal_and_precision_limit (0.00s)
    --- PASS: TestSetCellFloat/with_a_decimal_and_no_limit (0.00s)
=== RUN   TestSetCellValuesMultiByte
--- PASS: TestSetCellValuesMultiByte (0.03s)
=== RUN   TestSetCellValue
--- PASS: TestSetCellValue (0.00s)
=== RUN   TestSetCellValues
--- PASS: TestSetCellValues (0.00s)
=== RUN   TestSetCellBool
--- PASS: TestSetCellBool (0.00s)
=== RUN   TestSetCellTime
--- PASS: TestSetCellTime (0.00s)
=== RUN   TestGetCellValue
--- PASS: TestGetCellValue (0.00s)
=== RUN   TestGetCellType
--- PASS: TestGetCellType (0.00s)
=== RUN   TestGetValueFrom
--- PASS: TestGetValueFrom (0.00s)
=== RUN   TestGetCellFormula
--- PASS: TestGetCellFormula (0.00s)
=== RUN   TestOverflowNumericCell
--- PASS: TestOverflowNumericCell (0.00s)
=== RUN   TestSetCellFormula
--- PASS: TestSetCellFormula (0.02s)
=== RUN   TestGetCellRichText
--- PASS: TestGetCellRichText (0.00s)
=== RUN   TestSetCellRichText
--- PASS: TestSetCellRichText (0.00s)
=== RUN   TestFormattedValue
--- PASS: TestFormattedValue (0.00s)
=== RUN   TestFormattedValueNilXfs
--- PASS: TestFormattedValueNilXfs (0.00s)
=== RUN   TestFormattedValueNilNumFmts
--- PASS: TestFormattedValueNilNumFmts (0.00s)
=== RUN   TestFormattedValueNilWorkbook
--- PASS: TestFormattedValueNilWorkbook (0.00s)
=== RUN   TestFormattedValueNilWorkbookPr
--- PASS: TestFormattedValueNilWorkbookPr (0.00s)
=== RUN   TestSharedStringsError
--- PASS: TestSharedStringsError (0.04s)
=== RUN   TestSIString
--- PASS: TestSIString (0.00s)
=== RUN   TestChartSize
--- PASS: TestChartSize (0.01s)
=== RUN   TestAddDrawingChart
--- PASS: TestAddDrawingChart (0.00s)
=== RUN   TestAddSheetDrawingChart
--- PASS: TestAddSheetDrawingChart (0.00s)
=== RUN   TestDeleteDrawing
--- PASS: TestDeleteDrawing (0.00s)
=== RUN   TestAddChart
--- PASS: TestAddChart (0.05s)
=== RUN   TestAddChartSheet
--- PASS: TestAddChartSheet (0.00s)
=== RUN   TestDeleteChart
--- PASS: TestDeleteChart (0.01s)
=== RUN   TestChartWithLogarithmicBase
--- PASS: TestChartWithLogarithmicBase (0.01s)
=== RUN   TestCols
--- PASS: TestCols (0.01s)
=== RUN   TestColumnsIterator
--- PASS: TestColumnsIterator (0.00s)
=== RUN   TestColsError
--- PASS: TestColsError (0.00s)
=== RUN   TestGetColsError
--- PASS: TestGetColsError (0.00s)
=== RUN   TestColsRows
--- PASS: TestColsRows (0.00s)
=== RUN   TestColumnVisibility
=== RUN   TestColumnVisibility/TestBook1
=== RUN   TestColumnVisibility/TestBook3
--- PASS: TestColumnVisibility (0.01s)
    --- PASS: TestColumnVisibility/TestBook1 (0.01s)
    --- PASS: TestColumnVisibility/TestBook3 (0.00s)
=== RUN   TestOutlineLevel
--- PASS: TestOutlineLevel (0.00s)
=== RUN   TestSetColStyle
--- PASS: TestSetColStyle (0.00s)
=== RUN   TestColWidth
--- PASS: TestColWidth (0.00s)
=== RUN   TestGetColStyle
--- PASS: TestGetColStyle (0.00s)
=== RUN   TestInsertCols
--- PASS: TestInsertCols (0.00s)
=== RUN   TestRemoveCol
--- PASS: TestRemoveCol (0.00s)
=== RUN   TestConvertColWidthToPixels
--- PASS: TestConvertColWidthToPixels (0.00s)
=== RUN   TestAddComment
--- PASS: TestAddComment (0.01s)
=== RUN   TestDeleteComment
--- PASS: TestDeleteComment (0.00s)
=== RUN   TestDecodeVMLDrawingReader
--- PASS: TestDecodeVMLDrawingReader (0.00s)
=== RUN   TestCommentsReader
--- PASS: TestCommentsReader (0.00s)
=== RUN   TestCountComments
--- PASS: TestCountComments (0.00s)
=== RUN   TestEncrypt
--- PASS: TestEncrypt (0.31s)
=== RUN   TestEncryptionMechanism
--- PASS: TestEncryptionMechanism (0.00s)
=== RUN   TestHashing
--- PASS: TestHashing (0.00s)
=== RUN   TestGenISOPasswdHash
--- PASS: TestGenISOPasswdHash (0.48s)
=== RUN   TestDataValidation
--- PASS: TestDataValidation (0.01s)
=== RUN   TestDataValidationError
--- PASS: TestDataValidationError (0.00s)
=== RUN   TestDeleteDataValidation
--- PASS: TestDeleteDataValidation (0.00s)
=== RUN   TestTimeToExcelTime
=== RUN   TestTimeToExcelTime/TestData1
=== RUN   TestTimeToExcelTime/TestData2
=== RUN   TestTimeToExcelTime/TestData3
=== RUN   TestTimeToExcelTime/TestData4
=== RUN   TestTimeToExcelTime/TestData5
=== RUN   TestTimeToExcelTime/TestData6
=== RUN   TestTimeToExcelTime/TestData7
=== RUN   TestTimeToExcelTime/TestData8
=== RUN   TestTimeToExcelTime/TestData9
=== RUN   TestTimeToExcelTime/TestData10
--- PASS: TestTimeToExcelTime (0.00s)
    --- PASS: TestTimeToExcelTime/TestData1 (0.00s)
    --- PASS: TestTimeToExcelTime/TestData2 (0.00s)
    --- PASS: TestTimeToExcelTime/TestData3 (0.00s)
    --- PASS: TestTimeToExcelTime/TestData4 (0.00s)
    --- PASS: TestTimeToExcelTime/TestData5 (0.00s)
    --- PASS: TestTimeToExcelTime/TestData6 (0.00s)
    --- PASS: TestTimeToExcelTime/TestData7 (0.00s)
    --- PASS: TestTimeToExcelTime/TestData8 (0.00s)
    --- PASS: TestTimeToExcelTime/TestData9 (0.00s)
    --- PASS: TestTimeToExcelTime/TestData10 (0.00s)
=== RUN   TestTimeToExcelTime_Timezone
=== RUN   TestTimeToExcelTime_Timezone/TestData1
=== RUN   TestTimeToExcelTime_Timezone/TestData2
=== RUN   TestTimeToExcelTime_Timezone/TestData3
=== RUN   TestTimeToExcelTime_Timezone/TestData4
=== RUN   TestTimeToExcelTime_Timezone/TestData5
=== RUN   TestTimeToExcelTime_Timezone/TestData6
=== RUN   TestTimeToExcelTime_Timezone/TestData7
=== RUN   TestTimeToExcelTime_Timezone/TestData8
=== RUN   TestTimeToExcelTime_Timezone/TestData9
=== RUN   TestTimeToExcelTime_Timezone/TestData10
--- PASS: TestTimeToExcelTime_Timezone (0.00s)
    --- PASS: TestTimeToExcelTime_Timezone/TestData1 (0.00s)
    --- PASS: TestTimeToExcelTime_Timezone/TestData2 (0.00s)
    --- PASS: TestTimeToExcelTime_Timezone/TestData3 (0.00s)
    --- PASS: TestTimeToExcelTime_Timezone/TestData4 (0.00s)
    --- PASS: TestTimeToExcelTime_Timezone/TestData5 (0.00s)
    --- PASS: TestTimeToExcelTime_Timezone/TestData6 (0.00s)
    --- PASS: TestTimeToExcelTime_Timezone/TestData7 (0.00s)
    --- PASS: TestTimeToExcelTime_Timezone/TestData8 (0.00s)
    --- PASS: TestTimeToExcelTime_Timezone/TestData9 (0.00s)
    --- PASS: TestTimeToExcelTime_Timezone/TestData10 (0.00s)
=== RUN   TestTimeFromExcelTime
=== RUN   TestTimeFromExcelTime/TestData1
=== RUN   TestTimeFromExcelTime/TestData2
=== RUN   TestTimeFromExcelTime/TestData3
=== RUN   TestTimeFromExcelTime/TestData4
=== RUN   TestTimeFromExcelTime/TestData5
=== RUN   TestTimeFromExcelTime/TestData6
--- PASS: TestTimeFromExcelTime (0.20s)
    --- PASS: TestTimeFromExcelTime/TestData1 (0.00s)
    --- PASS: TestTimeFromExcelTime/TestData2 (0.00s)
    --- PASS: TestTimeFromExcelTime/TestData3 (0.00s)
    --- PASS: TestTimeFromExcelTime/TestData4 (0.00s)
    --- PASS: TestTimeFromExcelTime/TestData5 (0.00s)
    --- PASS: TestTimeFromExcelTime/TestData6 (0.00s)
=== RUN   TestTimeFromExcelTime_1904
--- PASS: TestTimeFromExcelTime_1904 (0.00s)
=== RUN   TestExcelDateToTime
=== RUN   TestExcelDateToTime/TestData1
=== RUN   TestExcelDateToTime/TestData2
=== RUN   TestExcelDateToTime/TestData3
=== RUN   TestExcelDateToTime/TestData4
=== RUN   TestExcelDateToTime/TestData5
=== RUN   TestExcelDateToTime/TestData6
--- PASS: TestExcelDateToTime (0.00s)
    --- PASS: TestExcelDateToTime/TestData1 (0.00s)
    --- PASS: TestExcelDateToTime/TestData2 (0.00s)
    --- PASS: TestExcelDateToTime/TestData3 (0.00s)
    --- PASS: TestExcelDateToTime/TestData4 (0.00s)
    --- PASS: TestExcelDateToTime/TestData5 (0.00s)
    --- PASS: TestExcelDateToTime/TestData6 (0.00s)
=== RUN   TestSetAppProps
--- PASS: TestSetAppProps (0.01s)
=== RUN   TestGetAppProps
--- PASS: TestGetAppProps (0.00s)
=== RUN   TestSetDocProps
--- PASS: TestSetDocProps (0.01s)
=== RUN   TestGetDocProps
--- PASS: TestGetDocProps (0.00s)
=== RUN   TestDrawingParser
--- PASS: TestDrawingParser (0.00s)
=== RUN   TestNewInvalidColNameError
--- PASS: TestNewInvalidColNameError (0.00s)
=== RUN   TestNewInvalidRowNumberError
--- PASS: TestNewInvalidRowNumberError (0.00s)
=== RUN   TestNewInvalidCellNameError
--- PASS: TestNewInvalidCellNameError (0.00s)
=== RUN   TestNewInvalidExcelDateError
--- PASS: TestNewInvalidExcelDateError (0.00s)
=== RUN   TestOpenFile
--- PASS: TestOpenFile (0.01s)
=== RUN   TestSaveFile
--- PASS: TestSaveFile (0.02s)
=== RUN   TestSaveAsWrongPath
--- PASS: TestSaveAsWrongPath (0.00s)
=== RUN   TestCharsetTranscoder
--- PASS: TestCharsetTranscoder (0.00s)
=== RUN   TestOpenReader
--- PASS: TestOpenReader (0.15s)
=== RUN   TestBrokenFile
=== RUN   TestBrokenFile/SaveWithoutName
=== RUN   TestBrokenFile/SaveAsEmptyStruct
=== RUN   TestBrokenFile/OpenBadWorkbook
=== RUN   TestBrokenFile/OpenNotExistsFile
--- PASS: TestBrokenFile (0.00s)
    --- PASS: TestBrokenFile/SaveWithoutName (0.00s)
    --- PASS: TestBrokenFile/SaveAsEmptyStruct (0.00s)
    --- PASS: TestBrokenFile/OpenBadWorkbook (0.00s)
    --- PASS: TestBrokenFile/OpenNotExistsFile (0.00s)
=== RUN   TestNewFile
--- PASS: TestNewFile (0.01s)
=== RUN   TestAddDrawingVML
--- PASS: TestAddDrawingVML (0.00s)
=== RUN   TestSetCellHyperLink
--- PASS: TestSetCellHyperLink (0.01s)
=== RUN   TestGetCellHyperLink
--- PASS: TestGetCellHyperLink (0.00s)
=== RUN   TestSetSheetBackground
--- PASS: TestSetSheetBackground (0.01s)
=== RUN   TestSetSheetBackgroundErrors
--- PASS: TestSetSheetBackgroundErrors (0.00s)
=== RUN   TestWriteArrayFormula
--- PASS: TestWriteArrayFormula (0.00s)
=== RUN   TestSetCellStyleAlignment
--- PASS: TestSetCellStyleAlignment (0.01s)
=== RUN   TestSetCellStyleBorder
--- PASS: TestSetCellStyleBorder (0.01s)
=== RUN   TestSetCellStyleBorderErrors
--- PASS: TestSetCellStyleBorderErrors (0.00s)
=== RUN   TestSetCellStyleNumberFormat
--- PASS: TestSetCellStyleNumberFormat (0.01s)
=== RUN   TestSetCellStyleCurrencyNumberFormat
=== RUN   TestSetCellStyleCurrencyNumberFormat/TestBook3
=== RUN   TestSetCellStyleCurrencyNumberFormat/TestBook4
--- PASS: TestSetCellStyleCurrencyNumberFormat (0.01s)
    --- PASS: TestSetCellStyleCurrencyNumberFormat/TestBook3 (0.00s)
    --- PASS: TestSetCellStyleCurrencyNumberFormat/TestBook4 (0.00s)
=== RUN   TestSetCellStyleCustomNumberFormat
--- PASS: TestSetCellStyleCustomNumberFormat (0.00s)
=== RUN   TestSetCellStyleFill
--- PASS: TestSetCellStyleFill (0.01s)
=== RUN   TestSetCellStyleFont
--- PASS: TestSetCellStyleFont (0.01s)
=== RUN   TestSetCellStyleProtection
--- PASS: TestSetCellStyleProtection (0.01s)
=== RUN   TestSetDeleteSheet
=== RUN   TestSetDeleteSheet/TestBook3
=== RUN   TestSetDeleteSheet/TestBook4
--- PASS: TestSetDeleteSheet (0.01s)
    --- PASS: TestSetDeleteSheet/TestBook3 (0.00s)
    --- PASS: TestSetDeleteSheet/TestBook4 (0.00s)
=== RUN   TestSheetVisibility
--- PASS: TestSheetVisibility (0.01s)
=== RUN   TestCopySheet
--- PASS: TestCopySheet (0.01s)
=== RUN   TestCopySheetError
--- PASS: TestCopySheetError (0.02s)
=== RUN   TestGetSheetComments
--- PASS: TestGetSheetComments (0.00s)
=== RUN   TestGetActiveSheetIndex
--- PASS: TestGetActiveSheetIndex (0.00s)
=== RUN   TestRelsWriter
--- PASS: TestRelsWriter (0.00s)
=== RUN   TestConditionalFormat
--- PASS: TestConditionalFormat (0.01s)
=== RUN   TestSharedStrings
--- PASS: TestSharedStrings (0.00s)
=== RUN   TestSetSheetCol
--- PASS: TestSetSheetCol (0.01s)
=== RUN   TestSetSheetRow
--- PASS: TestSetSheetRow (0.01s)
=== RUN   TestHSL
--- PASS: TestHSL (0.00s)
=== RUN   TestProtectSheet
--- PASS: TestProtectSheet (0.33s)
=== RUN   TestUnprotectSheet
--- PASS: TestUnprotectSheet (0.10s)
=== RUN   TestProtectWorkbook
--- PASS: TestProtectWorkbook (0.09s)
=== RUN   TestUnprotectWorkbook
--- PASS: TestUnprotectWorkbook (0.34s)
=== RUN   TestSetDefaultTimeStyle
--- PASS: TestSetDefaultTimeStyle (0.00s)
=== RUN   TestAddVBAProject
--- PASS: TestAddVBAProject (0.00s)
=== RUN   TestContentTypesReader
--- PASS: TestContentTypesReader (0.00s)
=== RUN   TestWorkbookReader
--- PASS: TestWorkbookReader (0.00s)
=== RUN   TestWorkSheetReader
--- PASS: TestWorkSheetReader (0.00s)
=== RUN   TestRelsReader
--- PASS: TestRelsReader (0.00s)
=== RUN   TestDeleteSheetFromWorkbookRels
--- PASS: TestDeleteSheetFromWorkbookRels (0.00s)
=== RUN   TestUpdateLinkedValue
--- PASS: TestUpdateLinkedValue (0.00s)
=== RUN   TestAttrValToInt
--- PASS: TestAttrValToInt (0.00s)
=== RUN   TestWriteTo
--- PASS: TestWriteTo (0.00s)
=== RUN   TestClose
--- PASS: TestClose (0.00s)
=== RUN   TestColumnNameToNumber_OK
--- PASS: TestColumnNameToNumber_OK (0.00s)
=== RUN   TestColumnNameToNumber_Error
--- PASS: TestColumnNameToNumber_Error (0.00s)
=== RUN   TestColumnNumberToName_OK
--- PASS: TestColumnNumberToName_OK (0.00s)
=== RUN   TestColumnNumberToName_Error
--- PASS: TestColumnNumberToName_Error (0.00s)
=== RUN   TestSplitCellName_OK
--- PASS: TestSplitCellName_OK (0.00s)
=== RUN   TestSplitCellName_Error
--- PASS: TestSplitCellName_Error (0.00s)
=== RUN   TestJoinCellName_OK
--- PASS: TestJoinCellName_OK (0.00s)
=== RUN   TestJoinCellName_Error
--- PASS: TestJoinCellName_Error (0.00s)
=== RUN   TestCellNameToCoordinates_OK
--- PASS: TestCellNameToCoordinates_OK (0.00s)
=== RUN   TestCellNameToCoordinates_Error
--- PASS: TestCellNameToCoordinates_Error (0.00s)
=== RUN   TestCoordinatesToCellName_OK
--- PASS: TestCoordinatesToCellName_OK (0.00s)
=== RUN   TestCoordinatesToCellName_Error
--- PASS: TestCoordinatesToCellName_Error (0.00s)
=== RUN   TestCoordinatesToRangeRef
--- PASS: TestCoordinatesToRangeRef (0.00s)
=== RUN   TestSortCoordinates
--- PASS: TestSortCoordinates (0.00s)
=== RUN   TestInStrSlice
--- PASS: TestInStrSlice (0.00s)
=== RUN   TestBoolValMarshal
--- PASS: TestBoolValMarshal (0.00s)
=== RUN   TestBoolValUnmarshalXML
--- PASS: TestBoolValUnmarshalXML (0.00s)
=== RUN   TestBytesReplace
--- PASS: TestBytesReplace (0.00s)
=== RUN   TestGetRootElement
--- PASS: TestGetRootElement (0.00s)
=== RUN   TestSetIgnorableNameSpace
--- PASS: TestSetIgnorableNameSpace (0.00s)
=== RUN   TestStack
--- PASS: TestStack (0.00s)
=== RUN   TestGenXMLNamespace
--- PASS: TestGenXMLNamespace (0.00s)
=== RUN   TestBstrUnmarshal
--- PASS: TestBstrUnmarshal (0.00s)
=== RUN   TestBstrMarshal
--- PASS: TestBstrMarshal (0.00s)
=== RUN   TestReadBytes
--- PASS: TestReadBytes (0.00s)
=== RUN   TestUnzipToTemp
    /Users/zhidchen/Workspace/github/excelize/lib_test.go:347:
--- SKIP: TestUnzipToTemp (0.00s)
=== RUN   TestMergeCell
--- PASS: TestMergeCell (0.01s)
=== RUN   TestMergeCellOverlap
--- PASS: TestMergeCellOverlap (0.00s)
=== RUN   TestGetMergeCells
--- PASS: TestGetMergeCells (0.00s)
=== RUN   TestUnmergeCell
--- PASS: TestUnmergeCell (0.00s)
=== RUN   TestFlatMergedCells
--- PASS: TestFlatMergedCells (0.00s)
=== RUN   TestMergeCellsParser
--- PASS: TestMergeCellsParser (0.00s)
=== RUN   TestNumFmt
--- PASS: TestNumFmt (0.05s)
=== RUN   TestAddPicture
--- PASS: TestAddPicture (0.01s)
=== RUN   TestAddPictureErrors
--- PASS: TestAddPictureErrors (0.01s)
=== RUN   TestGetPicture
--- PASS: TestGetPicture (0.02s)
=== RUN   TestAddDrawingPicture
--- PASS: TestAddDrawingPicture (0.00s)
=== RUN   TestAddPictureFromBytes
--- PASS: TestAddPictureFromBytes (0.00s)
=== RUN   TestDeletePicture
--- PASS: TestDeletePicture (0.01s)
=== RUN   TestDrawingResize
--- PASS: TestDrawingResize (0.00s)
=== RUN   TestSetContentTypePartImageExtensions
--- PASS: TestSetContentTypePartImageExtensions (0.00s)
=== RUN   TestSetContentTypePartVMLExtensions
--- PASS: TestSetContentTypePartVMLExtensions (0.00s)
=== RUN   TestAddContentTypePart
--- PASS: TestAddContentTypePart (0.00s)
=== RUN   TestAddPivotTable
--- PASS: TestAddPivotTable (0.01s)
=== RUN   TestAddPivotRowFields
--- PASS: TestAddPivotRowFields (0.00s)
=== RUN   TestAddPivotPageFields
--- PASS: TestAddPivotPageFields (0.00s)
=== RUN   TestAddPivotDataFields
--- PASS: TestAddPivotDataFields (0.00s)
=== RUN   TestAddPivotColFields
--- PASS: TestAddPivotColFields (0.00s)
=== RUN   TestGetPivotFieldsOrder
--- PASS: TestGetPivotFieldsOrder (0.00s)
=== RUN   TestGetPivotTableFieldName
--- PASS: TestGetPivotTableFieldName (0.00s)
=== RUN   TestGetRows
--- PASS: TestGetRows (0.00s)
=== RUN   TestRows
--- PASS: TestRows (0.01s)
=== RUN   TestRowsIterator
--- PASS: TestRowsIterator (0.00s)
=== RUN   TestRowsGetRowOpts
--- PASS: TestRowsGetRowOpts (0.00s)
=== RUN   TestRowsError
--- PASS: TestRowsError (0.00s)
=== RUN   TestRowHeight
--- PASS: TestRowHeight (0.00s)
=== RUN   TestColumns
--- PASS: TestColumns (0.00s)
=== RUN   TestSharedStringsReader
--- PASS: TestSharedStringsReader (0.00s)
=== RUN   TestRowVisibility
--- PASS: TestRowVisibility (0.01s)
=== RUN   TestRemoveRow
--- PASS: TestRemoveRow (0.00s)
=== RUN   TestInsertRows
--- PASS: TestInsertRows (0.00s)
=== RUN   TestInsertRowsInEmptyFile
--- PASS: TestInsertRowsInEmptyFile (0.00s)
=== RUN   TestDuplicateRowFromSingleRow
=== RUN   TestDuplicateRowFromSingleRow/FromSingleRow
--- PASS: TestDuplicateRowFromSingleRow (0.01s)
    --- PASS: TestDuplicateRowFromSingleRow/FromSingleRow (0.01s)
=== RUN   TestDuplicateRowUpdateDuplicatedRows
=== RUN   TestDuplicateRowUpdateDuplicatedRows/UpdateDuplicatedRows
--- PASS: TestDuplicateRowUpdateDuplicatedRows (0.00s)
    --- PASS: TestDuplicateRowUpdateDuplicatedRows/UpdateDuplicatedRows (0.00s)
=== RUN   TestDuplicateRowFirstOfMultipleRows
=== RUN   TestDuplicateRowFirstOfMultipleRows/FirstOfMultipleRows
--- PASS: TestDuplicateRowFirstOfMultipleRows (0.00s)
    --- PASS: TestDuplicateRowFirstOfMultipleRows/FirstOfMultipleRows (0.00s)
=== RUN   TestDuplicateRowZeroWithNoRows
=== RUN   TestDuplicateRowZeroWithNoRows/ZeroWithNoRows
--- PASS: TestDuplicateRowZeroWithNoRows (0.00s)
    --- PASS: TestDuplicateRowZeroWithNoRows/ZeroWithNoRows (0.00s)
=== RUN   TestDuplicateRowMiddleRowOfEmptyFile
=== RUN   TestDuplicateRowMiddleRowOfEmptyFile/MiddleRowOfEmptyFile
--- PASS: TestDuplicateRowMiddleRowOfEmptyFile (0.00s)
    --- PASS: TestDuplicateRowMiddleRowOfEmptyFile/MiddleRowOfEmptyFile (0.00s)
=== RUN   TestDuplicateRowWithLargeOffsetToMiddleOfData
=== RUN   TestDuplicateRowWithLargeOffsetToMiddleOfData/WithLargeOffsetToMiddleOfData
--- PASS: TestDuplicateRowWithLargeOffsetToMiddleOfData (0.00s)
    --- PASS: TestDuplicateRowWithLargeOffsetToMiddleOfData/WithLargeOffsetToMiddleOfData (0.00s)
=== RUN   TestDuplicateRowWithLargeOffsetToEmptyRows
=== RUN   TestDuplicateRowWithLargeOffsetToEmptyRows/WithLargeOffsetToEmptyRows
--- PASS: TestDuplicateRowWithLargeOffsetToEmptyRows (0.00s)
    --- PASS: TestDuplicateRowWithLargeOffsetToEmptyRows/WithLargeOffsetToEmptyRows (0.00s)
=== RUN   TestDuplicateRowInsertBefore
=== RUN   TestDuplicateRowInsertBefore/InsertBefore
--- PASS: TestDuplicateRowInsertBefore (0.00s)
    --- PASS: TestDuplicateRowInsertBefore/InsertBefore (0.00s)
=== RUN   TestDuplicateRowInsertBeforeWithLargeOffset
=== RUN   TestDuplicateRowInsertBeforeWithLargeOffset/InsertBeforeWithLargeOffset
--- PASS: TestDuplicateRowInsertBeforeWithLargeOffset (0.00s)
    --- PASS: TestDuplicateRowInsertBeforeWithLargeOffset/InsertBeforeWithLargeOffset (0.00s)
=== RUN   TestDuplicateRowInsertBeforeWithMergeCells
=== RUN   TestDuplicateRowInsertBeforeWithMergeCells/InsertBeforeWithLargeOffset
--- PASS: TestDuplicateRowInsertBeforeWithMergeCells (0.00s)
    --- PASS: TestDuplicateRowInsertBeforeWithMergeCells/InsertBeforeWithLargeOffset (0.00s)
=== RUN   TestDuplicateRowInvalidRowNum
=== RUN   TestDuplicateRowInvalidRowNum/-100
=== RUN   TestDuplicateRowInvalidRowNum/-2
=== RUN   TestDuplicateRowInvalidRowNum/-1
=== RUN   TestDuplicateRowInvalidRowNum/0
=== RUN   TestDuplicateRowInvalidRowNum/[-100,-100]
=== RUN   TestDuplicateRowInvalidRowNum/[-100,-2]
=== RUN   TestDuplicateRowInvalidRowNum/[-100,-1]
=== RUN   TestDuplicateRowInvalidRowNum/[-100,0]
=== RUN   TestDuplicateRowInvalidRowNum/[-2,-100]
=== RUN   TestDuplicateRowInvalidRowNum/[-2,-2]
=== RUN   TestDuplicateRowInvalidRowNum/[-2,-1]
=== RUN   TestDuplicateRowInvalidRowNum/[-2,0]
=== RUN   TestDuplicateRowInvalidRowNum/[-1,-100]
=== RUN   TestDuplicateRowInvalidRowNum/[-1,-2]
=== RUN   TestDuplicateRowInvalidRowNum/[-1,-1]
=== RUN   TestDuplicateRowInvalidRowNum/[-1,0]
=== RUN   TestDuplicateRowInvalidRowNum/[0,-100]
=== RUN   TestDuplicateRowInvalidRowNum/[0,-2]
=== RUN   TestDuplicateRowInvalidRowNum/[0,-1]
=== RUN   TestDuplicateRowInvalidRowNum/[0,0]
--- PASS: TestDuplicateRowInvalidRowNum (0.07s)
    --- PASS: TestDuplicateRowInvalidRowNum/-100 (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/-2 (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/-1 (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/0 (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[-100,-100] (0.01s)
    --- PASS: TestDuplicateRowInvalidRowNum/[-100,-2] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[-100,-1] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[-100,0] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[-2,-100] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[-2,-2] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[-2,-1] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[-2,0] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[-1,-100] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[-1,-2] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[-1,-1] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[-1,0] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[0,-100] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[0,-2] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[0,-1] (0.00s)
    --- PASS: TestDuplicateRowInvalidRowNum/[0,0] (0.00s)
=== RUN   TestDuplicateRow
--- PASS: TestDuplicateRow (0.00s)
=== RUN   TestDuplicateRowTo
--- PASS: TestDuplicateRowTo (0.00s)
=== RUN   TestDuplicateMergeCells
--- PASS: TestDuplicateMergeCells (0.00s)
=== RUN   TestGetValueFromInlineStr
--- PASS: TestGetValueFromInlineStr (0.00s)
=== RUN   TestGetValueFromNumber
--- PASS: TestGetValueFromNumber (0.00s)
=== RUN   TestErrSheetNotExistError
--- PASS: TestErrSheetNotExistError (0.00s)
=== RUN   TestCheckRow
--- PASS: TestCheckRow (0.00s)
=== RUN   TestSetRowStyle
--- PASS: TestSetRowStyle (0.00s)
=== RUN   TestNumberFormats
--- PASS: TestNumberFormats (0.01s)
=== RUN   TestAddShape
--- PASS: TestAddShape (0.01s)
=== RUN   TestAddDrawingShape
--- PASS: TestAddDrawingShape (0.00s)
=== RUN   TestNewSheet
--- PASS: TestNewSheet (0.00s)
=== RUN   TestSetPanes
--- PASS: TestSetPanes (0.01s)
=== RUN   TestSearchSheet
--- PASS: TestSearchSheet (0.01s)
=== RUN   TestSetPageLayout
--- PASS: TestSetPageLayout (0.00s)
=== RUN   TestGetPageLayout
--- PASS: TestGetPageLayout (0.00s)
=== RUN   TestSetHeaderFooter
--- PASS: TestSetHeaderFooter (0.00s)
=== RUN   TestDefinedName
--- PASS: TestDefinedName (0.00s)
=== RUN   TestGroupSheets
--- PASS: TestGroupSheets (0.00s)
=== RUN   TestUngroupSheets
--- PASS: TestUngroupSheets (0.00s)
=== RUN   TestInsertPageBreak
--- PASS: TestInsertPageBreak (0.00s)
=== RUN   TestRemovePageBreak
--- PASS: TestRemovePageBreak (0.00s)
=== RUN   TestGetSheetName
--- PASS: TestGetSheetName (0.01s)
=== RUN   TestGetSheetMap
--- PASS: TestGetSheetMap (0.00s)
=== RUN   TestSetActiveSheet
--- PASS: TestSetActiveSheet (0.01s)
=== RUN   TestSetSheetName
--- PASS: TestSetSheetName (0.00s)
=== RUN   TestWorksheetWriter
--- PASS: TestWorksheetWriter (0.00s)
=== RUN   TestGetWorkbookPath
--- PASS: TestGetWorkbookPath (0.00s)
=== RUN   TestGetWorkbookRelsPath
--- PASS: TestGetWorkbookRelsPath (0.00s)
=== RUN   TestDeleteSheet
--- PASS: TestDeleteSheet (0.01s)
=== RUN   TestDeleteAndAdjustDefinedNames
--- PASS: TestDeleteAndAdjustDefinedNames (0.00s)
=== RUN   TestGetSheetID
--- PASS: TestGetSheetID (0.00s)
=== RUN   TestSetSheetVisible
--- PASS: TestSetSheetVisible (0.00s)
=== RUN   TestGetSheetVisible
--- PASS: TestGetSheetVisible (0.00s)
=== RUN   TestGetSheetIndex
--- PASS: TestGetSheetIndex (0.00s)
=== RUN   TestSetContentTypes
--- PASS: TestSetContentTypes (0.00s)
=== RUN   TestDeleteSheetFromContentTypes
--- PASS: TestDeleteSheetFromContentTypes (0.00s)
=== RUN   TestAttrValToBool
--- PASS: TestAttrValToBool (0.00s)
=== RUN   TestAttrValToFloat
--- PASS: TestAttrValToFloat (0.00s)
=== RUN   TestSetSheetBackgroundFromBytes
--- PASS: TestSetSheetBackgroundFromBytes (0.02s)
=== RUN   TestCheckSheetName
--- PASS: TestCheckSheetName (0.00s)
=== RUN   TestSheetDimension
--- PASS: TestSheetDimension (0.00s)
=== RUN   TestSetPageMargins
--- PASS: TestSetPageMargins (0.00s)
=== RUN   TestGetPageMargins
--- PASS: TestGetPageMargins (0.00s)
=== RUN   TestSetSheetProps
--- PASS: TestSetSheetProps (0.00s)
=== RUN   TestGetSheetProps
--- PASS: TestGetSheetProps (0.00s)
=== RUN   TestSetView
--- PASS: TestSetView (0.00s)
=== RUN   TestGetView
--- PASS: TestGetView (0.00s)
=== RUN   TestAddSparkline
--- PASS: TestAddSparkline (0.02s)
=== RUN   TestAppendSparkline
--- PASS: TestAppendSparkline (0.00s)
=== RUN   TestStreamWriter
--- PASS: TestStreamWriter (13.92s)
=== RUN   TestStreamSetColWidth
--- PASS: TestStreamSetColWidth (0.00s)
=== RUN   TestStreamSetPanes
--- PASS: TestStreamSetPanes (0.00s)
=== RUN   TestStreamTable
--- PASS: TestStreamTable (0.01s)
=== RUN   TestStreamMergeCells
--- PASS: TestStreamMergeCells (0.00s)
=== RUN   TestStreamInsertPageBreak
--- PASS: TestStreamInsertPageBreak (0.00s)
=== RUN   TestNewStreamWriter
--- PASS: TestNewStreamWriter (0.00s)
=== RUN   TestStreamMarshalAttrs
--- PASS: TestStreamMarshalAttrs (0.00s)
=== RUN   TestStreamSetRow
--- PASS: TestStreamSetRow (0.00s)
=== RUN   TestStreamSetRowNilValues
--- PASS: TestStreamSetRowNilValues (0.00s)
=== RUN   TestStreamSetRowWithStyle
--- PASS: TestStreamSetRowWithStyle (0.00s)
=== RUN   TestStreamSetCellValFunc
--- PASS: TestStreamSetCellValFunc (0.00s)
=== RUN   TestStreamWriterOutlineLevel
--- PASS: TestStreamWriterOutlineLevel (0.00s)
=== RUN   TestStyleFill
--- PASS: TestStyleFill (0.00s)
=== RUN   TestSetConditionalFormat
--- PASS: TestSetConditionalFormat (0.00s)
=== RUN   TestGetConditionalFormats
--- PASS: TestGetConditionalFormats (0.01s)
=== RUN   TestUnsetConditionalFormat
--- PASS: TestUnsetConditionalFormat (0.00s)
=== RUN   TestNewStyle
--- PASS: TestNewStyle (0.01s)
=== RUN   TestNewConditionalStyle
--- PASS: TestNewConditionalStyle (0.00s)
=== RUN   TestGetDefaultFont
--- PASS: TestGetDefaultFont (0.00s)
=== RUN   TestSetDefaultFont
--- PASS: TestSetDefaultFont (0.00s)
=== RUN   TestStylesReader
--- PASS: TestStylesReader (0.00s)
=== RUN   TestThemeReader
--- PASS: TestThemeReader (0.00s)
=== RUN   TestSetCellStyle
--- PASS: TestSetCellStyle (0.00s)
=== RUN   TestGetStyleID
--- PASS: TestGetStyleID (0.00s)
=== RUN   TestGetFillID
--- PASS: TestGetFillID (0.00s)
=== RUN   TestThemeColor
--- PASS: TestThemeColor (0.00s)
=== RUN   TestGetNumFmtID
--- PASS: TestGetNumFmtID (0.00s)
=== RUN   TestAddTable
--- PASS: TestAddTable (0.01s)
=== RUN   TestSetTableHeader
--- PASS: TestSetTableHeader (0.00s)
=== RUN   TestAutoFilter
=== RUN   TestAutoFilter/Expression1
=== RUN   TestAutoFilter/Expression2
=== RUN   TestAutoFilter/Expression3
=== RUN   TestAutoFilter/Expression4
=== RUN   TestAutoFilter/Expression5
=== RUN   TestAutoFilter/Expression6
=== RUN   TestAutoFilter/Expression7
=== RUN   TestAutoFilter/Expression8
=== RUN   TestAutoFilter/Expression9
--- PASS: TestAutoFilter (0.04s)
    --- PASS: TestAutoFilter/Expression1 (0.00s)
    --- PASS: TestAutoFilter/Expression2 (0.00s)
    --- PASS: TestAutoFilter/Expression3 (0.00s)
    --- PASS: TestAutoFilter/Expression4 (0.00s)
    --- PASS: TestAutoFilter/Expression5 (0.00s)
    --- PASS: TestAutoFilter/Expression6 (0.00s)
    --- PASS: TestAutoFilter/Expression7 (0.00s)
    --- PASS: TestAutoFilter/Expression8 (0.00s)
    --- PASS: TestAutoFilter/Expression9 (0.01s)
=== RUN   TestAutoFilterError
=== RUN   TestAutoFilterError/Expression1
=== RUN   TestAutoFilterError/Expression2
=== RUN   TestAutoFilterError/Expression3
=== RUN   TestAutoFilterError/Expression4
=== RUN   TestAutoFilterError/Expression5
=== RUN   TestAutoFilterError/Expression6
--- PASS: TestAutoFilterError (0.03s)
    --- PASS: TestAutoFilterError/Expression1 (0.01s)
    --- PASS: TestAutoFilterError/Expression2 (0.00s)
    --- PASS: TestAutoFilterError/Expression3 (0.00s)
    --- PASS: TestAutoFilterError/Expression4 (0.00s)
    --- PASS: TestAutoFilterError/Expression5 (0.00s)
    --- PASS: TestAutoFilterError/Expression6 (0.00s)
=== RUN   TestParseFilterTokens
--- PASS: TestParseFilterTokens (0.00s)
=== RUN   TestWorkbookProps
--- PASS: TestWorkbookProps (0.00s)
=== RUN   ExampleFile_SetCellFloat
--- PASS: ExampleFile_SetCellFloat (0.00s)
PASS
	github.com/xuri/excelize/v2	coverage: 99.3% of statements
ok  	github.com/xuri/excelize/v2	45.119s	coverage: 99.3% of statements
```

Tested locally with pprof open and see there are significant reduce of regexp calls.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
