### PR TITLE
1820 Bug - Convert styleFillVariants from slice to func

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -1071,25 +1071,28 @@ var (
 		"gray0625",
 	}
 	// styleFillVariants list all preset variants of the fill style.
-	styleFillVariants = []xlsxGradientFill{
-		{Degree: 90, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
-		{Degree: 270, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
-		{Degree: 90, Stop: []*xlsxGradientFillStop{{}, {Position: 0.5}, {Position: 1}}},
-		{Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
-		{Degree: 180, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
-		{Stop: []*xlsxGradientFillStop{{}, {Position: 0.5}, {Position: 1}}},
-		{Degree: 45, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
-		{Degree: 255, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
-		{Degree: 45, Stop: []*xlsxGradientFillStop{{}, {Position: 0.5}, {Position: 1}}},
-		{Degree: 135, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
-		{Degree: 315, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
-		{Degree: 135, Stop: []*xlsxGradientFillStop{{}, {Position: 0.5}, {Position: 1}}},
-		{Stop: []*xlsxGradientFillStop{{}, {Position: 1}}, Type: "path"},
-		{Stop: []*xlsxGradientFillStop{{}, {Position: 1}}, Type: "path", Left: 1, Right: 1},
-		{Stop: []*xlsxGradientFillStop{{}, {Position: 1}}, Type: "path", Bottom: 1, Top: 1},
-		{Stop: []*xlsxGradientFillStop{{}, {Position: 1}}, Type: "path", Bottom: 1, Left: 1, Right: 1, Top: 1},
-		{Stop: []*xlsxGradientFillStop{{}, {Position: 1}}, Type: "path", Bottom: 0.5, Left: 0.5, Right: 0.5, Top: 0.5},
+	styleFillVariants = func() []xlsxGradientFill {
+		return []xlsxGradientFill{
+			{Degree: 90, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
+			{Degree: 270, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
+			{Degree: 90, Stop: []*xlsxGradientFillStop{{}, {Position: 0.5}, {Position: 1}}},
+			{Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
+			{Degree: 180, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
+			{Stop: []*xlsxGradientFillStop{{}, {Position: 0.5}, {Position: 1}}},
+			{Degree: 45, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
+			{Degree: 255, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
+			{Degree: 45, Stop: []*xlsxGradientFillStop{{}, {Position: 0.5}, {Position: 1}}},
+			{Degree: 135, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
+			{Degree: 315, Stop: []*xlsxGradientFillStop{{}, {Position: 1}}},
+			{Degree: 135, Stop: []*xlsxGradientFillStop{{}, {Position: 0.5}, {Position: 1}}},
+			{Stop: []*xlsxGradientFillStop{{}, {Position: 1}}, Type: "path"},
+			{Stop: []*xlsxGradientFillStop{{}, {Position: 1}}, Type: "path", Left: 1, Right: 1},
+			{Stop: []*xlsxGradientFillStop{{}, {Position: 1}}, Type: "path", Bottom: 1, Top: 1},
+			{Stop: []*xlsxGradientFillStop{{}, {Position: 1}}, Type: "path", Bottom: 1, Left: 1, Right: 1, Top: 1},
+			{Stop: []*xlsxGradientFillStop{{}, {Position: 1}}, Type: "path", Bottom: 0.5, Left: 0.5, Right: 0.5, Top: 0.5},
+		}
 	}
+
 	// getXfIDFuncs provides a function to get xfID by given style.
 	getXfIDFuncs = map[string]func(int, xlsxXf, *Style) bool{
 		"numFmt": func(numFmtID int, xf xlsxXf, style *Style) bool {
@@ -1132,6 +1135,7 @@ var (
 			return reflect.DeepEqual(xf.Protection, newProtection(style)) && xf.ApplyProtection != nil && *xf.ApplyProtection
 		},
 	}
+
 	// extractStyleCondFuncs provides a function set to returns if shoudle be
 	// extract style definition by given style.
 	extractStyleCondFuncs = map[string]func(xlsxXf, *xlsxStyleSheet) bool{
@@ -1157,6 +1161,7 @@ var (
 			return xf.ApplyProtection == nil || (xf.ApplyProtection != nil && *xf.ApplyProtection)
 		},
 	}
+
 	// drawContFmtFunc defines functions to create conditional formats.
 	drawContFmtFunc = map[string]func(p int, ct, ref, GUID string, fmtCond *ConditionalFormatOptions) (*xlsxCfRule, *xlsxX14CfRule){
 		"cellIs":            drawCondFmtCellIs,
@@ -1176,6 +1181,7 @@ var (
 		"expression":        drawCondFmtExp,
 		"iconSet":           drawCondFmtIconSet,
 	}
+
 	// extractContFmtFunc defines functions to get conditional formats.
 	extractContFmtFunc = map[string]func(*File, *xlsxCfRule, *xlsxExtLst) ConditionalFormatOptions{
 		"cellIs": func(f *File, c *xlsxCfRule, extLst *xlsxExtLst) ConditionalFormatOptions {
@@ -1233,6 +1239,7 @@ var (
 			return f.extractCondFmtIconSet(c, extLst)
 		},
 	}
+
 	// validType defined the list of valid validation types.
 	validType = map[string]string{
 		"cell":          "cellIs",
@@ -1456,7 +1463,7 @@ func (f *File) extractFills(fl *xlsxFill, s *xlsxStyleSheet, style *Style) {
 		var fill Fill
 		if fl.GradientFill != nil {
 			fill.Type = "gradient"
-			for shading, variants := range styleFillVariants {
+			for shading, variants := range styleFillVariants() {
 				if fl.GradientFill.Bottom == variants.Bottom &&
 					fl.GradientFill.Degree == variants.Degree &&
 					fl.GradientFill.Left == variants.Left &&
@@ -2024,7 +2031,7 @@ func newFills(style *Style, fg bool) *xlsxFill {
 		if len(style.Fill.Color) != 2 || style.Fill.Shading < 0 || style.Fill.Shading > 16 {
 			break
 		}
-		gradient := styleFillVariants[style.Fill.Shading]
+		gradient := styleFillVariants()[style.Fill.Shading]
 		gradient.Stop[0].Color.RGB = getPaletteColor(style.Fill.Color[0])
 		gradient.Stop[1].Color.RGB = getPaletteColor(style.Fill.Color[1])
 		if len(gradient.Stop) == 3 {

--- a/styles_test.go
+++ b/styles_test.go
@@ -341,7 +341,16 @@ func TestNewStyle(t *testing.T) {
 	_, err = f.NewStyle(nil)
 	assert.NoError(t, err)
 
+	// Test gradient fills
+	f = NewFile()
+	styleID1, err := f.NewStyle(&Style{Fill: Fill{Type: "gradient", Color: []string{"FFFFFF", "4E71BE"}, Shading: 1, Pattern: 1}})
+	assert.NoError(t, err)
+	styleID2, err := f.NewStyle(&Style{Fill: Fill{Type: "gradient", Color: []string{"FF0000", "4E71BE"}, Shading: 1, Pattern: 1}})
+	assert.NoError(t, err)
+	assert.NotEqual(t, styleID1, styleID2)
+
 	var exp string
+	f = NewFile()
 	_, err = f.NewStyle(&Style{CustomNumFmt: &exp})
 	assert.Equal(t, ErrCustomNumFmt, err)
 	_, err = f.NewStyle(&Style{Font: &Font{Family: strings.Repeat("s", MaxFontFamilyLength+1)}})
@@ -356,7 +365,7 @@ func TestNewStyle(t *testing.T) {
 		CustomNumFmt: &numFmt,
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, 2, styleID)
+	assert.Equal(t, 1, styleID)
 
 	assert.NotNil(t, f.Styles)
 	assert.NotNil(t, f.Styles.CellXfs)
@@ -371,7 +380,7 @@ func TestNewStyle(t *testing.T) {
 		NumFmt: 32, // must not be in currencyNumFmt
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, 3, styleID)
+	assert.Equal(t, 2, styleID)
 
 	assert.NotNil(t, f.Styles)
 	assert.NotNil(t, f.Styles.CellXfs)


### PR DESCRIPTION
# PR Details

Fixes a bug with gradient fill styles that was causing different colored fills to return the same `styleID` making it impossible to use more than one gradient fill per workbook.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed the `styleFillVariants` variable from `[]xlsxGradientFill` to `func() []xlsxGradientFill` per @xuri's recommendation.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
* Closes #1820 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Customer required several gradient fills in the workbook we were generating for them. This PR allows use to generate those gradient fills.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
* Added unit test to verify gradients did not produce the same `styleID`
* Executed `go test ./...`
```text
ok      github.com/xuri/excelize/v2     23.656s
```

* Executed the following test program to verify the fills we required returned unique `styleID`
```go
package main

import (
	"fmt"
	"github.com/xuri/excelize/v2"
)

func main() {
	f := excelize.NewFile()

	s1 := excelize.Style{
		Fill: excelize.Fill{
			Type:    "gradient",
			Pattern: 4,
			Shading: 1,
			Color:   []string{"#000000", "#FFFFFF"},
		},
	}

	s2 := excelize.Style{
		Fill: excelize.Fill{
			Type:    "gradient",
			Pattern: 2,
			Shading: 1,
			Color:   []string{"#FFFF00", "#000000"},
		},
	}

	s1Index, err := f.NewStyle(&s1)
	if err != nil {
		fmt.Println(err)
		return

	}
	s2Index, _ := f.NewStyle(&s2)

	fmt.Println("s1Index:", s1Index)
	fmt.Println("s2Index:", s2Index)
}
```
Result:
```text
s1Index: 1
s2Index: 2
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
