### PR TITLE
Support filling images in cells

### DIFF
--- a/picture.go
+++ b/picture.go
@@ -727,15 +727,19 @@ func (f *File) drawingResize(sheet, cell string, width, height float64, opts *Gr
 			cellHeight += f.getRowHeight(sheet, row)
 		}
 	}
-	if float64(cellWidth) < width {
-		asp := float64(cellWidth) / width
-		width, height = float64(cellWidth), height*asp
+	if opts.Fill {
+		width, height = float64(cellWidth), float64(cellHeight)
+	} else {
+		if float64(cellWidth) < width {
+			asp := float64(cellWidth) / width
+			width, height = float64(cellWidth), height*asp
+		}
+		if float64(cellHeight) < height {
+			asp := float64(cellHeight) / height
+			height, width = float64(cellHeight), width*asp
+		}
+		width, height = width-float64(opts.OffsetX), height-float64(opts.OffsetY)
 	}
-	if float64(cellHeight) < height {
-		asp := float64(cellHeight) / height
-		height, width = float64(cellHeight), width*asp
-	}
-	width, height = width-float64(opts.OffsetX), height-float64(opts.OffsetY)
 	w, h = int(width*opts.ScaleX), int(height*opts.ScaleY)
 	return
 }

--- a/picture.go
+++ b/picture.go
@@ -140,6 +140,10 @@ func parseGraphicOptions(opts *GraphicOptions) *GraphicOptions {
 // The optional parameter "AutoFit" specifies if you make graph object size
 // auto-fits the cell, the default value of that is 'false'.
 //
+// The optional parameter "AutoFitIgnoreAspect" specifies if fill the cell with
+// the image and ignore its aspect ratio, the default value of that is 'false'.
+// This option only works when the "AutoFit" is enabled.
+//
 // The optional parameter "OffsetX" specifies the horizontal offset of the graph
 // object with the cell, the default value of that is 0.
 //
@@ -727,19 +731,18 @@ func (f *File) drawingResize(sheet, cell string, width, height float64, opts *Gr
 			cellHeight += f.getRowHeight(sheet, row)
 		}
 	}
-	if opts.Fill {
-		width, height = float64(cellWidth), float64(cellHeight)
-	} else {
-		if float64(cellWidth) < width {
-			asp := float64(cellWidth) / width
-			width, height = float64(cellWidth), height*asp
-		}
-		if float64(cellHeight) < height {
-			asp := float64(cellHeight) / height
-			height, width = float64(cellHeight), width*asp
-		}
-		width, height = width-float64(opts.OffsetX), height-float64(opts.OffsetY)
+	if float64(cellWidth) < width {
+		asp := float64(cellWidth) / width
+		width, height = float64(cellWidth), height*asp
 	}
+	if float64(cellHeight) < height {
+		asp := float64(cellHeight) / height
+		height, width = float64(cellHeight), width*asp
+	}
+	if opts.AutoFitIgnoreAspect {
+		width, height = float64(cellWidth), float64(cellHeight)
+	}
+	width, height = width-float64(opts.OffsetX), height-float64(opts.OffsetY)
 	w, h = int(width*opts.ScaleX), int(height*opts.ScaleY)
 	return
 }

--- a/picture_test.go
+++ b/picture_test.go
@@ -48,6 +48,7 @@ func TestAddPicture(t *testing.T) {
 	// Test add picture to worksheet with autofit
 	assert.NoError(t, f.AddPicture("Sheet1", "A30", filepath.Join("test", "images", "excel.jpg"), &GraphicOptions{AutoFit: true}))
 	assert.NoError(t, f.AddPicture("Sheet1", "B30", filepath.Join("test", "images", "excel.jpg"), &GraphicOptions{OffsetX: 10, OffsetY: 10, AutoFit: true}))
+	assert.NoError(t, f.AddPicture("Sheet1", "A31", filepath.Join("test", "images", "excel.jpg"), &GraphicOptions{AutoFit: true, Fill: true}))
 	_, err = f.NewSheet("AddPicture")
 	assert.NoError(t, err)
 	assert.NoError(t, f.SetRowHeight("AddPicture", 10, 30))
@@ -82,7 +83,7 @@ func TestAddPicture(t *testing.T) {
 	// Test get picture cells
 	cells, err := f.GetPictureCells("Sheet1")
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"F21", "A30", "B30", "Q1", "Q8", "Q15", "Q22", "Q28"}, cells)
+	assert.Equal(t, []string{"F21", "A30", "B30", "A31", "Q1", "Q8", "Q15", "Q22", "Q28"}, cells)
 	assert.NoError(t, f.Close())
 
 	f, err = OpenFile(filepath.Join("test", "TestAddPicture1.xlsx"))
