### PR TITLE
add Footer & Header clarification to docs

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -1123,8 +1123,8 @@ func attrValToBool(name string, attrs []xml.Attr) (val bool, err error) {
 //	 DifferentFirst   | Different first-page header and footer indicator
 //	 DifferentOddEven | Different odd and even page headers and footers indicator
 //	 ScaleWithDoc     | Scale header and footer with document scaling
-//	 OddFooter        | Odd Page Footer
-//	 OddHeader        | Odd Header
+//	 OddFooter        | Odd Page Footer, or primary Page Footer if 'DifferentOddEven' is 'false'
+//	 OddHeader        | Odd Header, or primary Page Header if 'DifferentOddEven' is 'false'
 //	 EvenFooter       | Even Page Footer
 //	 EvenHeader       | Even Page Header
 //	 FirstFooter      | First Page Footer


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
improve documentation related to **SetHeaderFooter** field use

## Description

<!--- Describe your changes in detail -->

The existing documentation does not identify the fields to be used when just wanting to set a simple header or footer to the page layout.  It is not obvious to folks who are not familiar with the inner data layout of Excel's data structures that 'OddFooter' and 'OddHeader' are overloaded as the primary fields to be referenced if only using one header and footer in the sheet.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
