### PR TITLE
[BUG] fix Get Rows function memory issues

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -70,10 +70,9 @@ func (f *File) GetRows(sheet string, opts ...Options) ([][]string, error) {
 		if err != nil {
 			break
 		}
-		if len(row) > 0 {	
-			nullCells := cur - maxVal
-			for i := 0; i < nullCells - 1; i++ {
-				results = append(results, []string(nil))
+		if len(row) > 0 {
+			if emptyRows := cur - maxVal - 1; emptyRows > 0 {
+				results = append(results, make([][]string, emptyRows)...)
 			}
 			results = append(results, row)
 			maxVal = cur

--- a/rows.go
+++ b/rows.go
@@ -70,7 +70,11 @@ func (f *File) GetRows(sheet string, opts ...Options) ([][]string, error) {
 		if err != nil {
 			break
 		}
-		if len(row) > 0 {
+		if len(row) > 0 {	
+			nullCells := cur - maxVal
+			for i := 0; i < nullCells - 1; i++ {
+				results = append(results, []string(nil))
+			}
 			results = append(results, row)
 			maxVal = cur
 		}

--- a/rows.go
+++ b/rows.go
@@ -70,8 +70,8 @@ func (f *File) GetRows(sheet string, opts ...Options) ([][]string, error) {
 		if err != nil {
 			break
 		}
-		results = append(results, row)
 		if len(row) > 0 {
+			results = append(results, row)
 			maxVal = cur
 		}
 	}


### PR DESCRIPTION
# PR Details

fix Get Rows function memory issues that allocate huge amount of memory in special xlsx files

## Description

the problem is discussed in the issue
here i just changed it in a way that those empty rows that are located at the end of rows will be ignored

["A", "B", nil, "C", nil, nil] => ["A", "B", nil, "C"]

these nils exist in some special files more than normal
for me was 1 million nils

## Related Issue

https://github.com/qax-os/excelize/issues/1874

## Motivation and Context

it was allocating 30Mb of memory for a 10kb file

## How Has This Been Tested

discussed in the issue

## Types of changes


- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
