### PR TITLE
Optimize VLOOKUP/HLOOKUP performance with range caching and smart truncation

### DIFF
--- a/excelize.go
+++ b/excelize.go
@@ -42,6 +42,7 @@ type File struct {
 	tempFiles        sync.Map
 	xmlAttr          sync.Map
 	calcCache        sync.Map
+	rangeCache       sync.Map
 	CalcChain        *xlsxCalcChain
 	CharsetReader    func(charset string, input io.Reader) (rdr io.Reader, err error)
 	Comments         map[string]*xlsxComments


### PR DESCRIPTION
 ## Summary

  This PR significantly improves the performance of formula calculations, especially for VLOOKUP/HLOOKUP functions with large datasets, by implementing range caching, smart full-column reference truncation, and hash-based lookups.

  ## Problem

  Current implementation has several performance bottlenecks:

  1. **No range caching**: Every VLOOKUP call re-reads the entire lookup table, even when querying the same range repeatedly
  2. **Full-column references inefficiency**: References like `$A:$B` attempt to read all 1,048,576 rows, even when only a few contain data
  3. **Linear search for exact matches**: O(n) linear search is used even when hash-based O(1) lookup would be more efficient
  4. **Redundant cellResolver calls**: Formula cells are resolved multiple times without checking the existing calcCache

  For workbooks with 10,000+ VLOOKUP formulas querying the same 1,000-row table, this results in extremely slow calculation times.

  ## Solution

  ### 1. Range Cache (Most Critical)
  - Added `rangeCache sync.Map` to `File` struct
  - Cache resolved range data with key format: `"Sheet!R1C1:R100C5"`
  - Avoid re-reading the same range multiple times

  **Files changed**: `excelize.go`, `calc.go:1758-1806`

  ### 2. Smart Full-Column Reference Truncation
  - Added `optimizeValueRange()` function to detect full-column references (ending at TotalRows)
  - Automatically truncate to the actual maximum row with data
  - Reduce reading from 1,048,576 rows to actual data rows

  **Files changed**: `calc.go:1716-1732, 1798`

  ### 3. Hash-Based Lookup for VLOOKUP/HLOOKUP
  - Added `lookupHashSearch()` function for O(1) exact match lookups
  - Use hash index when `matchMode == matchModeExact` and dataset > 100 rows/columns
  - Dramatically faster than O(n) linear search for large datasets

  **Files changed**: `calc.go:15536-15602`

  ### 4. CalcCache Check in cellResolver
  - Added calcCache check at the beginning of `cellResolver()` to avoid redundant calculations
  - Safe type assertion to prevent panics

  **Files changed**: `calc.go:1656-1662`

  ### 5. Cache Invalidation Strategy
  - Clear both `calcCache` and `rangeCache` when cell values change to ensure correctness
  - Use fine-grained clearing for formula-only changes

  **Files changed**: `cell.go:185-188, 799-800, 1376-1377`

  ## Performance Impact

  For the scenario of 10,000 VLOOKUP formulas querying a 1,000-row table:

  - **Range caching**: Saves 9,999 redundant table reads
  - **Smart truncation**: Reduces reading from 1M+ rows to actual 1K rows (~1000x reduction)
  - **Hash lookup**: O(1) vs O(n) search (~1000x faster per lookup)

  **Expected overall improvement: 100-1000x faster** for typical use cases with repeated lookups.

  ## Testing

  ✅ All existing tests pass:
  - `TestCalcCellValue` - Pass
  - `TestCalcCellValueCache` - Pass
  - `TestCalcVLOOKUP` - Pass
  - `TestCalcHLOOKUP` - Pass
  - Full test suite (44.13s) - Pass

  ## Backward Compatibility

  ✅ Fully backward compatible - all existing functionality preserved
  ✅ No breaking changes to public API
  ✅ Cache is transparent to users