### PR TITLE
Reduce memory consumption

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -177,9 +177,8 @@ func (f *File) workSheetWriter() {
 
 // trimRow provides a function to trim empty rows.
 func trimRow(sheetData *xlsxSheetData) []xlsxRow {
-	var (
-		row xlsxRow
-	)
+	var row xlsxRow
+
 	nextIndex := 0
 	for k := range sheetData.Row {
 		row = sheetData.Row[k]

--- a/sheet.go
+++ b/sheet.go
@@ -177,17 +177,19 @@ func (f *File) workSheetWriter() {
 
 // trimRow provides a function to trim empty rows.
 func trimRow(sheetData *xlsxSheetData) []xlsxRow {
-	var row xlsxRow
+	var (
+		row xlsxRow
+		i   int
+	)
 
-	nextIndex := 0
 	for k := range sheetData.Row {
 		row = sheetData.Row[k]
 		if row = trimCell(row); len(row.C) != 0 || row.hasAttr() {
-			sheetData.Row[nextIndex] = row
+			sheetData.Row[i] = row
 		}
-		nextIndex++
+		i++
 	}
-	return sheetData.Row[:nextIndex]
+	return sheetData.Row[:i]
 }
 
 // trimCell provides a function to trim blank cells which created by fillColumns.

--- a/sheet.go
+++ b/sheet.go
@@ -178,36 +178,38 @@ func (f *File) workSheetWriter() {
 // trimRow provides a function to trim empty rows.
 func trimRow(sheetData *xlsxSheetData) []xlsxRow {
 	var (
-		row  xlsxRow
-		rows []xlsxRow
+		row xlsxRow
 	)
-	for k, v := range sheetData.Row {
+	nextIndex := 0
+	for k := range sheetData.Row {
 		row = sheetData.Row[k]
-		if row.C = trimCell(v.C); len(row.C) != 0 || row.hasAttr() {
-			rows = append(rows, row)
+		if row = trimCell(row); len(row.C) != 0 || row.hasAttr() {
+			sheetData.Row[nextIndex] = row
 		}
+		nextIndex++
 	}
-	return rows
+	return sheetData.Row[:nextIndex]
 }
 
 // trimCell provides a function to trim blank cells which created by fillColumns.
-func trimCell(column []xlsxC) []xlsxC {
+func trimCell(row xlsxRow) xlsxRow {
+	column := row.C
 	rowFull := true
 	for i := range column {
 		rowFull = column[i].hasValue() && rowFull
 	}
 	if rowFull {
-		return column
+		return row
 	}
-	col := make([]xlsxC, len(column))
 	i := 0
 	for _, c := range column {
 		if c.hasValue() {
-			col[i] = c
+			row.C[i] = c
 			i++
 		}
 	}
-	return col[:i]
+	row.C = row.C[:i]
+	return row
 }
 
 // setContentTypes provides a function to read and update property of contents


### PR DESCRIPTION
# PR Details

Reduce memory consumption

## Description
By having a lot of rows and columns, memory consumption increases a lot. The reason is that we always allocate a new underlying array instead of re-using the existing one.

## Related Issue

https://github.com/qax-os/excelize/issues/1712

## Motivation and Context

By having a huge amount of rows, the library consumes a lot of memory for converting it to the xlsx file. After this change, a lot of memory would be saved.

## How Has This Been Tested

I tried to convert a huge amount of data (60000 rows) to the xlsx 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