@@ -91,7 +92,7 @@ func TestAddPicture(t *testing.T) {
 	f.Drawings.Delete(path)
 	cells, err = f.GetPictureCells("Sheet1")
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"F21", "A30", "B30", "Q1", "Q8", "Q15", "Q22", "Q28"}, cells)
+	assert.Equal(t, []string{"F21", "A30", "B30", "A31", "Q1", "Q8", "Q15", "Q22", "Q28"}, cells)
 	// Test get picture cells with unsupported charset
 	f.Drawings.Delete(path)
 	f.Pkg.Store(path, MacintoshCyrillicCharset)

--- a/picture_test.go
+++ b/picture_test.go
@@ -48,7 +48,7 @@ func TestAddPicture(t *testing.T) {
 	// Test add picture to worksheet with autofit
 	assert.NoError(t, f.AddPicture("Sheet1", "A30", filepath.Join("test", "images", "excel.jpg"), &GraphicOptions{AutoFit: true}))
 	assert.NoError(t, f.AddPicture("Sheet1", "B30", filepath.Join("test", "images", "excel.jpg"), &GraphicOptions{OffsetX: 10, OffsetY: 10, AutoFit: true}))
-	assert.NoError(t, f.AddPicture("Sheet1", "A31", filepath.Join("test", "images", "excel.jpg"), &GraphicOptions{AutoFit: true, Fill: true}))
+	assert.NoError(t, f.AddPicture("Sheet1", "C30", filepath.Join("test", "images", "excel.jpg"), &GraphicOptions{AutoFit: true, AutoFitIgnoreAspect: true}))
 	_, err = f.NewSheet("AddPicture")
 	assert.NoError(t, err)
 	assert.NoError(t, f.SetRowHeight("AddPicture", 10, 30))
@@ -83,7 +83,7 @@ func TestAddPicture(t *testing.T) {
 	// Test get picture cells
 	cells, err := f.GetPictureCells("Sheet1")
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"F21", "A30", "B30", "A31", "Q1", "Q8", "Q15", "Q22", "Q28"}, cells)
+	assert.Equal(t, []string{"F21", "A30", "B30", "C30", "Q1", "Q8", "Q15", "Q22", "Q28"}, cells)
 	assert.NoError(t, f.Close())
 
 	f, err = OpenFile(filepath.Join("test", "TestAddPicture1.xlsx"))
@@ -92,7 +92,7 @@ func TestAddPicture(t *testing.T) {
 	f.Drawings.Delete(path)
 	cells, err = f.GetPictureCells("Sheet1")
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"F21", "A30", "B30", "A31", "Q1", "Q8", "Q15", "Q22", "Q28"}, cells)
+	assert.Equal(t, []string{"F21", "A30", "B30", "C30", "Q1", "Q8", "Q15", "Q22", "Q28"}, cells)
 	// Test get picture cells with unsupported charset
 	f.Drawings.Delete(path)
 	f.Pkg.Store(path, MacintoshCyrillicCharset)

--- a/xmlDrawing.go
+++ b/xmlDrawing.go
@@ -417,19 +417,19 @@ type Picture struct {
 
 // GraphicOptions directly maps the format settings of the picture.
 type GraphicOptions struct {
-	AltText         string
-	PrintObject     *bool
-	Locked          *bool
-	LockAspectRatio bool
-	AutoFit         bool
-	Fill            bool
-	OffsetX         int
-	OffsetY         int
-	ScaleX          float64
-	ScaleY          float64
-	Hyperlink       string
-	HyperlinkType   string
-	Positioning     string
+	AltText             string
+	PrintObject         *bool
+	Locked              *bool
+	LockAspectRatio     bool
+	AutoFit             bool
+	AutoFitIgnoreAspect bool
+	OffsetX             int
+	OffsetY             int
+	ScaleX              float64
+	ScaleY              float64
+	Hyperlink           string
+	HyperlinkType       string
+	Positioning         string
 }
 
 // Shape directly maps the format settings of the shape.

--- a/xmlDrawing.go
+++ b/xmlDrawing.go
@@ -422,6 +422,7 @@ type GraphicOptions struct {
 	Locked          *bool
 	LockAspectRatio bool
 	AutoFit         bool
+	Fill            bool
 	OffsetX         int
 	OffsetY         int
 	ScaleX          float64


### PR DESCRIPTION
# PR Details

Support filling images in cells

## Description

<!--- Describe your changes in detail -->
Add `Fill` option in excelize.GraphicOptions to allow user filling images in cells.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
