### PR TITLE
Support unset custom row height if height value is -1

### DIFF
--- a/rows_test.go
+++ b/rows_test.go
@@ -1034,6 +1034,22 @@ func TestSetRowStyle(t *testing.T) {
 	assert.EqualError(t, f.SetRowStyle("Sheet1", 1, 1, cellStyleID), "XML syntax error on line 1: invalid UTF-8")
 }
 
+func TestSetRowHeight(t *testing.T) {
+	f := NewFile()
+	// Test hidden row by set row height to 0
+	assert.NoError(t, f.SetRowHeight("Sheet1", 2, 0))
+	ht, err := f.GetRowHeight("Sheet1", 2)
+	assert.NoError(t, err)
+	assert.Empty(t, ht)
+	// Test unset custom row height
+	assert.NoError(t, f.SetRowHeight("Sheet1", 2, -1))
+	ht, err = f.GetRowHeight("Sheet1", 2)
+	assert.NoError(t, err)
+	assert.Equal(t, defaultRowHeight, ht)
+	// Test set row height with invalid height value
+	assert.Equal(t, ErrParameterInvalid, f.SetRowHeight("Sheet1", 2, -2))
+}
+
 func TestNumberFormats(t *testing.T) {
 	f, err := OpenFile(filepath.Join("test", "Book1.xlsx"))
 	if !assert.NoError(t, err) {


### PR DESCRIPTION
# PR Details

Support unset custom row height if height value is -1

## Description

- Return error if get an invalid row height value
- Update unit tests and update documentation of the `SetRowHeigth` function

## Related Issue

N/A

## Motivation and Context

Need to unset custom row height

## How Has This Been Tested

All exist unit test are passed, and new test cases are passed

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
