### PR TITLE
This closes #2068, breaking changes: SetCellInt function required int64 data type parameter

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -207,15 +207,15 @@ func (f *File) setCellIntFunc(sheet, cell string, value interface{}) error {
 	var err error
 	switch v := value.(type) {
 	case int:
-		err = f.SetCellInt(sheet, cell, v)
+		err = f.SetCellInt(sheet, cell, int64(v))
 	case int8:
-		err = f.SetCellInt(sheet, cell, int(v))
+		err = f.SetCellInt(sheet, cell, int64(v))
 	case int16:
-		err = f.SetCellInt(sheet, cell, int(v))
+		err = f.SetCellInt(sheet, cell, int64(v))
 	case int32:
-		err = f.SetCellInt(sheet, cell, int(v))
+		err = f.SetCellInt(sheet, cell, int64(v))
 	case int64:
-		err = f.SetCellInt(sheet, cell, int(v))
+		err = f.SetCellInt(sheet, cell, v)
 	case uint:
 		err = f.SetCellUint(sheet, cell, uint64(v))
 	case uint8:
@@ -288,7 +288,7 @@ func setCellDuration(value time.Duration) (t string, v string) {
 
 // SetCellInt provides a function to set int type value of a cell by given
 // worksheet name, cell reference and cell value.
-func (f *File) SetCellInt(sheet, cell string, value int) error {
+func (f *File) SetCellInt(sheet, cell string, value int64) error {
 	f.mu.Lock()
 	ws, err := f.workSheetReader(sheet)
 	if err != nil {
@@ -309,8 +309,8 @@ func (f *File) SetCellInt(sheet, cell string, value int) error {
 }
 
 // setCellInt prepares cell type and string type cell value by a given integer.
-func setCellInt(value int) (t string, v string) {
-	v = strconv.Itoa(value)
+func setCellInt(value int64) (t string, v string) {
+	v = strconv.FormatInt(value, 10)
 	return
 }
 

--- a/excelize_test.go
+++ b/excelize_test.go
@@ -628,7 +628,7 @@ func TestWriteArrayFormula(t *testing.T) {
 		valCell := cell(1, i+firstResLine)
 		assocCell := cell(2, i+firstResLine)
 
-		assert.NoError(t, f.SetCellInt("Sheet1", valCell, values[i]))
+		assert.NoError(t, f.SetCellInt("Sheet1", valCell, int64(values[i])))
 		assert.NoError(t, f.SetCellStr("Sheet1", assocCell, sample[assoc[i]]))
 	}
 
@@ -642,8 +642,8 @@ func TestWriteArrayFormula(t *testing.T) {
 		stdevCell := cell(i+2, 4)
 		calcStdevCell := cell(i+2, 5)
 
-		assert.NoError(t, f.SetCellInt("Sheet1", calcAvgCell, average(i)))
-		assert.NoError(t, f.SetCellInt("Sheet1", calcStdevCell, stdev(i)))
+		assert.NoError(t, f.SetCellInt("Sheet1", calcAvgCell, int64(average(i))))
+		assert.NoError(t, f.SetCellInt("Sheet1", calcStdevCell, int64(stdev(i))))
 
 		// Average can be done with AVERAGEIF
 		assert.NoError(t, f.SetCellFormula("Sheet1", avgCell, fmt.Sprintf("ROUND(AVERAGEIF(%s,%s,%s),0)", assocRange, nameCell, valRange)))

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -675,7 +675,7 @@ func BenchmarkNewSheet(b *testing.B) {
 func newSheetWithSet() {
 	file := NewFile()
 	for i := 0; i < 1000; i++ {
-		_ = file.SetCellInt("Sheet1", "A"+strconv.Itoa(i+1), i)
+		_ = file.SetCellInt("Sheet1", "A"+strconv.Itoa(i+1), int64(i))
 	}
 	file = nil
 }
@@ -691,7 +691,7 @@ func BenchmarkFile_SaveAs(b *testing.B) {
 func newSheetWithSave() {
 	file := NewFile()
 	for i := 0; i < 1000; i++ {
-		_ = file.SetCellInt("Sheet1", "A"+strconv.Itoa(i+1), i)
+		_ = file.SetCellInt("Sheet1", "A"+strconv.Itoa(i+1), int64(i))
 	}
 	_ = file.Save()
 }

--- a/stream.go
+++ b/stream.go
@@ -557,15 +557,15 @@ func (sw *StreamWriter) setCellValFunc(c *xlsxC, val interface{}) error {
 func setCellIntFunc(c *xlsxC, val interface{}) {
 	switch val := val.(type) {
 	case int:
-		c.T, c.V = setCellInt(val)
+		c.T, c.V = setCellInt(int64(val))
 	case int8:
-		c.T, c.V = setCellInt(int(val))
+		c.T, c.V = setCellInt(int64(val))
 	case int16:
-		c.T, c.V = setCellInt(int(val))
+		c.T, c.V = setCellInt(int64(val))
 	case int32:
-		c.T, c.V = setCellInt(int(val))
+		c.T, c.V = setCellInt(int64(val))
 	case int64:
-		c.T, c.V = setCellInt(int(val))
+		c.T, c.V = setCellInt(val)
 	case uint:
 		c.T, c.V = setCellUint(uint64(val))
 	case uint8:

--- a/stream_test.go
+++ b/stream_test.go
@@ -380,6 +380,29 @@ func TestStreamSetCellValFunc(t *testing.T) {
 	}
 }
 
+func TestSetCellIntFunc(t *testing.T) {
+	cases := []struct{
+		val interface{}
+		target string
+	}{
+		{val: 128, target: "128"},
+		{val: int8(-128), target: "-128"},
+		{val: int16(-32768), target: "-32768"},
+		{val: int32(-2147483648), target: "-2147483648"},
+		{val: int64(-9223372036854775808), target: "-9223372036854775808"},
+		{val: uint(128), target: "128"},
+		{val: uint8(255), target: "255"},
+		{val: uint16(65535), target: "65535"},
+		{val: uint32(4294967295), target: "4294967295"},
+		{val: uint64(18446744073709551615), target: "18446744073709551615"},
+	}
+	for _, c := range cases {
+		cell := &xlsxC{}
+		setCellIntFunc(cell, c.val)
+		assert.Equal(t, c.target, cell.V)
+	}
+}
+
 func TestStreamWriterOutlineLevel(t *testing.T) {
 	file := NewFile()
 	streamWriter, err := file.NewStreamWriter("Sheet1")


### PR DESCRIPTION
# PR Details

SetCellInt function required int64 data type parameter

## Description

SetCellInt function required int64 data type parameter

## Related Issue

 #2068

## Motivation and Context

SetCellInt function required int64 data type parameter

## How Has This Been Tested

Add unit test and update existing unit test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
