### PR TITLE
Fix: Add OpenReader options to GetRows

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -805,12 +805,12 @@ type formulaFuncs struct {
 //	Z.TEST
 //	ZTEST
 func (f *File) CalcCellValue(sheet, cell string, opts ...Options) (result string, err error) {
+	opts = append([]Options{*f.options}, opts...)
 	var (
 		rawCellValue = getOptions(opts...).RawCellValue
 		styleIdx     int
 		token        formulaArg
 	)
-	opts = append([]Options{*f.options}, opts...)
 	if token, err = f.calcCellValue(&calcContext{
 		entry:             fmt.Sprintf("%s!%s", sheet, cell),
 		maxCalcIterations: getOptions(opts...).MaxCalcIterations,

--- a/calc.go
+++ b/calc.go
@@ -805,14 +805,15 @@ type formulaFuncs struct {
 //	Z.TEST
 //	ZTEST
 func (f *File) CalcCellValue(sheet, cell string, opts ...Options) (result string, err error) {
+	options := f.getOptions(opts...)
 	var (
-		rawCellValue = f.getOptions(opts...).RawCellValue
+		rawCellValue = options.RawCellValue
 		styleIdx     int
 		token        formulaArg
 	)
 	if token, err = f.calcCellValue(&calcContext{
 		entry:             fmt.Sprintf("%s!%s", sheet, cell),
-		maxCalcIterations: f.getOptions(opts...).MaxCalcIterations,
+		maxCalcIterations: options.MaxCalcIterations,
 		iterations:        make(map[string]uint),
 		iterationsCache:   make(map[string]formulaArg),
 	}, sheet, cell); err != nil {

--- a/calc.go
+++ b/calc.go
@@ -805,15 +805,14 @@ type formulaFuncs struct {
 //	Z.TEST
 //	ZTEST
 func (f *File) CalcCellValue(sheet, cell string, opts ...Options) (result string, err error) {
-	opts = append([]Options{*f.options}, opts...)
 	var (
-		rawCellValue = getOptions(opts...).RawCellValue
+		rawCellValue = f.getOptions(opts...).RawCellValue
 		styleIdx     int
 		token        formulaArg
 	)
 	if token, err = f.calcCellValue(&calcContext{
 		entry:             fmt.Sprintf("%s!%s", sheet, cell),
-		maxCalcIterations: getOptions(opts...).MaxCalcIterations,
+		maxCalcIterations: f.getOptions(opts...).MaxCalcIterations,
 		iterations:        make(map[string]uint),
 		iterationsCache:   make(map[string]formulaArg),
 	}, sheet, cell); err != nil {

--- a/calc.go
+++ b/calc.go
@@ -810,6 +810,7 @@ func (f *File) CalcCellValue(sheet, cell string, opts ...Options) (result string
 		styleIdx     int
 		token        formulaArg
 	)
+	opts = append([]Options{*f.options}, opts...)
 	if token, err = f.calcCellValue(&calcContext{
 		entry:             fmt.Sprintf("%s!%s", sheet, cell),
 		maxCalcIterations: getOptions(opts...).MaxCalcIterations,

--- a/cell.go
+++ b/cell.go
@@ -72,8 +72,7 @@ func (f *File) GetCellValue(sheet, cell string, opts ...Options) (string, error)
 		if err != nil {
 			return "", true, err
 		}
-		opts = append([]Options{*f.options}, opts...)
-		val, err := c.getValueFrom(f, sst, getOptions(opts...).RawCellValue)
+		val, err := c.getValueFrom(f, sst, f.getOptions(opts...).RawCellValue)
 		return val, true, err
 	})
 }

--- a/cell.go
+++ b/cell.go
@@ -72,6 +72,7 @@ func (f *File) GetCellValue(sheet, cell string, opts ...Options) (string, error)
 		if err != nil {
 			return "", true, err
 		}
+		opts = append([]Options{*f.options}, opts...)
 		val, err := c.getValueFrom(f, sst, getOptions(opts...).RawCellValue)
 		return val, true, err
 	})

--- a/col.go
+++ b/col.go
@@ -68,6 +68,7 @@ func (f *File) GetCols(sheet string, opts ...Options) ([][]string, error) {
 	}
 	cols, err := f.Cols(sheet)
 	results := make([][]string, 0, 64)
+	opts = append([]Options{*f.options}, opts...)
 	for cols.Next() {
 		col, _ := cols.Rows(opts...)
 		results = append(results, col)
@@ -92,6 +93,7 @@ func (cols *Cols) Rows(opts ...Options) ([]string, error) {
 	if cols.stashCol >= cols.curCol {
 		return rowIterator.cells, rowIterator.err
 	}
+	opts = append([]Options{*cols.f.options}, opts...)
 	cols.rawCellValue = getOptions(opts...).RawCellValue
 	if cols.sst, rowIterator.err = cols.f.sharedStringsReader(); rowIterator.err != nil {
 		return rowIterator.cells, rowIterator.err

--- a/col.go
+++ b/col.go
@@ -93,8 +93,7 @@ func (cols *Cols) Rows(opts ...Options) ([]string, error) {
 	if cols.stashCol >= cols.curCol {
 		return rowIterator.cells, rowIterator.err
 	}
-	opts = append([]Options{*cols.f.options}, opts...)
-	cols.rawCellValue = getOptions(opts...).RawCellValue
+	cols.rawCellValue = cols.f.getOptions(opts...).RawCellValue
 	if cols.sst, rowIterator.err = cols.f.sharedStringsReader(); rowIterator.err != nil {
 		return rowIterator.cells, rowIterator.err
 	}

--- a/col.go
+++ b/col.go
@@ -68,7 +68,6 @@ func (f *File) GetCols(sheet string, opts ...Options) ([][]string, error) {
 	}
 	cols, err := f.Cols(sheet)
 	results := make([][]string, 0, 64)
-	opts = append([]Options{*f.options}, opts...)
 	for cols.Next() {
 		col, _ := cols.Rows(opts...)
 		results = append(results, col)

--- a/excelize.go
+++ b/excelize.go
@@ -180,7 +180,7 @@ func OpenReader(r io.Reader, opts ...Options) (*File, error) {
 		return nil, err
 	}
 	f := newFile()
-	f.options = getOptions(opts...)
+	f.options = f.getOptions(opts...)
 	if err = f.checkOpenReaderOptions(); err != nil {
 		return nil, err
 	}
@@ -219,8 +219,8 @@ func OpenReader(r io.Reader, opts ...Options) (*File, error) {
 
 // getOptions provides a function to parse the optional settings for open
 // and reading spreadsheet.
-func getOptions(opts ...Options) *Options {
-	options := &Options{}
+func (f *File) getOptions(opts ...Options) *Options {
+	options := f.options
 	for _, opt := range opts {
 		options = &opt
 	}

--- a/file.go
+++ b/file.go
@@ -50,7 +50,7 @@ func NewFile(opts ...Options) *File {
 	ws, _ := f.workSheetReader("Sheet1")
 	f.Sheet.Store("xl/worksheets/sheet1.xml", ws)
 	f.Theme, _ = f.themeReader()
-	f.options = getOptions(opts...)
+	f.options = f.getOptions(opts...)
 	return f
 }
 

--- a/rows.go
+++ b/rows.go
@@ -63,8 +63,6 @@ func (f *File) GetRows(sheet string, opts ...Options) ([][]string, error) {
 		return nil, err
 	}
 	rows, _ := f.Rows(sheet)
-	// Adding the OpenReader function options
-	opts = append([]Options{*f.options}, opts...)
 	results, cur, max := make([][]string, 0, 64), 0, 0
 	for rows.Next() {
 		cur++

--- a/rows.go
+++ b/rows.go
@@ -153,8 +153,7 @@ func (rows *Rows) Columns(opts ...Options) ([]string, error) {
 	}
 	var rowIterator rowXMLIterator
 	var token xml.Token
-	opts = append([]Options{*rows.f.options}, opts...)
-	rows.rawCellValue = getOptions(opts...).RawCellValue
+	rows.rawCellValue = rows.f.getOptions(opts...).RawCellValue
 	if rows.sst, rowIterator.err = rows.f.sharedStringsReader(); rowIterator.err != nil {
 		return rowIterator.cells, rowIterator.err
 	}

--- a/rows.go
+++ b/rows.go
@@ -63,6 +63,8 @@ func (f *File) GetRows(sheet string, opts ...Options) ([][]string, error) {
 		return nil, err
 	}
 	rows, _ := f.Rows(sheet)
+	// Adding the OpenReader function options
+	opts = append(opts, *f.options) 
 	results, cur, max := make([][]string, 0, 64), 0, 0
 	for rows.Next() {
 		cur++

--- a/rows.go
+++ b/rows.go
@@ -64,7 +64,7 @@ func (f *File) GetRows(sheet string, opts ...Options) ([][]string, error) {
 	}
 	rows, _ := f.Rows(sheet)
 	// Adding the OpenReader function options
-	opts = append(opts, *f.options) 
+	opts = append([]Options{*f.options}, opts...)
 	results, cur, max := make([][]string, 0, 64), 0, 0
 	for rows.Next() {
 		cur++
@@ -153,6 +153,7 @@ func (rows *Rows) Columns(opts ...Options) ([]string, error) {
 	}
 	var rowIterator rowXMLIterator
 	var token xml.Token
+	opts = append([]Options{*rows.f.options}, opts...)
 	rows.rawCellValue = getOptions(opts...).RawCellValue
 	if rows.sst, rowIterator.err = rows.f.sharedStringsReader(); rowIterator.err != nil {
 		return rowIterator.cells, rowIterator.err


### PR DESCRIPTION
# PR Details

The Options struct passed to OpenReader function is not passed in the GetRows which results in passing the options separately resulting in duplication 

## Description

Passing Options to OpenReader should automatically pass the same Options in the child function call as it is done initially. Currently the OpenReader options are not used in GetRows function, which causes inconsistency and leads to duplication. 

## Related Issue
https://github.com/qax-os/excelize/issues/1815

## Motivation and Context

It solves the duplicate need of passing Options if it's already passed in OpenReader

## How Has This Been Tested

Tested locally on my machine with multiple excel files and the output it gives satisfies the requirement

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
