### PR TITLE
Fix adjustDataValidations skips adjustments on subsequent sheets when the first sheet has no validations

### DIFF
--- a/adjust.go
+++ b/adjust.go
@@ -969,7 +969,7 @@ func (f *File) adjustDataValidations(ws *xlsxWorksheet, sheet string, dir adjust
 			return err
 		}
 		if worksheet.DataValidations == nil {
-			return nil
+			continue
 		}
 		for i := 0; i < len(worksheet.DataValidations.DataValidation); i++ {
 			dv := worksheet.DataValidations.DataValidation[i]

--- a/adjust_test.go
+++ b/adjust_test.go
@@ -1170,6 +1170,25 @@ func TestAdjustDataValidations(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, formula, dvs[0].Formula1)
 	})
+
+	t.Run("no_data_validations_on_first_sheet", func(t *testing.T) {
+		f := NewFile()
+
+		// Add Sheet2 and set a data validation
+		_, err = f.NewSheet("Sheet2")
+		assert.NoError(t, err)
+		dv := NewDataValidation(true)
+		dv.Sqref = "C5:D6"
+		assert.NoError(t, f.AddDataValidation("Sheet2", dv))
+
+		// Adjust Sheet2 by removing a column
+		assert.NoError(t, f.RemoveCol("Sheet2", "A"))
+
+		// Verify that data validations on Sheet2 are adjusted correctly
+		dvs, err = f.GetDataValidations("Sheet2")
+		assert.NoError(t, err)
+		assert.Equal(t, "B5:C6", dvs[0].Sqref) // Adjusted range
+	})
 }
 
 func TestAdjustDrawings(t *testing.T) {


### PR DESCRIPTION
# PR Details

Fix https://github.com/qax-os/excelize/issues/2072

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
