### PR TITLE
Fix: Issue ##1682 - Delete table

### DIFF
--- a/table.go
+++ b/table.go
@@ -196,18 +196,6 @@ func (f *File) DeleteTable(name string) error {
 			if ws.TableParts.Count = len(ws.TableParts.TableParts); ws.TableParts.Count == 0 {
 				ws.TableParts = nil
 			}
-			// Delete cell value in the table header
-			coordinates, err := rangeRefToCoordinates(table.Range)
-			if err != nil {
-				return err
-			}
-			_ = sortCoordinates(coordinates)
-			for col := coordinates[0]; col <= coordinates[2]; col++ {
-				for row := coordinates[1]; row < coordinates[1]+1; row++ {
-					cell, _ := CoordinatesToCellName(col, row)
-					err = f.SetCellValue(sheet, cell, nil)
-				}
-			}
 			return err
 		}
 	}

--- a/table_test.go
+++ b/table_test.go
@@ -122,11 +122,19 @@ func TestDeleteTable(t *testing.T) {
 	f.Sheet.Delete("xl/worksheets/sheet1.xml")
 	f.Pkg.Store("xl/worksheets/sheet1.xml", MacintoshCyrillicCharset)
 	assert.EqualError(t, f.DeleteTable("Table1"), "XML syntax error on line 1: invalid UTF-8")
-	// Test delete table with invalid table range
+	// Test delete table without deleting table header
 	f = NewFile()
-	assert.NoError(t, f.AddTable("Sheet1", &Table{Range: "A1:B4", Name: "Table1"}))
-	f.Pkg.Store("xl/tables/table1.xml", []byte("<table name=\"Table1\" ref=\"-\" />"))
-	assert.EqualError(t, f.DeleteTable("Table1"), ErrParameterInvalid.Error())
+	assert.NoError(t, f.SetCellValue("Sheet1", "A1", "Date"))
+	assert.NoError(t, f.SetCellValue("Sheet1", "B1", "Values"))
+	assert.NoError(t, f.UpdateLinkedValue())
+	assert.NoError(t, f.AddTable("Sheet1", &Table{Range: "A1:B2", Name: "Table1"}))
+	assert.NoError(t, f.DeleteTable("Table1"))
+	val, err := f.GetCellValue("Sheet1", "A1")
+	assert.NoError(t, err)
+	assert.Equal(t, "Date", val)
+	val, err = f.GetCellValue("Sheet1", "B1")
+	assert.NoError(t, err)
+	assert.Equal(t, "Values", val)
 }
 
 func TestSetTableHeader(t *testing.T) {


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

- Removed the code that makes the table header cells empty after the table is deleted
- Added a test to make sure that deleting a table does not make the header cells empty


## Related Issue
[#issue1682](https://github.com/qax-os/excelize/issues/1682)


<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Unit test added to table_test.go
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
