### PR TITLE
Fix DeleteDataValidation to handle unordered sqref ranges

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode/utf16"
@@ -392,6 +393,12 @@ func flatSqref(sqref string) (cells map[int][][]int, err error) {
 				}
 			}
 		}
+	}
+	// Sort each column's cells by row number
+	for col := range cells {
+		sort.Slice(cells[col], func(i, j int) bool {
+			return cells[col][i][1] < cells[col][j][1]
+		})
 	}
 	return
 }


### PR DESCRIPTION
# PR Details

## Description

Fixed an issue where `DeleteDataValidation` incorrectly updates data validation ranges when the `sqref` attribute contains unordered cell ranges.

**Environment where the issue was confirmed:**

- Excel for Mac Version 16.105 (26011018)

### Problem

When copying and pasting data validation rules in Excel, the `sqref` attribute can become unsorted (e.g., `"A5:A10 A15:A20 A3:A4"` instead of `"A3:A4 A5:A10 A15:A20"`). This causes `DeleteDataValidation` to incorrectly modify the validation ranges.

### Solution

Added sorting logic to the `flatSqref` function to ensure all cell ranges are processed in the correct order, regardless of their original sequence in the `sqref` attribute.

### Changes

- Added sorting logic to the `flatSqref` function to sort cells by row number
- Added test case to verify the fix

## Related Issue

N/A

## Motivation and Context

**Why is this change required?**

Excel allows users to copy and paste data validation rules, which can result in unsorted `sqref` attributes in the underlying XML. When `DeleteDataValidation` is called on a cell within these unordered ranges, the function fails to correctly identify and remove the cell from the validation range, leading to corrupted data validation rules.

## How Has This Been Tested

Copying and pasting data validation without following row order can result in unordered `sqref` ranges in Excel.

Verified the fix by reproducing the issue with an actual Excel file and confirming the correct behavior. The `sqref` order was confirmed by inspecting the internal Excel file structure (`xl/worksheets/sheet1.xml`).

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
