### PR TITLE
Optimize `getSharedFormula` to avoid `runtime.duffcopy`

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -1655,8 +1655,10 @@ func parseSharedFormula(dCol, dRow int, orig []byte) (res string, start int) {
 // Note that this function not validate ref tag to check the cell whether in
 // allow range reference, and always return origin shared formula.
 func getSharedFormula(ws *xlsxWorksheet, si int, cell string) string {
-	for _, r := range ws.SheetData.Row {
-		for _, c := range r.C {
+	for row := 0; row < len(ws.SheetData.Row); row++ {
+		r := &ws.SheetData.Row[row]
+		for column := 0; column < len(r.C); column++ {
+			c := &r.C[column]
 			if c.F != nil && c.F.Ref != "" && c.F.T == STCellFormulaTypeShared && c.F.Si != nil && *c.F.Si == si {
 				col, row, _ := CellNameToCoordinates(cell)
 				sharedCol, sharedRow, _ := CellNameToCoordinates(c.R)


### PR DESCRIPTION
# PR Details

Avoids large copies when dealing with `getSharedFormula`, which is called by `CalcCellValue`, increasing the performance of evaluating formulas in cells.

## Description

According to https://stackoverflow.com/a/45786922 uses of `range` in `getSharedFormula` caused large copies of objects, which would show-up in flamegraphs as `runtime.duffcopy`. Changing to a loop with indexing avoids the copying.

## Related Issue

#1836

## Motivation and Context

It cuts out about 40% of execution time from `CalcCellValue`.

Compared to the one in the issue, the flamegraph now looks like this:

![image](https://github.com/qax-os/excelize/assets/6215781/bbaed2e9-a0c5-4f93-a6b4-26cbe13e5420)

## How Has This Been Tested

I've run the patched version inside my program and observed the calculations work as they did before.
I've also run `go test`.

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
