### PR TITLE
Fix string counting and truncation for cell length limitation #2205

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -14366,7 +14366,7 @@ func (fn *formulaFuncs) TEXTJOIN(argsList *list.List) formulaArg {
 		return ok
 	}
 	result := strings.Join(args, delimiter.Value())
-	if len(result) > TotalCellChars {
+	if utf16UnitCountInString(result) > TotalCellChars {
 		return newErrorFormulaArg(formulaErrorVALUE, fmt.Sprintf("TEXTJOIN function exceeds %d characters", TotalCellChars))
 	}
 	return newStringFormulaArg(result)

--- a/calc.go
+++ b/calc.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"unicode/utf16"
 	"unicode/utf8"
 	"unsafe"
 
@@ -14366,7 +14367,7 @@ func (fn *formulaFuncs) TEXTJOIN(argsList *list.List) formulaArg {
 		return ok
 	}
 	result := strings.Join(args, delimiter.Value())
-	if utf16UnitCountInString(result) > TotalCellChars {
+	if len(utf16.Encode([]rune(result))) > TotalCellChars {
 		return newErrorFormulaArg(formulaErrorVALUE, fmt.Sprintf("TEXTJOIN function exceeds %d characters", TotalCellChars))
 	}
 	return newStringFormulaArg(result)

--- a/calc_test.go
+++ b/calc_test.go
@@ -3969,6 +3969,7 @@ func TestCalcCellValue(t *testing.T) {
 		"TEXTJOIN(\"\",TRUE,NA())": {"#N/A", "#N/A"},
 		"TEXTJOIN(\"\",TRUE," + strings.Repeat("0,", 250) + ",0)": {"#VALUE!", "TEXTJOIN accepts at most 252 arguments"},
 		"TEXTJOIN(\",\",FALSE,REPT(\"*\",32768))":                 {"#VALUE!", "TEXTJOIN function exceeds 32767 characters"},
+		"TEXTJOIN(\"\",FALSE,REPT(\"😀\",16384))":                  {"#VALUE!", "TEXTJOIN function exceeds 32767 characters"},
 		// TRIM
 		"TRIM()":    {"#VALUE!", "TRIM requires 1 argument"},
 		"TRIM(1,2)": {"#VALUE!", "TRIM requires 1 argument"},

--- a/calc_test.go
+++ b/calc_test.go
@@ -3969,7 +3969,7 @@ func TestCalcCellValue(t *testing.T) {
 		"TEXTJOIN(\"\",TRUE,NA())": {"#N/A", "#N/A"},
 		"TEXTJOIN(\"\",TRUE," + strings.Repeat("0,", 250) + ",0)": {"#VALUE!", "TEXTJOIN accepts at most 252 arguments"},
 		"TEXTJOIN(\",\",FALSE,REPT(\"*\",32768))":                 {"#VALUE!", "TEXTJOIN function exceeds 32767 characters"},
-		"TEXTJOIN(\"\",FALSE,REPT(\"😀\",16384))":                  {"#VALUE!", "TEXTJOIN function exceeds 32767 characters"},
+		"TEXTJOIN(\"\",FALSE,REPT(\"\U0001F600\",16384))":         {"#VALUE!", "TEXTJOIN function exceeds 32767 characters"},
 		// TRIM
 		"TRIM()":    {"#VALUE!", "TRIM requires 1 argument"},
 		"TRIM(1,2)": {"#VALUE!", "TRIM requires 1 argument"},

--- a/cell_test.go
+++ b/cell_test.go
@@ -245,34 +245,6 @@ func TestSetCellValuesMultiByte(t *testing.T) {
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetCellValuesMultiByte.xlsx")))
 }
 
-func TestSetCellValuesSurrogatePairString(t *testing.T) {
-	f := NewFile()
-	row := []interface{}{
-		// Test set cell value with surrogate pair characters value
-		strings.Repeat("😀", TotalCellChars),
-		strings.Repeat("A", TotalCellChars-1) + "😀",
-	}
-	assert.NoError(t, f.SetSheetRow("Sheet1", "A1", &row))
-	// Test set cell value with XML escape characters in stream writer
-	_, err := f.NewSheet("Sheet2")
-	assert.NoError(t, err)
-	streamWriter, err := f.NewStreamWriter("Sheet2")
-	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.SetRow("A1", row))
-	assert.NoError(t, streamWriter.Flush())
-	for _, sheetName := range []string{"Sheet1", "Sheet2"} {
-		for cell, expected := range map[string]int{
-			"A1": TotalCellChars / 2,
-			"B1": TotalCellChars - 1,
-		} {
-			result, err := f.GetCellValue(sheetName, cell)
-			assert.NoError(t, err)
-			assert.Len(t, []rune(result), expected)
-		}
-	}
-	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetCellValuesSurrogatePairString.xlsx")))
-}
-
 func TestSetCellValue(t *testing.T) {
 	f := NewFile()
 	assert.Equal(t, newCellNameToCoordinatesError("A", newInvalidCellNameError("A")), f.SetCellValue("Sheet1", "A", time.Now().UTC()))

--- a/cell_test.go
+++ b/cell_test.go
@@ -245,6 +245,34 @@ func TestSetCellValuesMultiByte(t *testing.T) {
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetCellValuesMultiByte.xlsx")))
 }
 
+func TestSetCellValuesSurrogatePairString(t *testing.T) {
+	f := NewFile()
+	row := []interface{}{
+		// Test set cell value with surrogate pair characters value
+		strings.Repeat("😀", TotalCellChars),
+		strings.Repeat("A", TotalCellChars-1) + "😀",
+	}
+	assert.NoError(t, f.SetSheetRow("Sheet1", "A1", &row))
+	// Test set cell value with XML escape characters in stream writer
+	_, err := f.NewSheet("Sheet2")
+	assert.NoError(t, err)
+	streamWriter, err := f.NewStreamWriter("Sheet2")
+	assert.NoError(t, err)
+	assert.NoError(t, streamWriter.SetRow("A1", row))
+	assert.NoError(t, streamWriter.Flush())
+	for _, sheetName := range []string{"Sheet1", "Sheet2"} {
+		for cell, expected := range map[string]int{
+			"A1": TotalCellChars / 2,
+			"B1": TotalCellChars - 1,
+		} {
+			result, err := f.GetCellValue(sheetName, cell)
+			assert.NoError(t, err)
+			assert.Len(t, []rune(result), expected)
+		}
+	}
+	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetCellValuesSurrogatePairString.xlsx")))
+}
+
 func TestSetCellValue(t *testing.T) {
 	f := NewFile()
 	assert.Equal(t, newCellNameToCoordinatesError("A", newInvalidCellNameError("A")), f.SetCellValue("Sheet1", "A", time.Now().UTC()))

--- a/lib.go
+++ b/lib.go
@@ -941,22 +941,12 @@ func setPtrFieldsVal(fields []string, immutable, mutable reflect.Value) {
 	}
 }
 
-// utf16UnitCountInString returns the number of UTF-16 code units in a string.
-func utf16UnitCountInString(s string) int {
-	var count int
-	for _, r := range s {
-		count += utf16.RuneLen(r)
-	}
-	return count
-}
-
-// truncateUTF16Units truncates a string to a maximum number of UTF-16 code units.
-func truncateUTF16Units(s string, maxLength int) string {
-	var count int
+// truncateUTF16Units truncates a string to a maximum number of UTF-16 code
+// units.
+func truncateUTF16Units(s string, length int) string {
+	var cnt int
 	for i, r := range s {
-		count += utf16.RuneLen(r)
-		if count > maxLength {
-			// If s[maxLength-1] is a high surrogate, it is also truncated.
+		if cnt += utf16.RuneLen(r); cnt > length {
 			return s[:i]
 		}
 	}

--- a/lib.go
+++ b/lib.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode/utf16"
 )
 
 // ReadZipReader extract spreadsheet with given options.
@@ -938,6 +939,28 @@ func setPtrFieldsVal(fields []string, immutable, mutable reflect.Value) {
 		ptr.Elem().Set(immutableField)
 		mutable.FieldByName(field).Set(ptr)
 	}
+}
+
+// utf16UnitCountInString returns the number of UTF-16 code units in a string.
+func utf16UnitCountInString(s string) int {
+	var count int
+	for _, r := range s {
+		count += utf16.RuneLen(r)
+	}
+	return count
+}
+
+// truncateUTF16Units truncates a string to a maximum number of UTF-16 code units.
+func truncateUTF16Units(s string, maxLength int) string {
+	var count int
+	for i, r := range s {
+		count += utf16.RuneLen(r)
+		if count > maxLength {
+			// If s[maxLength-1] is a high surrogate, it is also truncated.
+			return s[:i]
+		}
+	}
+	return s
 }
 
 // Stack defined an abstract data type that serves as a collection of elements.

--- a/sheet.go
+++ b/sheet.go
@@ -1484,7 +1484,7 @@ func checkSheetName(name string) error {
 	if name == "" {
 		return ErrSheetNameBlank
 	}
-	if utf16UnitCountInString(name) > MaxSheetNameLength {
+	if len(utf16.Encode([]rune(name))) > MaxSheetNameLength {
 		return ErrSheetNameLength
 	}
 	if strings.HasPrefix(name, "'") || strings.HasSuffix(name, "'") {

--- a/sheet.go
+++ b/sheet.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf16"
-	"unicode/utf8"
 
 	"github.com/tiendc/go-deepcopy"
 )
@@ -1485,7 +1484,7 @@ func checkSheetName(name string) error {
 	if name == "" {
 		return ErrSheetNameBlank
 	}
-	if utf8.RuneCountInString(name) > MaxSheetNameLength {
+	if utf16UnitCountInString(name) > MaxSheetNameLength {
 		return ErrSheetNameLength
 	}
 	if strings.HasPrefix(name, "'") || strings.HasSuffix(name, "'") {

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -762,26 +762,28 @@ func TestSetSheetBackgroundFromBytes(t *testing.T) {
 }
 
 func TestCheckSheetName(t *testing.T) {
-	// Test valid sheet name
-	assert.NoError(t, checkSheetName("Sheet1"))
-	assert.NoError(t, checkSheetName("She'et1"))
-	assert.NoError(t, checkSheetName("Sheet😀😀😀😀😀😀😀😀😀😀😀😀😀")) // 5+13*2=31 UTF-16 units
-	// Test invalid sheet name, empty name
-	assert.EqualError(t, checkSheetName(""), ErrSheetNameBlank.Error())
-	// Test invalid sheet name, include :\/?*[]
-	assert.EqualError(t, checkSheetName("Sheet:"), ErrSheetNameInvalid.Error())
-	assert.EqualError(t, checkSheetName(`Sheet\`), ErrSheetNameInvalid.Error())
-	assert.EqualError(t, checkSheetName("Sheet/"), ErrSheetNameInvalid.Error())
-	assert.EqualError(t, checkSheetName("Sheet?"), ErrSheetNameInvalid.Error())
-	assert.EqualError(t, checkSheetName("Sheet*"), ErrSheetNameInvalid.Error())
-	assert.EqualError(t, checkSheetName("Sheet["), ErrSheetNameInvalid.Error())
-	assert.EqualError(t, checkSheetName("Sheet]"), ErrSheetNameInvalid.Error())
-	// Test invalid sheet name, single quotes at the front or at the end
-	assert.EqualError(t, checkSheetName("'Sheet"), ErrSheetNameSingleQuote.Error())
-	assert.EqualError(t, checkSheetName("Sheet'"), ErrSheetNameSingleQuote.Error())
-	// Test invalid sheet name, exceed max length
-	assert.EqualError(t, checkSheetName("Sheet678901234567890123456789012"), ErrSheetNameLength.Error())
-	assert.EqualError(t, checkSheetName("Sheet😀😀😀😀😀😀😀😀😀😀😀😀😀😀"), ErrSheetNameLength.Error()) // 5+14*2=33 UTF-16 units
+	for expected, name := range map[error]string{
+		// Test valid sheet name
+		nil: "Sheet1",
+		nil: "She'et1",
+		// Test invalid sheet name, empty name
+		ErrSheetNameBlank: "",
+		// Test invalid sheet name, include :\/?*[]
+		ErrSheetNameInvalid: "Sheet:",
+		ErrSheetNameInvalid: `Sheet\`,
+		ErrSheetNameInvalid: "Sheet/",
+		ErrSheetNameInvalid: "Sheet?",
+		ErrSheetNameInvalid: "Sheet*",
+		ErrSheetNameInvalid: "Sheet[",
+		ErrSheetNameInvalid: "Sheet]",
+		// Test invalid sheet name, single quotes at the front or at the end
+		ErrSheetNameSingleQuote: "'Sheet",
+		ErrSheetNameSingleQuote: "Sheet'",
+		// Test invalid sheet name, exceed max length
+		ErrSheetNameLength: "Sheet" + strings.Repeat("\U0001F600", 14),
+	} {
+		assert.Equal(t, expected, checkSheetName(name))
+	}
 }
 
 func TestSheetDimension(t *testing.T) {

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -765,6 +765,7 @@ func TestCheckSheetName(t *testing.T) {
 	// Test valid sheet name
 	assert.NoError(t, checkSheetName("Sheet1"))
 	assert.NoError(t, checkSheetName("She'et1"))
+	assert.NoError(t, checkSheetName("Sheet😀😀😀😀😀😀😀😀😀😀😀😀😀")) // 5+13*2=31 UTF-16 units
 	// Test invalid sheet name, empty name
 	assert.EqualError(t, checkSheetName(""), ErrSheetNameBlank.Error())
 	// Test invalid sheet name, include :\/?*[]
@@ -778,6 +779,9 @@ func TestCheckSheetName(t *testing.T) {
 	// Test invalid sheet name, single quotes at the front or at the end
 	assert.EqualError(t, checkSheetName("'Sheet"), ErrSheetNameSingleQuote.Error())
 	assert.EqualError(t, checkSheetName("Sheet'"), ErrSheetNameSingleQuote.Error())
+	// Test invalid sheet name, exceed max length
+	assert.EqualError(t, checkSheetName("Sheet678901234567890123456789012"), ErrSheetNameLength.Error())
+	assert.EqualError(t, checkSheetName("Sheet😀😀😀😀😀😀😀😀😀😀😀😀😀😀"), ErrSheetNameLength.Error()) // 5+14*2=33 UTF-16 units
 }
 
 func TestSheetDimension(t *testing.T) {


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->
Add UTF-16 code unit aware helpers (utf16UnitCountInString, truncateUTF16Units) and update sheet name validation to use code unit length.

## Description

<!--- Describe your changes in detail -->

This change introduces two new internal helpers:

- utf16UnitCountInString: counts UTF-16 code units (BMP runes =1, supplementary runes =2).
- truncateUTF16Units: safely truncates a string to a maximum number of UTF-16 code units without splitting surrogate pairs.

Sheet name validation (checkSheetName) now enforces the 31 unit limit using UTF-16 code units instead of plain rune count, aligning behavior with Excel’s internal UTF-16 length semantics (emoji / supplementary characters consume two units). This prevents accepting names that Excel would later reject or truncating inside a surrogate pair in downstream consumers.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/qax-os/excelize/issues/2205

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The Excel limit is effectively a UTF-16 unit, not a Unicode scalar number.
The previous length check did not properly handle strings containing surrogate pairs, resulting in problematic Excel files.
This will be fixed so that correct Excel files are output.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

- Count correctness for BMP-only strings.
- Mixed BMP + supplementary (emoji) sequences.
- Boundary where max falls exactly before / inside a surrogate pair.
- Zero and negative max cases (empty result).
- No-op when already within limit.
- Truncation preserves whole characters (no half surrogate).

Testing Environment:
Go version: go version go1.24.2 darwin/arm64
OS: macOS 15.5

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Stricter rejection of sheet names that previously slipped through when they exceeded the true UTF-16 unit limit via supplementary characters. This aligns behavior with Excel and is considered a correctness fix.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
