### PR TITLE
Rename SetLegacyDrawingHF to SetHeaderFooterImage

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -1239,7 +1239,7 @@ func attrValToBool(name string, attrs []xml.Attr) (val bool, err error) {
 //	                        |
 //	 &F                     | Current workbook's file name
 //	                        |
-//	 &G                     | Drawing object as background (Use SetLegacyDrawingHF)
+//	 &G                     | Drawing object as background (Use SetHeaderFooterImage)
 //	                        |
 //	 &H                     | Shadow text format
 //	                        |

--- a/vml.go
+++ b/vml.go
@@ -1071,12 +1071,12 @@ func extractVMLFont(font []decodeVMLFont) []RichTextRun {
 	return runs
 }
 
-// SetLegacyDrawingHF provides a mechanism to set the graphics that
+// SetHeaderFooterImage provides a mechanism to set the graphics that
 // can be referenced in the Header/Footer defitions via &G.
 //
 // The extension should be provided with a "." in front, e.g. ".png".
 // The width/height should have units in them, e.g. "100pt".
-func (f *File) SetLegacyDrawingHF(sheet string, g *HeaderFooterGraphics) error {
+func (f *File) SetHeaderFooterImage(sheet string, g *HeaderFooterGraphics) error {
 	vmlID := f.countVMLDrawing() + 1
 
 	vml := &vmlDrawing{

--- a/vml_test.go
+++ b/vml_test.go
@@ -413,7 +413,7 @@ func TestExtractFormControl(t *testing.T) {
 	assert.EqualError(t, err, "XML syntax error on line 1: invalid UTF-8")
 }
 
-func TestSetLegacyDrawingHF(t *testing.T) {
+func TestSetHeaderFooterImage(t *testing.T) {
 	f := NewFile()
 	sheet := "Sheet1"
 	headerFooterOptions := HeaderFooterOptions{
@@ -422,21 +422,21 @@ func TestSetLegacyDrawingHF(t *testing.T) {
 	assert.NoError(t, f.SetHeaderFooter(sheet, &headerFooterOptions))
 	file, err := os.ReadFile(filepath.Join("test", "images", "excel.png"))
 	assert.NoError(t, err)
-	assert.NoError(t, f.SetLegacyDrawingHF(sheet, &HeaderFooterGraphics{
+	assert.NoError(t, f.SetHeaderFooterImage(sheet, &HeaderFooterGraphics{
 		Extension: ".png",
 		File:      file,
 		Width:     "50pt",
 		Height:    "32pt",
 	}))
 	assert.NoError(t, f.SetCellValue(sheet, "A1", "Example"))
-	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetLegacyDrawingHF.xlsx")))
+	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetHeaderFooterImage.xlsx")))
 	assert.NoError(t, f.Close())
 
 	// Test set legacy drawing header/footer with unsupported charset content types
 	f = NewFile()
 	f.ContentTypes = nil
 	f.Pkg.Store(defaultXMLPathContentTypes, MacintoshCyrillicCharset)
-	assert.EqualError(t, f.SetLegacyDrawingHF(sheet, &HeaderFooterGraphics{
+	assert.EqualError(t, f.SetHeaderFooterImage(sheet, &HeaderFooterGraphics{
 		Extension: ".png",
 		File:      file,
 		Width:     "50pt",


### PR DESCRIPTION
Question: should `HeaderFooterGraphics` be renamed to something, or OK as-is?

# PR Details

Rename SetLegacyDrawingHF to SetHeaderFooterImage.

## Motivation and Context

This is being done per request from @xuri. Probably fits in better with the overall naming convention.

## How Has This Been Tested

`go test` passes. Given that this was generated with `sed -i`, no further testing has been done.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
