### PR TITLE
The GetCellRichText function support to return inline rich text

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -971,6 +971,9 @@ func (f *File) SetCellHyperLink(sheet, cell, link, linkType string, opts ...Hype
 
 // getCellRichText returns rich text of cell by given string item.
 func getCellRichText(si *xlsxSI) (runs []RichTextRun) {
+	if si.T != nil {
+		runs = append(runs, RichTextRun{Text: si.T.Val})
+	}
 	for _, v := range si.R {
 		run := RichTextRun{
 			Text: v.T.Val,
@@ -992,6 +995,13 @@ func (f *File) GetCellRichText(sheet, cell string) (runs []RichTextRun, err erro
 	}
 	c, _, _, err := ws.prepareCell(cell)
 	if err != nil {
+		return
+	}
+	if c.T == "inlineStr" && c.IS != nil {
+		runs = getCellRichText(c.IS)
+		return
+	}
+	if c.T == "" {
 		return
 	}
 	siIdx, err := strconv.Atoi(c.V)


### PR DESCRIPTION
# PR Details

The GetCellRichText function support to return inline rich text

## Description

The GetCellRichText function support to return inline rich text

## Related Issue

N/A

## Motivation and Context

The GetCellRichText function returns error `strconv.Atoi: parsing "": invalid syntax` in some cases

## How Has This Been Tested

Existing unit tests and new test cases passed

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.