### PR TITLE
Allow protect workbook read-only 

### DIFF
--- a/workbook.go
+++ b/workbook.go
@@ -99,6 +99,13 @@ func (f *File) ProtectWorkbook(opts *WorkbookProtectionOptions) error {
 		wb.WorkbookProtection.WorkbookHashValue = hashValue
 		wb.WorkbookProtection.WorkbookSpinCount = int(workbookProtectionSpinCount)
 	}
+	if opts.ReadOnlyRecommended {
+		if wb.FileSharing == nil {
+			wb.FileSharing = new(xlsxFileSharing)
+		}
+		wb.FileSharing.ReadOnlyRecommended = "1"
+	}
+
 	return nil
 }
 

--- a/xmlWorkbook.go
+++ b/xmlWorkbook.go
@@ -39,7 +39,7 @@ type xlsxWorkbook struct {
 	XMLName                xml.Name                 `xml:"http://schemas.openxmlformats.org/spreadsheetml/2006/main workbook"`
 	Conformance            string                   `xml:"conformance,attr,omitempty"`
 	FileVersion            *xlsxFileVersion         `xml:"fileVersion"`
-	FileSharing            *xlsxExtLst              `xml:"fileSharing"`
+	FileSharing            *xlsxFileSharing         `xml:"fileSharing"`
 	WorkbookPr             *xlsxWorkbookPr          `xml:"workbookPr"`
 	AlternateContent       *xlsxAlternateContent    `xml:"mc:AlternateContent"`
 	DecodeAlternateContent *xlsxInnerXML            `xml:"http://schemas.openxmlformats.org/markup-compatibility/2006 AlternateContent"`
@@ -104,6 +104,11 @@ type xlsxFileVersion struct {
 	LastEdited   string `xml:"lastEdited,attr,omitempty"`
 	LowestEdited string `xml:"lowestEdited,attr,omitempty"`
 	RupBuild     string `xml:"rupBuild,attr,omitempty"`
+}
+
+// xlsxFileSharing directly maps the fileSharing element.
+type xlsxFileSharing struct {
+	ReadOnlyRecommended string `xml:"readOnlyRecommended,attr"`
 }
 
 // xlsxWorkbookPr directly maps the workbookPr element from the namespace
@@ -393,8 +398,9 @@ type WorkbookPropsOptions struct {
 
 // WorkbookProtectionOptions directly maps the settings of workbook protection.
 type WorkbookProtectionOptions struct {
-	AlgorithmName string
-	Password      string
-	LockStructure bool
-	LockWindows   bool
+	AlgorithmName       string
+	Password            string
+	LockStructure       bool
+	LockWindows         bool
+	ReadOnlyRecommended bool
 }


### PR DESCRIPTION
# PR Details

Allow protect workbook read-only

## Description

Add new `ReadOnlyRecommended` field in the `WorkbookProtectionOptions` structure. 

## Related Issue

N/A

## Motivation and Context

Allow protect workbook read-only

## How Has This Been Tested

All unit tests passed.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
