### PR TITLE
Fix panic on GetPictureCells without drawing relationships parts

### DIFF
--- a/picture.go
+++ b/picture.go
@@ -622,9 +622,10 @@ func (f *File) extractDecodeCellAnchor(anchor *xdrCellAnchor, drawingRelationshi
 	_ = f.xmlNewDecoder(strings.NewReader("<decodeCellAnchor>" + anchor.GraphicFrame + "</decodeCellAnchor>")).Decode(&deCellAnchor)
 	if deCellAnchor.From != nil && deCellAnchor.Pic != nil {
 		if cond(deCellAnchor.From) {
-			drawRel = f.getDrawingRelationships(drawingRelationships, deCellAnchor.Pic.BlipFill.Blip.Embed)
-			if _, ok := supportedImageTypes[strings.ToLower(filepath.Ext(drawRel.Target))]; ok {
-				cb(deCellAnchor, drawRel)
+			if drawRel = f.getDrawingRelationships(drawingRelationships, deCellAnchor.Pic.BlipFill.Blip.Embed); drawRel != nil {
+				if _, ok := supportedImageTypes[strings.ToLower(filepath.Ext(drawRel.Target))]; ok {
+					cb(deCellAnchor, drawRel)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# PR Details

Fix panic on GetPictureCells without drawing relationships parts

## Description

Fix panic on GetPictureCells without drawing relationships parts

## Related Issue

N/A

## Motivation and Context

Fix panic on GetPictureCells without drawing relationships parts

## How Has This Been Tested

Existing unit tests and new test cases passed

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.