### PR TITLE
Remove redundant `len` check in `GroupSheets` and `UngroupSheets`

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -1739,11 +1739,8 @@ func (f *File) GroupSheets(sheets []string) error {
 	}
 	for _, ws := range wss {
 		sheetViews := ws.SheetViews.SheetView
-		if len(sheetViews) > 0 {
-			for idx := range sheetViews {
-				ws.SheetViews.SheetView[idx].TabSelected = true
-			}
-			continue
+		for idx := range sheetViews {
+			ws.SheetViews.SheetView[idx].TabSelected = true
 		}
 	}
 	return nil
@@ -1758,10 +1755,8 @@ func (f *File) UngroupSheets() error {
 		}
 		ws, _ := f.workSheetReader(sheet)
 		sheetViews := ws.SheetViews.SheetView
-		if len(sheetViews) > 0 {
-			for idx := range sheetViews {
-				ws.SheetViews.SheetView[idx].TabSelected = false
-			}
+		for idx := range sheetViews {
+			ws.SheetViews.SheetView[idx].TabSelected = false
 		}
 	}
 	return nil


### PR DESCRIPTION
# PR Details

This pull request is a minor code cleanup.

From the Go specification (https://go.dev/ref/spec#For_range):

> "1. For a nil slice, the number of iterations is 0."

`len` returns 0 if the slice is nil (https://pkg.go.dev/builtin#len). Therefore, checking `len(v) > 0` before a loop is unnecessary.

## Description

Remove redundant `len(sheetViews) > 0` around loop

```go
if len(sheetViews) > 0 {
	for idx := range sheetViews {
		...
	}
}
```

to

```go
for idx := range sheetViews {
	...
}
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
