### PR TITLE
Add custom ZIP writer support for WriteToBuffer function

### DIFF
--- a/excelize_test.go
+++ b/excelize_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/html/charset"
 )
 
 func TestOpenFile(t *testing.T) {
@@ -244,7 +245,7 @@ func TestSaveAsWrongPath(t *testing.T) {
 
 func TestCharsetTranscoder(t *testing.T) {
 	f := NewFile()
-	f.CharsetTranscoder(*new(charsetTranscoderFn))
+	f.CharsetTranscoder(charset.NewReaderLabel)
 }
 
 func TestOpenReader(t *testing.T) {
@@ -355,7 +356,7 @@ func TestOpenReader(t *testing.T) {
 
 func TestBrokenFile(t *testing.T) {
 	// Test write file with broken file struct
-	f := File{}
+	f := File{ZipWriter: func(w io.Writer) ZipWriter { return zip.NewWriter(w) }}
 
 	t.Run("SaveWithoutName", func(t *testing.T) {
 		assert.EqualError(t, f.Save(), "no path defined for file, consider File.WriteTo or File.Write")

--- a/file_test.go
+++ b/file_test.go
@@ -1,9 +1,11 @@
 package excelize
 
 import (
+	"archive/zip"
 	"bufio"
 	"bytes"
 	"encoding/binary"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -43,6 +45,7 @@ func TestWriteTo(t *testing.T) {
 	// Test WriteToBuffer err
 	{
 		f, buf := File{Pkg: sync.Map{}}, bytes.Buffer{}
+		f.SetZipWriter(func(w io.Writer) ZipWriter { return zip.NewWriter(w) })
 		f.Pkg.Store("/d/", []byte("s"))
 		_, err := f.WriteTo(bufio.NewWriter(&buf))
 		assert.EqualError(t, err, "zip: write to directory")
@@ -51,6 +54,7 @@ func TestWriteTo(t *testing.T) {
 	// Test file path overflow
 	{
 		f, buf := File{Pkg: sync.Map{}}, bytes.Buffer{}
+		f.SetZipWriter(func(w io.Writer) ZipWriter { return zip.NewWriter(w) })
 		const maxUint16 = 1<<16 - 1
 		f.Pkg.Store(strings.Repeat("s", maxUint16+1), nil)
 		_, err := f.WriteTo(bufio.NewWriter(&buf))
@@ -59,6 +63,7 @@ func TestWriteTo(t *testing.T) {
 	// Test StreamsWriter err
 	{
 		f, buf := File{Pkg: sync.Map{}}, bytes.Buffer{}
+		f.SetZipWriter(func(w io.Writer) ZipWriter { return zip.NewWriter(w) })
 		f.Pkg.Store("s", nil)
 		f.streams = make(map[string]*StreamWriter)
 		file, _ := os.Open("123")
@@ -69,6 +74,7 @@ func TestWriteTo(t *testing.T) {
 	// Test write with temporary file
 	{
 		f, buf := File{tempFiles: sync.Map{}}, bytes.Buffer{}
+		f.SetZipWriter(func(w io.Writer) ZipWriter { return zip.NewWriter(w) })
 		const maxUint16 = 1<<16 - 1
 		f.tempFiles.Store("s", "")
 		f.tempFiles.Store(strings.Repeat("s", maxUint16+1), "")
@@ -78,6 +84,7 @@ func TestWriteTo(t *testing.T) {
 	// Test write with unsupported workbook file format
 	{
 		f, buf := File{Pkg: sync.Map{}}, bytes.Buffer{}
+		f.SetZipWriter(func(w io.Writer) ZipWriter { return zip.NewWriter(w) })
 		f.Pkg.Store("/d", []byte("s"))
 		f.Path = "Book1.xls"
 		_, err := f.WriteTo(bufio.NewWriter(&buf))


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Added `WriteToBufferCustomZIP` method, which allows using a custom ZIP library (e.g., `github.com/klauspost/compress/zip`) for better performance while keeping the original `WriteToBuffer` method backward-compatible.

- Introduced `ZipWriter` interface to abstract standard and custom ZIP writers.  
- `WriteToBuffer` now calls `WriteToBufferCustomZIP` with the standard library `zip.NewWriter` by default.  
- `writeToZip` method updated to accept `ZipWriter` interface.  

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/qax-os/excelize/issues/2199

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

To improve in-memory write performance and support high-performance third-party ZIP libraries while maintaining compatibility with the standard library.


## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

write a benchmark test for testing performance 

```go
package excel

import (
	"archive/zip"
	"bytes"
	"fmt"
	"io"
	"testing"

	kzip "github.com/klauspost/compress/zip"

	"github.com/stretchr/testify/require"
	"github.com/xuri/excelize/v2"
)

const (
	columnNum = 10
	columnLen = 100
	rowNum    = 50000
)

var data [rowNum][columnNum]string
var columnName []string
var columnNameAny []any

func init() {
	for r := range rowNum {
		for col := range columnNum {
			data[r][col] = string(bytes.Repeat([]byte{'a'}, columnLen))
		}
	}
	for range columnNum {
		columnName = append(columnName, "name")
		columnNameAny = append(columnNameAny, "name")
	}
}

func libExcelizeStreamImpl(t testing.TB, factory func(io.Writer) excelize.ZipWriter) []byte {
	file := excelize.NewFile()
	defer file.Close()
	sw, err := file.NewStreamWriter("Sheet1")
	require.NoError(t, err)

	style := &excelize.Style{Font: &excelize.Font{
		Bold: true,
	}}
	styleId, err := file.NewStyle(style)
	require.NoError(t, err)
	err = sw.SetRow("A1", columnNameAny, excelize.RowOpts{
		StyleID: styleId,
	})
	require.NoError(t, err)

	for i := range data {
		row := fmt.Sprintf("A%d", i+2)
		err := sw.SetRow(row, []any{data[i][0], data[i][1], data[i][2],
			data[i][3], data[i][4], data[i][5], data[i][6], data[i][7], data[i][8], data[i][9]})
		require.NoError(t, err)
	}

	require.NoError(t, sw.Flush())
	// buffer, err := file.WriteToBuffer()
	buffer, err := file.WriteToBufferCustomZIP(factory)
	require.NoError(t, err)
	return buffer.Bytes()
}

func BenchmarkExcelizeStreamStd(b *testing.B) {
	for b.Loop() {
		_ = libExcelizeStreamImpl(b, func(w io.Writer) excelize.ZipWriter { return zip.NewWriter(w) })
	}
}

func BenchmarkExcelizeStreamKzip(b *testing.B) {
	for b.Loop() {
		_ = libExcelizeStreamImpl(b, func(w io.Writer) excelize.ZipWriter { return kzip.NewWriter(w) })
	}
}

```

```
Running tool: D:\soft\Go125\bin\go.exe test -benchmem -run=^$ -bench ^(BenchmarkExcelizeStreamStd|BenchmarkExcelizeStreamKzip)$ github.com/a2659802/go-example/pkg/excel -count=1

goos: windows
goarch: amd64
pkg: github.com/a2659802/go-example/pkg/excel
cpu: 12th Gen Intel(R) Core(TM) i5-12500
=== RUN   BenchmarkExcelizeStreamStd
BenchmarkExcelizeStreamStd
BenchmarkExcelizeStreamStd-12
       2         599544500 ns/op        272403848 B/op   4153804 allocs/op
=== RUN   BenchmarkExcelizeStreamKzip
BenchmarkExcelizeStreamKzip
BenchmarkExcelizeStreamKzip-12
       3         468739967 ns/op        272623032 B/op   4152989 allocs/op
PASS
ok      github.com/a2659802/go-example/pkg/excel        3.077s
```


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
