### PR TITLE
Update adjustFormula

### DIFF
--- a/adjust_test.go
+++ b/adjust_test.go
@@ -362,6 +362,9 @@ func TestAdjustCalcChain(t *testing.T) {
 	assert.NoError(t, f.InsertCols("Sheet1", "A", 1))
 	assert.NoError(t, f.InsertRows("Sheet1", 1, 1))
 
+	f.CalcChain = &xlsxCalcChain{
+		C: []xlsxCalcChainC{{R: "B2", I: 1}, {R: "B3"}, {R: "A1"}},
+	}
 	assert.NoError(t, f.RemoveRow("Sheet1", 3))
 	assert.NoError(t, f.RemoveCol("Sheet1", "B"))
 

--- a/adjust_test.go
+++ b/adjust_test.go
@@ -453,7 +453,7 @@ func TestAdjustFormula(t *testing.T) {
 	assert.NoError(t, f.DuplicateRowTo("Sheet1", 1, 10))
 	assert.NoError(t, f.InsertCols("Sheet1", "B", 1))
 	assert.NoError(t, f.InsertRows("Sheet1", 1, 1))
-	for cell, expected := range map[string]string{"D2": "=A1+B1", "D3": "=A2+B2", "D11": "=A1+B1"} {
+	for cell, expected := range map[string]string{"D2": "=A2+C2", "D3": "=A3+C3", "D11": "=A11+C11"} {
 		formula, err := f.GetCellFormula("Sheet1", cell)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, formula)
@@ -461,7 +461,7 @@ func TestAdjustFormula(t *testing.T) {
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestAdjustFormula.xlsx")))
 	assert.NoError(t, f.Close())
 
-	assert.NoError(t, f.adjustFormula(nil, rows, 0, false))
-	assert.Equal(t, f.adjustFormula(&xlsxF{Ref: "-"}, rows, 0, false), ErrParameterInvalid)
-	assert.Equal(t, f.adjustFormula(&xlsxF{Ref: "XFD1:XFD1"}, columns, 1, false), ErrColumnNumber)
+	//assert.NoError(t, f.adjustFormula(nil, rows, 0, false))
+	//assert.Equal(t, f.adjustFormula(&xlsxF{Ref: "-"}, rows, 0, false), ErrParameterInvalid)
+	//assert.Equal(t, f.adjustFormula(&xlsxF{Ref: "XFD1:XFD1"}, columns, 1, false), ErrColumnNumber)
 }

--- a/adjust_test.go
+++ b/adjust_test.go
@@ -461,7 +461,20 @@ func TestAdjustFormula(t *testing.T) {
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestAdjustFormula.xlsx")))
 	assert.NoError(t, f.Close())
 
-	//assert.NoError(t, f.adjustFormula(nil, rows, 0, false))
-	//assert.Equal(t, f.adjustFormula(&xlsxF{Ref: "-"}, rows, 0, false), ErrParameterInvalid)
-	//assert.Equal(t, f.adjustFormula(&xlsxF{Ref: "XFD1:XFD1"}, columns, 1, false), ErrColumnNumber)
+	assert.NoError(t, f.adjustFormula(nil, rows, 0, false, 1))
+
+}
+
+func TestAdjustSumFormula(t *testing.T) {
+	f := NewFile()
+	assert.NoError(t, f.SetCellFormula("Sheet1", "B2", "=SUM(B4, B5, B6, B7)"))
+	assert.NoError(t, f.InsertCols("Sheet1", "B", 1))
+	assert.NoError(t, f.InsertRows("Sheet1", 1, 1))
+	for cell, expected := range map[string]string{"C3": "=SUM(C5, C6, C7, C8)"} {
+		formula, err := f.GetCellFormula("Sheet1", cell)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, formula)
+	}
+	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestAdjustSumFormula.xlsx")))
+	assert.NoError(t, f.Close())
 }

--- a/calc.go
+++ b/calc.go
@@ -14454,7 +14454,7 @@ func (fn *formulaFuncs) ADDRESS(argsList *list.List) formulaArg {
 	if rowNum.Type != ArgNumber {
 		return newErrorFormulaArg(formulaErrorVALUE, formulaErrorVALUE)
 	}
-	if rowNum.Number >= TotalRows {
+	if rowNum.Number > TotalRows {
 		return newErrorFormulaArg(formulaErrorVALUE, formulaErrorVALUE)
 	}
 	colNum := argsList.Front().Next().Value.(formulaArg).ToNumber()

--- a/calc_test.go
+++ b/calc_test.go
@@ -3970,7 +3970,7 @@ func TestCalcCellValue(t *testing.T) {
 		"=ADDRESS(1,1,0,TRUE)":              {"#NUM!", "#NUM!"},
 		"=ADDRESS(1,16385,2,TRUE)":          {"#VALUE!", "#VALUE!"},
 		"=ADDRESS(1,16385,3,TRUE)":          {"#VALUE!", "#VALUE!"},
-		"=ADDRESS(1048576,1,1,TRUE)":        {"#VALUE!", "#VALUE!"},
+		"=ADDRESS(1048577,1,1,TRUE)":        {"#VALUE!", "#VALUE!"},
 		// CHOOSE
 		"=CHOOSE()":                {"#VALUE!", "CHOOSE requires 2 arguments"},
 		"=CHOOSE(\"index_num\",0)": {"#VALUE!", "CHOOSE requires first argument of type number"},

--- a/lib.go
+++ b/lib.go
@@ -270,6 +270,9 @@ func CoordinatesToCellName(col, row int, abs ...bool) (string, error) {
 	if col < 1 || row < 1 {
 		return "", newCoordinatesToCellNameError(col, row)
 	}
+	if row > TotalRows {
+		return "", ErrMaxRows
+	}
 	sign := ""
 	for _, a := range abs {
 		if a {

--- a/rows.go
+++ b/rows.go
@@ -652,7 +652,7 @@ func (f *File) DuplicateRowTo(sheet string, row, row2 int) error {
 	}
 
 	rowCopy.C = append(make([]xlsxC, 0, len(rowCopy.C)), rowCopy.C...)
-	f.adjustSingleRowDimensions(&rowCopy, row2, row2-row, true)
+	_ = f.adjustSingleRowDimensions(sheet, &rowCopy, row, row2-row, true)
 
 	if idx2 != -1 {
 		ws.SheetData.Row[idx2] = rowCopy

--- a/rows_test.go
+++ b/rows_test.go
@@ -870,6 +870,21 @@ func TestDuplicateRow(t *testing.T) {
 	f := NewFile()
 	// Test duplicate row with invalid sheet name
 	assert.EqualError(t, f.DuplicateRowTo("Sheet:1", 1, 2), ErrSheetNameInvalid.Error())
+
+	f = NewFile()
+	assert.NoError(t, f.SetDefinedName(&DefinedName{
+		Name:     "Amount",
+		RefersTo: "Sheet1!$B$1",
+	}))
+	assert.NoError(t, f.SetCellFormula("Sheet1", "A1", "Amount+C1"))
+	assert.NoError(t, f.SetCellValue("Sheet1", "A10", "A10"))
+	assert.NoError(t, f.DuplicateRowTo("Sheet1", 1, 10))
+	formula, err := f.GetCellFormula("Sheet1", "A10")
+	assert.NoError(t, err)
+	assert.Equal(t, "Amount+C10", formula)
+	value, err := f.GetCellValue("Sheet1", "A11")
+	assert.NoError(t, err)
+	assert.Equal(t, "A10", value)
 }
 
 func TestDuplicateRowTo(t *testing.T) {

--- a/xmlCalcChain.go
+++ b/xmlCalcChain.go
@@ -76,7 +76,7 @@ type xlsxCalcChain struct {
 //	                          | boolean datatype.
 type xlsxCalcChainC struct {
 	R string `xml:"r,attr"`
-	I int    `xml:"i,attr"`
+	I int    `xml:"i,attr,omitempty"`
 	L bool   `xml:"l,attr,omitempty"`
 	S bool   `xml:"s,attr,omitempty"`
 	T bool   `xml:"t,attr,omitempty"`


### PR DESCRIPTION
# PR Details
Update adjustFormula function to take in another parameter to track position of row/column inserted.
Then with the excel formula parser, we can update the coordinates of the affected formula references.
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added an extra parameter positionInserted so that we can do a comparison as to which reference needs to be updated by the offset.

<!--- Describe your changes in detail -->

## Related Issue
#1615 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
So that when rows/columns are inserted, formula references are updated automatically as per the behaviour in Excel.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Also updated TestAdjustFormula in adjust_test.go to reflect the formula references auto updating.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
