### PR TITLE
Support absolute paths for `GetPictureCells` and `GetPictures` functions

### DIFF
--- a/picture_test.go
+++ b/picture_test.go
@@ -219,6 +219,19 @@ func TestGetPicture(t *testing.T) {
 	cells, err := f.GetPictureCells("Sheet2")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"K16"}, cells)
+
+	// Try to get picture cells with absolute target path in the drawing relationship
+	rels, err := f.relsReader("xl/drawings/_rels/drawing2.xml.rels")
+	assert.NoError(t, err)
+	rels.Relationships[0].Target = "/xl/media/image2.jpeg"
+	cells, err = f.GetPictureCells("Sheet2")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"K16"}, cells)
+	// Try to get pictures with absolute target path in the drawing relationship
+	pics, err = f.GetPictures("Sheet2", "K16")
+	assert.NoError(t, err)
+	assert.Len(t, pics, 1)
+
 	assert.NoError(t, f.Close())
 
 	// Test get picture from none drawing worksheet


### PR DESCRIPTION
# PR Details

Support absolute paths for the `GetPictureCells` and `GetPictures` functions. 

## Description

Detects when a relationship target is an absolute path (starts with `/`) and trims the prefix. The behaviour for relative paths is unchanged.

## Related Issue

Fixes #1987.

## Motivation and Context

This PR solves an issue when attempting to get pictures from an Excel file which uses absolute paths in the XML for the relationship target, such as in the example XML snippet below.

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
    <Relationship Id="rId1"
        Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
        Target="/xl/media/image1.jpg" />
</Relationships>
```

## How Has This Been Tested

The changes have been tested locally using the problematic Excel file attached to the issue and the PR extends the existing `TestGetPicture` test (in `picture_test.go`) to get picture cells and pictures with an absolute target path in the drawing relationship.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)