### PR TITLE
DefinedNames SheetNames are not escaped correctly, if a sheet gets renamed

### DIFF
--- a/adjust.go
+++ b/adjust.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"io"
+	"regexp"
 	"strconv"
 	"strings"
 	"unicode"
@@ -467,9 +468,10 @@ func adjustRangeSheetName(rng, source, target string) string {
 				if singleQuote {
 					part = strings.TrimPrefix(strings.TrimSuffix(part, "'"), "'")
 				}
+				needsQuoting := regexp.MustCompile(`\W`).MatchString(target)
 				if part == source {
-					if part = target; singleQuote {
-						part = "'" + part + "'"
+					if part = target; needsQuoting {
+						part = "'" + strings.ReplaceAll(part, "'", "''") + "'"
 					}
 				}
 				parts[k] = part

--- a/adjust.go
+++ b/adjust.go
@@ -457,17 +457,14 @@ func transformParenthesesToken(token efp.Token) string {
 // adjustRangeSheetName returns replaced range reference by given source and
 // target sheet name.
 func adjustRangeSheetName(rng, source, target string) string {
+	source = escapeSheetName(source)
 	cellRefs := strings.Split(rng, ",")
 	for i, cellRef := range cellRefs {
 		rangeRefs := strings.Split(cellRef, ":")
 		for j, rangeRef := range rangeRefs {
 			parts := strings.Split(rangeRef, "!")
 			for k, part := range parts {
-				singleQuote := strings.HasPrefix(part, "'") && strings.HasSuffix(part, "'")
-				if singleQuote {
-					part = strings.TrimPrefix(strings.TrimSuffix(part, "'"), "'")
-				}
-				if part == source {
+				if strings.TrimPrefix(strings.TrimSuffix(part, "'"), "'") == source {
 					part = escapeSheetName(target)
 				}
 				parts[k] = part

--- a/adjust.go
+++ b/adjust.go
@@ -15,7 +15,6 @@ import (
 	"bytes"
 	"encoding/xml"
 	"io"
-	"regexp"
 	"strconv"
 	"strings"
 	"unicode"

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -481,6 +481,8 @@ func TestSetSheetName(t *testing.T) {
 	assert.Equal(t, "sheet1", f.GetSheetName(0))
 	// Test set sheet name with invalid sheet name
 	assert.Equal(t, f.SetSheetName("Sheet:1", "Sheet1"), ErrSheetNameInvalid)
+	_, err := f.NewSheet("Sheet 3")
+	assert.NoError(t, err)
 
 	// Test set worksheet name with existing defined name and auto filter
 	assert.NoError(t, f.AutoFilter("Sheet1", "A1:A2", nil))
@@ -496,8 +498,12 @@ func TestSetSheetName(t *testing.T) {
 		Name:     "Name3",
 		RefersTo: "Sheet1!$A$1:'Sheet1'!A1:Sheet1!$A$1,Sheet1!A1:Sheet3!A1,Sheet3!A1",
 	}))
+	assert.NoError(t, f.SetDefinedName(&DefinedName{
+		Name:     "Name4",
+		RefersTo: "'Sheet 3'!$A1$2:A2",
+	}))
 	assert.NoError(t, f.SetSheetName("Sheet1", "Sheet 2"))
-	for i, expected := range []string{"'Sheet 2'!$A$1:$A$2", "$B$2", "$A1$2:A2", "'Sheet 2'!$A$1:'Sheet 2'!A1:'Sheet 2'!$A$1,'Sheet 2'!A1:Sheet3!A1,Sheet3!A1"} {
+	for i, expected := range []string{"'Sheet 2'!$A$1:$A$2", "$B$2", "$A1$2:A2", "'Sheet 2'!$A$1:'Sheet 2'!A1:'Sheet 2'!$A$1,'Sheet 2'!A1:Sheet3!A1,Sheet3!A1", "'Sheet 3'!$A1$2:A2"} {
 		assert.Equal(t, expected, f.WorkBook.DefinedNames.DefinedName[i].Data)
 	}
 }

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -496,8 +496,8 @@ func TestSetSheetName(t *testing.T) {
 		Name:     "Name3",
 		RefersTo: "Sheet1!$A$1:'Sheet1'!A1:Sheet1!$A$1,Sheet1!A1:Sheet3!A1,Sheet3!A1",
 	}))
-	assert.NoError(t, f.SetSheetName("Sheet1", "Sheet2"))
-	for i, expected := range []string{"'Sheet2'!$A$1:$A$2", "$B$2", "$A1$2:A2", "Sheet2!$A$1:'Sheet2'!A1:Sheet2!$A$1,Sheet2!A1:Sheet3!A1,Sheet3!A1"} {
+	assert.NoError(t, f.SetSheetName("Sheet1", "Sheet 2"))
+	for i, expected := range []string{"'Sheet 2'!$A$1:$A$2", "$B$2", "$A1$2:A2", "'Sheet 2'!$A$1:'Sheet 2'!A1:'Sheet 2'!$A$1,'Sheet 2'!A1:Sheet3!A1,Sheet3!A1"} {
 		assert.Equal(t, expected, f.WorkBook.DefinedNames.DefinedName[i].Data)
 	}
 }


### PR DESCRIPTION
# PR Details

DefinedNames SheetNames are not escaped correctly, if a sheet gets renamed

## Description

Renaming a sheet might cause Microsoft Excel to show a warning that the file contains broken links. This happens if the sheet name contains whitespaces for example and definedNames referencing this sheet. This is also the reason why some sheet names are escaped and others not. This PR checks via regex for non word characters and escapes sheet names in definedNames if required. The current implementation only preserves already present escaping, even if it is not required anymore.
Currently "Sheet 2!$A$1:$A$2"
Required "'Sheet 2'!$A$1:$A$2"

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2126 

## Motivation and Context

Fixes "broken links".

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

Tested in a local project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
