### PR TITLE
fixed:pivotTable extractPivotTableField function param causes reflect problem

### DIFF
--- a/pivotTable.go
+++ b/pivotTable.go
@@ -983,7 +983,7 @@ func extractPivotTableField(data string, fld *xlsxPivotField) PivotTableField {
 		ShowAll:        fld.ShowAll,
 		InsertBlankRow: fld.InsertBlankRow,
 	}
-	setPtrFieldsVal([]string{"Compact", "Name", "Outline", "DefaultSubtotal"},
+	setPtrFieldsVal([]string{"Compact", "Outline", "DefaultSubtotal"},
 		reflect.ValueOf(*fld), reflect.ValueOf(&pivotTableField).Elem())
 	return pivotTableField
 }


### PR DESCRIPTION
# PR Details

change 
setPtrFieldsVal([]string{"Compact", "Name", "Outline", "DefaultSubtotal"},reflect.ValueOf(*fld), reflect.ValueOf(&pivotTableField).Elem())
to 
setPtrFieldsVal([]string{"Compact", "Outline", "DefaultSubtotal"},reflect.ValueOf(*fld), reflect.ValueOf(&pivotTableField).Elem())

## Description

the "Name" param causes a reflect problem about pointer.

## Motivation and Context

I found this problem when I try to use slicer.

## How Has This Been Tested

I debug the source code when I met the reflect error.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
