### PR TITLE
Fix: add pivot table caused workbook corrupted on Excel for Mac

### DIFF
--- a/pivotTable.go
+++ b/pivotTable.go
@@ -372,7 +372,7 @@ func (f *File) addPivotTable(cacheID, pivotTableID int, opts *PivotTableOptions)
 			Count: 1,
 			I: []*xlsxI{
 				{
-					[]*xlsxX{{}, {}},
+					[]*xlsxX{{}},
 				},
 			},
 		},


### PR DESCRIPTION
# PR Details

This closes #2180, fix add pivot table caused workbook corrupted on Excel for Mac。

## Related Issue

#2180

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
