### PR TITLE
force-remove all files on Close

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -80,7 +80,7 @@ func (f *File) ReadZipReader(r *zip.Reader) (map[string][]byte, int, error) {
 // unzipToTemp unzip the zip entity to the system temporary directory and
 // returned the unzipped file path.
 func (f *File) unzipToTemp(zipFile *zip.File) (string, error) {
-	tmp, err := os.CreateTemp(os.TempDir(), "excelize-")
+	tmp, err := os.CreateTemp("", "excelize-")
 	if err != nil {
 		return "", err
 	}

--- a/rows.go
+++ b/rows.go
@@ -139,8 +139,10 @@ func (rows *Rows) Error() error {
 // Close closes the open worksheet XML file in the system temporary
 // directory.
 func (rows *Rows) Close() error {
-	if rows.tempFile != nil {
-		return rows.tempFile.Close()
+	tempFile := rows.tempFile
+	rows.tempFile = nil
+	if tempFile != nil {
+		return tempFile.Close()
 	}
 	return nil
 }
@@ -366,7 +368,7 @@ func (f *File) getFromStringItem(index int) string {
 		}()
 	}
 	f.sharedStringItem = [][]uint{}
-	f.sharedStringTemp, _ = os.CreateTemp(os.TempDir(), "excelize-")
+	f.sharedStringTemp, _ = os.CreateTemp("", "excelize-")
 	f.tempFiles.Store(defaultTempFileSST, f.sharedStringTemp.Name())
 	var (
 		inElement string

--- a/stream.go
+++ b/stream.go
@@ -775,7 +775,7 @@ func (bw *bufferedWriter) Sync() (err error) {
 		return nil
 	}
 	if bw.tmp == nil {
-		bw.tmp, err = os.CreateTemp(os.TempDir(), "excelize-")
+		bw.tmp, err = os.CreateTemp("", "excelize-")
 		if err != nil {
 			// can not use local storage
 			return nil


### PR DESCRIPTION
# PR Details

Force removing of all temporary files on File.Close().

## Description

Don't quit on error while removing temp files during iteration over tempFiles Map.

## Related Issue

#2119 

## Motivation and Context

Some of the temp files may be left there, occupying space.

## How Has This Been Tested

go test

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
