### PR TITLE
perf: avoid unnecessary byte/string conversion

### DIFF
--- a/numfmt.go
+++ b/numfmt.go
@@ -1220,7 +1220,7 @@ func printCommaSep(text string) string {
 		if i > 0 && (length-i)%3 == 0 {
 			target.WriteString(",")
 		}
-		target.WriteString(string(text[i]))
+		target.WriteByte(text[i])
 	}
 	if len(subStr) == 2 {
 		target.WriteString(".")

--- a/table.go
+++ b/table.go
@@ -490,7 +490,7 @@ func (f *File) parseFilterExpression(expression string, tokens []string) ([]int,
 		// expressions).
 		conditional := 0
 		c := tokens[3]
-		if conditionFormat.Match([]byte(c)) {
+		if conditionFormat.MatchString(c) {
 			conditional = 1
 		}
 		expression1, token1, err := f.parseFilterTokens(expression, tokens[:3])
@@ -538,7 +538,7 @@ func (f *File) parseFilterTokens(expression string, tokens []string) ([]int, str
 	}
 	token := tokens[2]
 	// Special handling for Blanks/NonBlanks.
-	re := blankFormat.Match([]byte(strings.ToLower(token)))
+	re := blankFormat.MatchString((strings.ToLower(token)))
 	if re {
 		// Only allow Equals or NotEqual in this context.
 		if operator != 2 && operator != 5 {
@@ -563,7 +563,7 @@ func (f *File) parseFilterTokens(expression string, tokens []string) ([]int, str
 	}
 	// If the string token contains an Excel match character then change the
 	// operator type to indicate a non "simple" equality.
-	re = matchFormat.Match([]byte(token))
+	re = matchFormat.MatchString(token)
 	if operator == 2 && re {
 		operator = 22
 	}


### PR DESCRIPTION
# PR Details

We can use alternative functions/methods to avoid unnecessary byte/string conversion calls.

## Description

<!--- Describe your changes in detail -->

1. `(*Builder).WriteString(string(<a byte>))` -> `(*Builder).WriteByte(<a byte>)`
2. `(*Regexp).Match([]byte(<a string>))` -> `(*Regexp).MatchString(<a string>)`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
go test ./...
ok  	github.com/xuri/excelize/v2	63.499s
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
