### PR TITLE
feat(merge): add GetMergedCellRefs to get references only

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -162,6 +162,28 @@ func (f *File) GetMergeCells(sheet string) ([]MergeCell, error) {
 	return mergeCells, err
 }
 
+// GetMergedCellRefs provides a function to get all merged cells' range
+// references from a worksheet. It is a more performant alternative to
+// GetMergeCells when only the merged cell coordinates are needed without
+// their values.
+func (f *File) GetMergedCellRefs(sheet string) ([]string, error) {
+	var mergeCells []string
+	ws, err := f.workSheetReader(sheet)
+	if err != nil {
+		return mergeCells, err
+	}
+	if ws.MergeCells != nil {
+		if err = f.mergeOverlapCells(ws); err != nil {
+			return mergeCells, err
+		}
+		for i := range ws.MergeCells.Cells {
+			ref := ws.MergeCells.Cells[i].Ref
+			mergeCells = append(mergeCells, ref)
+		}
+	}
+	return mergeCells, err
+}
+
 // overlapRange calculate overlap range of merged cells, and returns max
 // column and rows of the range.
 func overlapRange(ws *xlsxWorksheet) (row, col int, err error) {


### PR DESCRIPTION
The existing `GetMergeCells` function retrieves both the merged cell reference and its value. This requires reading cell data, which is unnecessary and less performant if the user only needs the coordinates of the merged areas.

This commit introduces a new, more efficient function `GetMergedCellRefs`. This function specifically returns only a slice of reference strings (e.g., `[]string{"A1:B2", "D4:E5"}`), avoiding the overhead of value lookups.

This provides a more lightweight and flexible API for users who work with merged cell layouts but do not need to process their content.
