### PR TITLE
This closes #2161, fix panic on read unsupported pivot table cache source types

### DIFF
--- a/chart.go
+++ b/chart.go
@@ -848,14 +848,16 @@ func (opts *Chart) parseTitle() {
 //	SecondPlotValues
 //	ShowBubbleSize
 //	ShowCatName
+//	ShowDataTable
+//	ShowDataTableKeys
 //	ShowLeaderLines
 //	ShowPercent
 //	ShowSerName
 //	ShowVal
 //	NumFmt
 //
-// SecondPlotValues: Specifies the values in second plot for the 'pieOfPie' and
-// 'barOfPie' chart.
+// SecondPlotValues: Specifies the values in second plot for the 'PieOfPie' and
+// 'BarOfPie' chart.
 //
 // ShowBubbleSize: Specifies the bubble size shall be shown in a data label. The
 // 'ShowBubbleSize' property is optional. The default value is false.

--- a/errors.go
+++ b/errors.go
@@ -328,6 +328,12 @@ func newUnsupportedChartType(chartType ChartType) error {
 	return fmt.Errorf("unsupported chart type %d", chartType)
 }
 
+// newUnsupportedPivotCacheSourceType defined the error message on receiving the
+// source type of pivot table cache.
+func newUnsupportedPivotCacheSourceType(sourceType string) error {
+	return fmt.Errorf("unsupported pivot table cache source type: %s", sourceType)
+}
+
 // newUnzipSizeLimitError defined the error message on unzip size exceeds the
 // limit.
 func newUnzipSizeLimitError(unzipSizeLimit int64) error {

--- a/excelize.go
+++ b/excelize.go
@@ -84,6 +84,9 @@ type charsetTranscoderFn func(charset string, input io.Reader) (rdr io.Reader, e
 // should be less than or equal to UnzipSizeLimit, the default value is
 // 16MB.
 //
+// TmpDir specifies the temporary directory for creating temporary files, if the
+// value is empty, the system default temporary directory will be used.
+//
 // ShortDatePattern specifies the short date number format code. In the
 // spreadsheet applications, date formats display date and time serial numbers
 // as date values. Date formats that begin with an asterisk (*) respond to
@@ -98,9 +101,6 @@ type charsetTranscoderFn func(charset string, input io.Reader) (rdr io.Reader, e
 //
 // CultureInfo specifies the country code for applying built-in language number
 // format code these effect by the system's local language settings.
-//
-// TmpDir specifies the temporary directory for creating temporary files, if the
-// value is empty, the system default temporary directory will be used.
 type Options struct {
 	MaxCalcIterations uint
 	Password          string

--- a/pivotTable.go
+++ b/pivotTable.go
@@ -781,7 +781,9 @@ func (f *File) addWorkbookPivotCache(RID int) int {
 }
 
 // GetPivotTables returns all pivot table definitions in a worksheet by given
-// worksheet name.
+// worksheet name. Currently only support get pivot table cache with worksheet
+// source type, and doesn't support source types: external, consolidation
+// and scenario.
 func (f *File) GetPivotTables(sheet string) ([]PivotTableOptions, error) {
 	var pivotTables []PivotTableOptions
 	name, ok := f.getSheetXMLPath(sheet)
@@ -867,6 +869,9 @@ func (f *File) getPivotTable(sheet, pivotTableXML, pivotCacheRels string) (Pivot
 	pt, err := f.pivotTableReader(pivotTableXML)
 	if err != nil {
 		return opts, err
+	}
+	if pc.CacheSource.WorksheetSource == nil {
+		return opts, newUnsupportedPivotCacheSourceType(pc.CacheSource.Type)
 	}
 	opts = PivotTableOptions{
 		pivotTableXML:    pivotTableXML,

--- a/pivotTable_test.go
+++ b/pivotTable_test.go
@@ -356,6 +356,13 @@ func TestPivotTable(t *testing.T) {
 	_, err = f.getPivotTables()
 	assert.EqualError(t, err, "XML syntax error on line 1: invalid UTF-8")
 	assert.NoError(t, f.Close())
+	// Test get pivot table with unsupported pivot table cache source type
+	f, err = OpenFile(filepath.Join("test", "TestAddPivotTable1.xlsx"))
+	assert.NoError(t, err)
+	f.Pkg.Store("xl/pivotCache/pivotCacheDefinition1.xml", fmt.Appendf(nil, `<pivotCacheDefinition  xmlns="%s"><cacheSource type="external" connectionId="1"/></pivotCacheDefinition>`, NameSpaceSpreadSheet.Value))
+	_, err = f.GetPivotTables("Sheet1")
+	assert.Equal(t, err, newUnsupportedPivotCacheSourceType("external"))
+	assert.NoError(t, f.Close())
 }
 
 func TestPivotTableDataRange(t *testing.T) {

--- a/rows.go
+++ b/rows.go
@@ -585,8 +585,8 @@ func (f *File) GetRowVisible(sheet string, row int) (bool, error) {
 }
 
 // SetRowOutlineLevel provides a function to set outline level number of a
-// single row by given worksheet name and Excel row number. The value of
-// parameter 'level' is 1-7. For example, outline row 2 in Sheet1 to level 1:
+// single row by given worksheet name and row number. The range of 'level' 
+// parameter value from 1 to 7. For example, outline row 2 in Sheet1 to level 1:
 //
 //	err := f.SetRowOutlineLevel("Sheet1", 2, 1)
 func (f *File) SetRowOutlineLevel(sheet string, row int, level uint8) error {

--- a/sheet.go
+++ b/sheet.go
@@ -751,7 +751,7 @@ func (f *File) getSheetRelationshipsTargetByID(sheet, rID string) string {
 //	    fmt.Println(err)
 //	    return
 //	}
-//	err := f.CopySheet(1, index)
+//	err = f.CopySheet(0, index)
 func (f *File) CopySheet(from, to int) error {
 	if from < 0 || to < 0 || from == to || f.GetSheetName(from) == "" || f.GetSheetName(to) == "" {
 		return ErrSheetIdx


### PR DESCRIPTION
# PR Details

fix panic on read unsupported pivot table cache source types

## Description

- GetPivotTables function return error on read unsupported pivot table cache source types
- Update docs for the AddChart function
- Update unit tests

## Related Issue

#2161

## Motivation and Context

fix panic on read unsupported pivot table cache source types

## How Has This Been Tested

add unit test for my changes

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
