### PR TITLE
Fix CalcCellValue does not return raw value when specify RawCellValue=true

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -823,7 +823,7 @@ func (f *File) CalcCellValue(sheet, cell string, opts ...Options) (result string
 		styleIdx, _ = f.GetCellStyle(sheet, cell)
 	}
 	result = token.Value()
-	if isNum, precision, decimal := isNumeric(result); isNum {
+	if isNum, precision, decimal := isNumeric(result); isNum && !rawCellValue {
 		if precision > 15 {
 			result, err = f.formattedValue(&xlsxC{S: styleIdx, V: strings.ToUpper(strconv.FormatFloat(decimal, 'G', 15, 64))}, rawCellValue, CellTypeNumber)
 			return

--- a/calc_test.go
+++ b/calc_test.go
@@ -6301,6 +6301,28 @@ func TestNestedFunctionsWithOperators(t *testing.T) {
 	}
 }
 
+func TestFormulaRawCellValueOption(t *testing.T) {
+	f := NewFile()
+	rawTest := []struct {
+		value    string
+		raw      bool
+		expected string
+	}{
+		{"=\"10e3\"", false, "10000"},
+		{"=\"10e3\"", true, "10e3"},
+		{"=\"10\" & \"e3\"", false, "10000"},
+		{"=\"10\" & \"e3\"", true, "10e3"},
+		{"=\"1111111111111111\"", false, "1.11111111111111E+15"},
+		{"=\"1111111111111111\"", true, "1111111111111111"},
+	}
+	for _, test := range rawTest {
+		assert.NoError(t, f.SetCellFormula("Sheet1", "A1", test.value))
+		val, err := f.CalcCellValue("Sheet1", "A1", Options{RawCellValue: test.raw})
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, val)
+	}
+}
+
 func TestFormulaArgToToken(t *testing.T) {
 	assert.Equal(t,
 		efp.Token{


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

`CalcCellValue()` returns result as formatted number like this.
* `="10" & "e3"` -> `10000`

I Changed to work  `RawCellValue` option to return "not formatted result".
* `="10" & "e3"` -> `10e3`

This change follow the code https://github.com/qax-os/excelize/blob/99e91e19efc562828af58fb9fde33b2e5d01f9a0/cell.go#L628

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

write test code and run `go test ./...`


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
