### PR TITLE
Add recalc to `xlsxC.getValueFrom()`

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -595,10 +595,48 @@ func (c *xlsxC) getCellDate(f *File, raw bool) (string, error) {
 	return f.formattedValue(c, raw, CellTypeDate)
 }
 
+// maybeRecalc runs File.CalcCellValue() if the cell's .F is not nil and its .R is not empty.
+// TODO: Consider adding more values to check when .V has an 'empty' value?
+// TODO: Allow this to be disabled (or enabled?) via a new option, for performance.
+//
+//	Maybe numerous options for recalc; always, never, or when .V is 'empty'?
+func (c *xlsxC) maybeRecalc(f *File, raw bool) (err error) {
+	var sheet, value string
+	if c.F == nil {
+		// Is checking for nil sufficient, or so I check for more here?
+		return nil
+	}
+	if c.R == "" {
+		// Is checking for empty sufficient, or so I check for more here?
+		return nil
+	}
+	switch c.V {
+	case "", "0", "0.0": // TODO: What other values should be here?
+		// TODO: These are ones we want to recalc for, correct?
+	default:
+		return nil
+	}
+	// TODO: Are there other things to check before recalcing?
+	// TODO: Is this always the correct sheet?
+	sheet = f.GetSheetName(f.GetActiveSheetIndex())
+	// TODO: Is there a lower-level private alternative to the public CalcCellValue()
+	//       that exists or could be created that we might want to use here instead?
+	// TODO: Is *f.options correct here?
+	value, err = f.CalcCellValue(sheet, c.R, *f.options)
+	// TODO: Should I maybe save its original value somewhere, for debugging/other?
+	c.V = strings.TrimSpace(value)
+	return err
+}
+
 // getValueFrom return a value from a column/row cell, this function is
 // intended to be used with for range on rows an argument with the spreadsheet
 // opened file.
 func (c *xlsxC) getValueFrom(f *File, d *xlsxSST, raw bool) (string, error) {
+	// TODO: Is there a better place than this to recalc?
+	err := c.maybeRecalc(f, raw)
+	if err != nil {
+		return "", err
+	}
 	switch c.T {
 	case "b":
 		return c.getCellBool(f, raw)


### PR DESCRIPTION
# PR Details

Adds a `maybeRecalc()` method to address the issue mentioned discussion #1822.

## Description

Adds a `maybeRecalc()` method to `xlsxc` to be called immediately after entering the `getFromValue()` method. 
This calls `File.CalcCellValue()` when `xlsxc.F != nil` and `xlsxc.R != ""` and `xlsxc.V` not one of `""`, `0`, or `0.0`.

This is a draft PR with many TODOs that bring up questions I had about if I was doing this the best way.  I also ask questions to ensure I am using the right internal features and if I am following the vision of the project.

NOTE, when I was about to submit this I read the checklist and then went through the very thorough contributing guidelines. 

Alas, I realizes there are many things I did not do — and since I am already running bind on my other deadlines I don't have time to do them all right now. 

So I could have chosen either to not submit this as a draft PR — as I wrote it to solve my own current issues — or submit it so that it could be reviewed in connection with the referenced discussion and possibly updated to turn into a non-draft PR that could be merged later.

I chose the latter. I hope that you agree with me that I made the right choice.

## Related Issue

Discussion #1822.

## Motivation and Context

Ensures that zero values are not returned for sheets where there is a formula and a zero value, and while Excel shows a value excelize otherwise returns a zero value because of what is in the `<v>` element.  

This issue surfaces when calling `File.GetRows()`, and maybe other methods.

I wrote this fix to meet my own needs, and am submitting it as a draft PR rather than just keeping it to myself.

## How Has This Been Tested

I have only done manual testing as it is only a draft PR meant to spur discussion.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [?] My code follows the code style of this project.
- [?] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.
