### PR TITLE
fixes issue #1926

### DIFF
--- a/drawing.go
+++ b/drawing.go
@@ -1088,7 +1088,6 @@ func (f *File) drawPlotAreaValAx(pa *cPlotArea, opts *Chart) []*cAxs {
 	if opts.order > 0 && opts.YAxis.Secondary && pa.ValAx != nil {
 		ax.AxID = &attrValInt{Val: intPtr(opts.YAxis.axID)}
 		ax.AxPos = &attrValString{Val: stringPtr("r")}
-		ax.Title = nil
 		ax.Crosses = &attrValString{Val: stringPtr("max")}
 		ax.CrossAx = &attrValInt{Val: intPtr(opts.XAxis.axID)}
 		return []*cAxs{pa.ValAx[0], ax}


### PR DESCRIPTION
# Corrects missing secondary Y-axis title 

<!--- Provide a general summary of your changes in the Title above -->

## Description

Corrects the line in the drawing.go file that set secondary axis title to nil.

## Related Issue

#1926

## Motivation and Context

I need this fix for one of my projects where I need to set the secondary Y-axis title

## How Has This Been Tested

Ran `go test` which came out clean. Performed two tests using my project binary - one to create a combo column + line chart with a secondary Y-axis that has a title and another one that created a combo column + line chart with invisible secondary Y-axis. Both tests produced expected results.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
