### PR TITLE
improve cell read performance by optimizing xml parsing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
       run: go build -v .
 
     - name: Test
-      run: env GO111MODULE=on go test -v -timeout 30m -race ./... -coverprofile='coverage.txt' -covermode=atomic
+      run: env GO111MODULE=on go test -v -timeout 50m -race ./... -coverprofile='coverage.txt' -covermode=atomic
 
     - name: Codecov
       uses: codecov/codecov-action@v5

--- a/rows.go
+++ b/rows.go
@@ -251,11 +251,13 @@ func (cell *xlsxC) cellXMLAttrHandler(start *xml.StartElement) error {
 		case "r":
 			cell.R = attr.Value
 		case "s":
-			i64, err := strconv.ParseInt(attr.Value, 10, 64)
+			val, err := strconv.ParseInt(attr.Value, 10, 64)
 			if err != nil {
 				return err
 			}
-			cell.S = int(i64)
+			if int64(math.MinInt) <= val && val <= int64(math.MaxInt) {
+				cell.S = int(val)
+			}
 		case "t":
 			cell.T = attr.Value
 		default:

--- a/rows.go
+++ b/rows.go
@@ -244,41 +244,32 @@ func (rows *Rows) rowXMLHandler(rowIterator *rowXMLIterator, xmlElement *xml.Sta
 	}
 }
 
