### PR TITLE
This fixed: type number format be saved as a string by SetCellValue. …

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -151,7 +151,25 @@ func (f *File) SetCellValue(sheet, cell string, value interface{}) error {
 	case nil:
 		err = f.SetCellDefault(sheet, cell, "")
 	default:
-		err = f.SetCellStr(sheet, cell, fmt.Sprint(value))
+
+		kd := reflect.TypeOf(value).Kind()
+		vv := reflect.ValueOf(value)
+		switch kd {
+		case reflect.Float32:
+			err = f.SetCellFloat(sheet, cell, vv.Float(), -1, 32)
+		case reflect.Float64:
+			err = f.SetCellFloat(sheet, cell, vv.Float(), -1, 64)
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			err = f.SetCellInt(sheet, cell, int(vv.Int()))
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			err = f.SetCellInt(sheet, cell, int(vv.Uint()))
+		case reflect.String:
+			err = f.SetCellStr(sheet, cell, vv.String())
+		case reflect.Bool:
+			err = f.SetCellBool(sheet, cell, vv.Bool())
+		default:
+			err = f.SetCellStr(sheet, cell, fmt.Sprint(value))
+		}
 	}
 	return err
 }

--- a/cell_test.go
+++ b/cell_test.go
@@ -229,6 +229,16 @@ func TestSetCellValue(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "0.50", B2)
 
+	//Test define type
+	type Number int
+	type NumberFloat float64
+	type Str string
+	type Bool bool
+	assert.NoError(t, f.SetCellValue("Sheet1", "B1", Number(100)))
+	assert.NoError(t, f.SetCellValue("Sheet1", "B2", NumberFloat(20.65)))
+	assert.NoError(t, f.SetCellValue("Sheet1", "B3", Str("ABC")))
+	assert.NoError(t, f.SetCellValue("Sheet1", "B4", Bool(true)))
+
 	// Test set cell value with invalid sheet name
 	assert.EqualError(t, f.SetCellValue("Sheet:1", "A1", "A1"), ErrSheetNameInvalid.Error())
 	// Test set cell value with unsupported charset shared strings table


### PR DESCRIPTION
# PR Details
This fixed: type number format be saved as a string by SetCellValue. 
eg: 
type Number int
SetCellValue( s , A1, Number(10))
SetCellValue( s , A2, Number(10))
SetCellFormula( s, A3,  "SUM(A1,A2)")

result:
A1,A2  be save as a string:  '10 
A3 is 0 if you open the file

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
