### PR TITLE
This closes #2024, add TempDir field in the Options data type (#2024)

### DIFF
--- a/excelize.go
+++ b/excelize.go
@@ -100,19 +100,18 @@ type charsetTranscoderFn func(charset string, input io.Reader) (rdr io.Reader, e
 // format code these effect by the system's local language settings.
 //
 // TmpDir specifies the temporary directory for creating temporary files, if the
-// value is empty, the system default temporary directory which is calculated by
-// os.TempDir() will be used.
+// value is empty, the system default temporary directory will be used.
 type Options struct {
 	MaxCalcIterations uint
 	Password          string
 	RawCellValue      bool
 	UnzipSizeLimit    int64
 	UnzipXMLSizeLimit int64
+	TmpDir            string
 	ShortDatePattern  string
 	LongDatePattern   string
 	LongTimePattern   string
 	CultureInfo       CultureName
-	TmpDir            string // when set this value, the temporary files will be created in this directory
 }
 
 // OpenFile take the name of a spreadsheet file and returns a populated

--- a/excelize.go
+++ b/excelize.go
@@ -98,6 +98,10 @@ type charsetTranscoderFn func(charset string, input io.Reader) (rdr io.Reader, e
 //
 // CultureInfo specifies the country code for applying built-in language number
 // format code these effect by the system's local language settings.
+//
+// TmpDir specifies the temporary directory for creating temporary files, if the
+// value is empty, the system default temporary directory which is calculated by
+// os.TempDir() will be used.
 type Options struct {
 	MaxCalcIterations uint
 	Password          string
@@ -108,6 +112,7 @@ type Options struct {
 	LongDatePattern   string
 	LongTimePattern   string
 	CultureInfo       CultureName
+	TmpDir            string // when set this value, the temporary files will be created in this directory
 }
 
 // OpenFile take the name of a spreadsheet file and returns a populated

--- a/lib.go
+++ b/lib.go
@@ -77,10 +77,17 @@ func (f *File) ReadZipReader(r *zip.Reader) (map[string][]byte, int, error) {
 	return fileList, worksheets, nil
 }
 
+func (f *File) getTempDir() string {
+	if f.options.TmpDir != "" {
+		return f.options.TmpDir
+	}
+	return "" // return "" means use the system temporary directory
+}
+
 // unzipToTemp unzip the zip entity to the system temporary directory and
 // returned the unzipped file path.
 func (f *File) unzipToTemp(zipFile *zip.File) (string, error) {
-	tmp, err := os.CreateTemp("", "excelize-")
+	tmp, err := os.CreateTemp(f.getTempDir(), "excelize-")
 	if err != nil {
 		return "", err
 	}

--- a/lib.go
+++ b/lib.go
@@ -77,17 +77,10 @@ func (f *File) ReadZipReader(r *zip.Reader) (map[string][]byte, int, error) {
 	return fileList, worksheets, nil
 }
 
-func (f *File) getTempDir() string {
-	if f.options.TmpDir != "" {
-		return f.options.TmpDir
-	}
-	return "" // return "" means use the system temporary directory
-}
-
 // unzipToTemp unzip the zip entity to the system temporary directory and
 // returned the unzipped file path.
 func (f *File) unzipToTemp(zipFile *zip.File) (string, error) {
-	tmp, err := os.CreateTemp(f.getTempDir(), "excelize-")
+	tmp, err := os.CreateTemp(f.options.TmpDir, "excelize-")
 	if err != nil {
 		return "", err
 	}

--- a/lib_test.go
+++ b/lib_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -390,51 +389,4 @@ func TestUnzipToTemp(t *testing.T) {
 
 	_, err = f.unzipToTemp(z.File[0])
 	assert.EqualError(t, err, "EOF")
-}
-
-func TestUnzipToSpecificTempDir(t *testing.T) {
-	wd, err := os.Getwd()
-	assert.NoError(t, err)
-	specificTempDir := path.Join(wd, "test")
-
-	for _, test := range []struct {
-		name    string
-		tempDir string
-	}{
-		{
-			name:    "specific temp dir",
-			tempDir: specificTempDir,
-		},
-	} {
-		file := NewFile(Options{
-			TmpDir: test.tempDir,
-		})
-		data := []byte("PK\x03\x040000000PK\x01\x0200000" +
-			"0000000000000000000\x00" +
-			"\x00\x00\x00\x00\x00000000000000PK\x01" +
-			"\x020000000000000000000" +
-			"00000\v\x00\x00\x00\x00\x00000000000" +
-			"00000000000000PK\x01\x0200" +
-			"00000000000000000000" +
-			"00\v\x00\x00\x00\x00\x00000000000000" +
-			"00000000000PK\x01\x020000<" +
-			"0\x00\x0000000000000000\v\x00\v" +
-			"\x00\x00\x00\x00\x0000000000\x00\x00\x00\x00000" +
-			"00000000PK\x01\x0200000000" +
-			"0000000000000000\v\x00\x00\x00" +
-			"\x00\x0000PK\x05\x06000000\x05\x00\xfd\x00\x00\x00" +
-			"\v\x00\x00\x00\x00\x00")
-		z, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
-		assert.NoError(t, err, fmt.Sprintf("test case: %s, new zip reader meet error, err: %v", test.name, err))
-
-		_, err = file.unzipToTemp(z.File[0])
-
-		require.Error(t, err, fmt.Sprintf("test case: %s, unzip to temp meet error, err: %v", test.name, err))
-		assert.NoError(t, os.Chmod(test.tempDir, 0o755), fmt.Sprintf("test case: %s, chmod meet error, err: %v", test.name, err))
-
-		_, err = file.unzipToTemp(z.File[0])
-		assert.EqualError(t, err, "EOF", fmt.Sprintf("test case: %s, unzip to temp meet error, err: %v", test.name, err))
-
-		assert.NoError(t, file.Close(), fmt.Sprintf("test case: %s, close file meet error, err: %v", test.name, err))
-	}
 }

--- a/rows.go
+++ b/rows.go
@@ -371,7 +371,7 @@ func (f *File) getFromStringItem(index int) string {
 		}()
 	}
 	f.sharedStringItem = [][]uint{}
-	f.sharedStringTemp, _ = os.CreateTemp("", "excelize-")
+	f.sharedStringTemp, _ = os.CreateTemp(f.getTempDir(), "excelize-")
 	f.tempFiles.Store(defaultTempFileSST, f.sharedStringTemp.Name())
 	var (
 		inElement string

--- a/rows.go
+++ b/rows.go
@@ -371,7 +371,7 @@ func (f *File) getFromStringItem(index int) string {
 		}()
 	}
 	f.sharedStringItem = [][]uint{}
-	f.sharedStringTemp, _ = os.CreateTemp(f.getTempDir(), "excelize-")
+	f.sharedStringTemp, _ = os.CreateTemp(f.options.TmpDir, "excelize-")
 	f.tempFiles.Store(defaultTempFileSST, f.sharedStringTemp.Name())
 	var (
 		inElement string

--- a/stream_test.go
+++ b/stream_test.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"math/rand"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -98,7 +97,7 @@ func TestStreamWriter(t *testing.T) {
 	assert.NoError(t, file.Close())
 
 	// Test close temporary file error
-	file = NewFile()
+	file = NewFile(Options{TmpDir: os.TempDir()})
 	streamWriter, err = file.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
 	for rowID := 10; rowID <= 25600; rowID++ {
@@ -486,91 +485,5 @@ func TestStreamWriterGetRowElement(t *testing.T) {
 		}
 		_, ok := getRowElement(token, 0)
 		assert.False(t, ok)
-	}
-}
-
-func TestSpecificTempDirStreamingWriter(t *testing.T) {
-	checkTempFileExist := func(testName, tempDir string, fileNames []string, exist bool) {
-		dirEntries, err := os.ReadDir(tempDir)
-		assert.NoError(t, err)
-
-		existFileNames := make(map[string]bool)
-		for _, dirEntry := range dirEntries {
-			if strings.HasPrefix(dirEntry.Name(), "excelize-") {
-				existFileNames[dirEntry.Name()] = true
-			}
-		}
-
-		// each file should exist or not exist
-		for _, fileName := range fileNames {
-			_, ok := existFileNames[fileName]
-			assert.Equal(t, exist, ok, fmt.Sprintf("test case: %s, file name: %v, expect: %v, actual: %v",
-				testName, fileName, exist, ok))
-		}
-	}
-
-	wd, err := os.Getwd()
-	assert.NoError(t, err)
-	specificTempDir := path.Join(wd, "test")
-
-	for _, test := range []struct {
-		name    string
-		tempDir string
-	}{
-		{
-			name:    "empty temp dir",
-			tempDir: "",
-		},
-		{
-			name:    "default temp dir",
-			tempDir: os.TempDir(),
-		},
-		{
-			name:    "specific temp dir",
-			tempDir: specificTempDir,
-		},
-	} {
-		tempDir := test.tempDir
-
-		file := NewFile(Options{
-			TmpDir: tempDir,
-		})
-
-		streamWriter, err := file.NewStreamWriter("Sheet1")
-		assert.NoError(t, err, fmt.Sprintf("test case: %s, new stream writer meet error, err: %v", test.name, err))
-
-		// enough to trigger temp file creation
-		for rowID := 10; rowID <= 51200; rowID++ {
-			row := make([]interface{}, 50)
-			for colID := 0; colID < 50; colID++ {
-				row[colID] = rand.Intn(640000)
-			}
-			cell, _ := CoordinatesToCellName(1, rowID)
-			assert.NoError(t, streamWriter.SetRow(cell, row), fmt.Sprintf("test case: %s, rowID: %d", test.name, rowID))
-		}
-
-		err = streamWriter.Flush()
-		assert.NoError(t, err, fmt.Sprintf("test case: %s, flush meet error, err: %v", test.name, err))
-
-		if tempDir == "" {
-			tempDir = os.TempDir()
-		}
-
-		var fileNames []string
-		file.tempFiles.Range(func(_, fileName any) bool {
-			fileNames = append(fileNames, fileName.(string))
-			return true
-		})
-
-		// when the temp file is not close, the temp file will not be deleted
-		checkTempFileExist(test.name, tempDir, fileNames, true)
-
-		assert.NoError(t, file.SaveAs(filepath.Join("test",
-			fmt.Sprintf("TestSpecificTempDirStreamingWriter_%s.xlsx", test.name))),
-			fmt.Sprintf("test case: %s, save meet error, err: %v", test.name, err))
-
-		assert.NoError(t, file.Close())
-		// when the temp file is close, the temp file will be deleted
-		checkTempFileExist(test.name, tempDir, fileNames, false)
 	}
 }


### PR DESCRIPTION
Change-Id: I96e24738982be893c8a52783069221b9abeff2cf

# PR Details
1. add specific temp dir option to excelize file options.
2. when writing excel using streaming writer or read excel to load data to tmp file, it will use specific temp dir or default os.TempDir() to place temp file.

## Description
Close https://github.com/qax-os/excelize/issues/2024, add temp dir file option.

## Related Issue
https://github.com/qax-os/excelize/issues/2024

## Motivation and Context
1. when we use excelize streaming writer to write excel in our production pod, we meet that /tmp mountion is small, so we need this feature to change the temp file directory.

## How Has This Been Tested
1. UT.
2. Test in our prod env.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