-func (cell *xlsxC) cellXMLAttrHandler(start *xml.StartElement) (err error) {
-	var res uint64
+// cellXMLAttrHandler parse the cell XML element attributes of the worksheet.
+func (cell *xlsxC) cellXMLAttrHandler(start *xml.StartElement) error {
 	for _, attr := range start.Attr {
-		if attr.Name.Local == "space" {
-			cell.XMLSpace = attr
-		} else if attr.Name.Local == "r" {
+		switch attr.Name.Local {
+		case "r":
 			cell.R = attr.Value
-		} else if attr.Name.Local == "s" {
-			var i64 int64
-			i64, err = strconv.ParseInt(attr.Value, 10, 64)
+		case "s":
+			i64, err := strconv.ParseInt(attr.Value, 10, 64)
+			if err != nil {
+				return err
+			}
 			cell.S = int(i64)
-		} else if attr.Name.Local == "t" {
+		case "t":
 			cell.T = attr.Value
-		} else if attr.Name.Local == "cm" {
-			res, err = strconv.ParseUint(attr.Value, 10, 64)
-			cm := uint(res)
-			cell.Cm = &cm
-		} else if attr.Name.Local == "vm" {
-			res, err = strconv.ParseUint(attr.Value, 10, 64)
-			vm := uint(res)
-			cell.Vm = &vm
-		} else if attr.Name.Local == "ph" {
-			var r bool
-			r, err = strconv.ParseBool(attr.Value)
-			cell.Ph = &r
+		default:
 		}
 	}
-	return
+	return nil
 }
 
-func (cell *xlsxC) cellXMLHandler(decoder *xml.Decoder, start *xml.StartElement) (err error) {
+// cellXMLHandler parse the cell XML element of the worksheet.
+func (cell *xlsxC) cellXMLHandler(decoder *xml.Decoder, start *xml.StartElement) error {
 	cell.XMLName = start.Name
-	err = cell.cellXMLAttrHandler(start)
+	err := cell.cellXMLAttrHandler(start)
 	if err != nil {
-		return
+		return err
 	}
 	for {
 		tok, err := decoder.Token()

--- a/rows.go
+++ b/rows.go
@@ -255,7 +255,7 @@ func (cell *xlsxC) cellXMLAttrHandler(start *xml.StartElement) error {
 			if err != nil {
 				return err
 			}
-			if int64(math.MinInt) <= val && val <= int64(math.MaxInt) {
+			if math.MinInt <= val && val <= math.MaxInt {
 				cell.S = int(val)
 			}
 		case "t":

--- a/rows_test.go
+++ b/rows_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1157,36 +1158,15 @@ func TestNumberFormats(t *testing.T) {
 	assert.Equal(t, "2019/3/19", result, "A1")
 }
 
-func TestCellsDecode(t *testing.T) {
-	content := []byte(`<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
-		xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheetData>
-		<row spans="1:17" r="1">
-			<c r="A1" t="s" vm="15"><v>10</v></c>
-			<c r="B1"><is><t>String</t></is></c>
-		</row>
-		<row r="2">
-			<c r="A2" s="4" t="str"><f>CONCATENATE("total is ",C7," units")</f><v>total is 23 units</v></c>
-			<c r="C2" s="1" ph="true"><f>PMT(B3/12,B4,-B5)</f><v>672.68336574300008</v></c>
-			<c r="D2" t="d" cm="1" vm="2" ph="false"><v>1976-11-22T08:30</v></c>
-           <c r="X2" xml:space="spurious1"></c>
-           <c r="X2" space="spurious2"></c>
-		</row>
-		</sheetData></worksheet>`)
-	type RowXML struct {
-		Cells []xlsxC `xml:"c"`
-	}
-	type Worksheet struct {
-		SheetData struct {
-			Rows []RowXML `xml:"row"`
-		} `xml:"sheetData"`
-	}
-	var base Worksheet
-	err := xml.Unmarshal(content, &base)
-	assert.NoError(t, err)
+func TestCellXMLHandler(t *testing.T) {
+	var (
+		content      = []byte(fmt.Sprintf(`<worksheet xmlns="%s"><sheetData><row r="1"><c r="A1" t="s"><v>10</v></c><c r="B1"><is><t>String</t></is></c></row><row r="2"><c r="A2" s="4" t="str"><f>2*A1</f><v>0</v></c><c r="C2" s="1"><f>A3</f><v>2422.3000000000002</v></c><c r="D2" t="d"><v>2022-10-22T15:05:29Z</v></c><c r="F2"></c><c r="G2"></c></row></sheetData></worksheet>`, NameSpaceSpreadSheet.Value))
+		expected, ws xlsxWorksheet
+		row          *xlsxRow
+	)
+	assert.NoError(t, xml.Unmarshal(content, &expected))
 	decoder := xml.NewDecoder(bytes.NewReader(content))
-	var compare Worksheet
-	var lastRow *RowXML
-	row := Rows{decoder: decoder}
+	rows := Rows{decoder: decoder}
 	for {
 		token, _ := decoder.Token()
 		if token == nil {
@@ -1195,41 +1175,31 @@ func TestCellsDecode(t *testing.T) {
 		switch element := token.(type) {
 		case xml.StartElement:
 			if element.Name.Local == "row" {
-				compare.SheetData.Rows = append(compare.SheetData.Rows, RowXML{})
-				lastRow = &compare.SheetData.Rows[len(compare.SheetData.Rows)-1]
-			} else if element.Name.Local == "c" {
-				colCell := xlsxC{}
-				err = colCell.cellXMLHandler(row.decoder, &element)
+				r, err := strconv.Atoi(element.Attr[0].Value)
 				assert.NoError(t, err)
-				lastRow.Cells = append(lastRow.Cells, colCell)
+				ws.SheetData.Row = append(ws.SheetData.Row, xlsxRow{R: r})
+				row = &ws.SheetData.Row[len(ws.SheetData.Row)-1]
+			}
+			if element.Name.Local == "c" {
+				colCell := xlsxC{}
+				assert.NoError(t, colCell.cellXMLHandler(rows.decoder, &element))
+				row.C = append(row.C, colCell)
 			}
 		}
 	}
-	assert.Equal(t, base, compare)
-}
+	assert.Equal(t, expected.SheetData.Row, ws.SheetData.Row)
 
-func TestCellsDecodeFail(t *testing.T) {
-	type RowXML struct {
-		Cells []xlsxC `xml:"c"`
-	}
-	type Worksheet struct {
-		SheetData struct {
-			Rows []RowXML `xml:"row"`
-		} `xml:"sheetData"`
-	}
-	prefix := `<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>`
-	tail := `</sheetData></worksheet>`
-	contents := [][]byte{
-		[]byte(prefix + `<row spans="1:17" r="1"><c r="A1" t="s" s="A"><v>10</v></c></row>` + tail), // s need number
-		[]byte(prefix + `<row spans="1:17" r="1"><c r="A1"><v>10</v>     </row>` + tail),            // missing </c>
-		[]byte(prefix + `<row spans="1:17" r="1"><c r="B1"><is><t>`),                                // incorrect data
-	}
-	for _, content := range contents {
-		var base Worksheet
-		err1 := xml.Unmarshal(content, &base)
-		assert.Error(t, err1)
+	for _, rowXML := range []string{
+		`<row spans="1:17" r="1"><c r="A1" t="s" s="A"><v>10</v></c></row></sheetData></worksheet>`, // s need number
+		`<row spans="1:17" r="1"><c r="A1"><v>10</v>    </row></sheetData></worksheet>`,             // missing </c>
+		`<row spans="1:17" r="1"><c r="B1"><is><t>`,                                                 // incorrect data
+	} {
+		ws := xlsxWorksheet{}
+		content := []byte(fmt.Sprintf(`<worksheet xmlns="%s"><sheetData>%s</sheetData></worksheet>`, NameSpaceSpreadSheet.Value, rowXML))
+		expected := xml.Unmarshal(content, &ws)
+		assert.Error(t, expected)
 		decoder := xml.NewDecoder(bytes.NewReader(content))
-		row := Rows{decoder: decoder}
+		rows := Rows{decoder: decoder}
 		for {
 			token, _ := decoder.Token()
 			if token == nil {
@@ -1239,14 +1209,15 @@ func TestCellsDecodeFail(t *testing.T) {
 			case xml.StartElement:
 				if element.Name.Local == "c" {
 					colCell := xlsxC{}
-					err2 := colCell.cellXMLHandler(row.decoder, &element)
-					assert.Error(t, err2)
-					assert.EqualError(t, err1, err2.Error())
+					err := colCell.cellXMLHandler(rows.decoder, &element)
+					assert.Error(t, err)
+					assert.Equal(t, expected, err)
 				}
 			}
 		}
 	}
 }
+
 func BenchmarkRows(b *testing.B) {
 	f, _ := OpenFile(filepath.Join("test", "Book1.xlsx"))
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
# PR Details

improve cell read performance by optimizing  unmarshal for xlsxC struct

## Description

<!--- Describe your changes in detail -->


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Improve the cell reading performance of large documents

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

Performance testing was conducted on an AMD64 WSL using Go's benchmark tool. The benchmarks were run BenchmarkRows 10 times each to ensure statistical significance. The following results were observed:
goos: linux
goarch: amd64
pkg: github.com/xuri/excelize/v2
cpu: 12th Gen Intel(R) Core(TM) i5-12400F
```
        │ bashline_1.txt │              new_1.txt              │
        │     sec/op     │   sec/op     vs base                │
Rows-12      164.7µ ± 5%   131.1µ ± 2%  -20.41% (p=0.000 n=10)

        │ bashline_1.txt │              new_1.txt              │
        │      B/op      │     B/op      vs base               │
Rows-12     72.20Ki ± 0%   66.44Ki ± 0%  -7.99% (p=0.000 n=10)

        │ bashline_1.txt │              new_1.txt              │
        │   allocs/op    │  allocs/op   vs base                │
Rows-12      1.903k ± 0%   1.658k ± 0%  -12.87% (p=0.000 n=10)
```

Due to the small size of Book1.xlsx, I replaced it with TestStreamWriter.xlsx(Get after run TestStreamWriter) and re-executed it:
```
       │ bashline_2.txt │             new_2.txt              │
        │     sec/op     │   sec/op    vs base                │
Rows-12       5.662 ± 3%   3.970 ± 3%  -29.88% (p=0.000 n=10)

        │ bashline_2.txt │              new_2.txt               │
        │      B/op      │     B/op      vs base                │
Rows-12     2.387Gi ± 0%   2.044Gi ± 0%  -14.38% (p=0.000 n=10)

        │ bashline_2.txt │              new_2.txt              │
        │   allocs/op    │  allocs/op   vs base                │
Rows-12      64.82M ± 0%   52.02M ± 0%  -19.75% (p=0.000 n=10)
```
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
