### PR TITLE
Add new exported function `GetCellPixelsWithCoordinates`

### DIFF
--- a/picture.go
+++ b/picture.go
@@ -675,8 +675,10 @@ func (f *File) drawingsWriter() {
 	})
 }
 
-// drawingResize calculate the height and width after resizing.
-func (f *File) drawingResize(sheet, cell string, width, height float64, opts *GraphicOptions) (w, h, c, r int, err error) {
+// GetCellPixelsWithCoordinates returns the pixel dimensions of a specified cell within a given sheet,
+// accounting for merged cells. This function calculates the total pixel width and height
+// for individual or merged cells and provides the column and row index of the cell.
+func (f *File) GetCellPixelsWithCoordinates(sheet, cell string) (cellWidth, cellHeight, c, r int, err error) {
 	var mergeCells []MergeCell
 	mergeCells, err = f.GetMergeCells(sheet)
 	if err != nil {
@@ -687,7 +689,7 @@ func (f *File) drawingResize(sheet, cell string, width, height float64, opts *Gr
 	if c, r, err = CellNameToCoordinates(cell); err != nil {
 		return
 	}
-	cellWidth, cellHeight := f.getColWidth(sheet, c), f.getRowHeight(sheet, r)
+	cellWidth, cellHeight = f.getColWidth(sheet, c), f.getRowHeight(sheet, r)
 	for _, mergeCell := range mergeCells {
 		if inMergeCell {
 			continue
@@ -707,6 +709,12 @@ func (f *File) drawingResize(sheet, cell string, width, height float64, opts *Gr
 			cellHeight += f.getRowHeight(sheet, row)
 		}
 	}
+	return
+}
+
+// drawingResize calculate the height and width after resizing.
+func (f *File) drawingResize(sheet, cell string, width, height float64, opts *GraphicOptions) (w, h, c, r int, err error) {
+	cellWidth, cellHeight, c, r, err := f.GetCellPixelsWithCoordinates(sheet, cell)
 	if float64(cellWidth) < width {
 		asp := float64(cellWidth) / width
 		width, height = float64(cellWidth), height*asp


### PR DESCRIPTION
# PR Details

Added `GetCellPixelsWithCoordinates` Function to Determine Cell Dimensions in Pixels

## Related Issue

https://github.com/qax-os/excelize/issues/1813

## Motivation and Context

To adjust the aspect ratio displayed in individual Excel cells, it is necessary to tweak ScaleX or ScaleY, but there isn't an appropriate public function available for this calculation. Although public functions like GetRowHeight and GetColWidth exist, they do not return values in pixels, and there's a discrepancy with the pixel calculations used within drawingResize in AddPicture. DrawingResize (using getRowHeight and getColWidth) seems to accurately calculate sizes for the most part.

```
-----GetRowHeight, GetColWidth-----
cellWidth:  306
cellHeight:  333
-----drawingResize(getRowHeight, getColWidth)-----
cellWidth:  360
cellHeight:  264
```

Therefore, the pixel function used in drawingResize has been extracted as a public function.
## How Has This Been Tested

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
