### PR TITLE
Fix duplicate style creation when using default font or fill

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -1115,13 +1115,13 @@ var (
 			return xf.NumFmtID != nil && *xf.NumFmtID == numFmtID
 		},
 		"font": func(fontID int, xf xlsxXf, style *Style) bool {
-			if style.Font == nil {
+			if style.Font == nil || fontID == 0 {
 				return (xf.FontID == nil || *xf.FontID == 0) && (xf.ApplyFont == nil || !*xf.ApplyFont)
 			}
 			return xf.FontID != nil && *xf.FontID == fontID && xf.ApplyFont != nil && *xf.ApplyFont
 		},
 		"fill": func(fillID int, xf xlsxXf, style *Style) bool {
-			if style.Fill.Type == "" {
+			if style.Fill.Type == "" || fillID == 0 {
 				return (xf.FillID == nil || *xf.FillID == 0) && (xf.ApplyFill == nil || !*xf.ApplyFill)
 			}
 			return xf.FillID != nil && *xf.FillID == fillID && xf.ApplyFill != nil && *xf.ApplyFill

--- a/styles_test.go
+++ b/styles_test.go
@@ -544,6 +544,15 @@ func TestNewStyle(t *testing.T) {
 		assert.NoError(t, f.SetCellStyle("Sheet1", "A1", "A1", styleID))
 		assert.NoError(t, f.SaveAs(filepath.Join("test", "TestSetFontCharset.xlsx")))
 	})
+
+	t.Run("recreate_default_style", func(t *testing.T) {
+		f := NewFile()
+		style2, err := f.GetStyle(0) // Get the default style
+		assert.NoError(t, err)
+		styleId, err := f.NewStyle(style2) // Try to recreate the same style. Should return style ID 0
+		assert.NoError(t, err)
+		assert.Equal(t, 0, styleId)
+	})
 }
 
 func TestConditionalStyle(t *testing.T) {


### PR DESCRIPTION
# PR Details

Fixed a bug in NewStyle where styles with default font (fontID=0) or default fill (fillID=0) bypassed the deduplication check, causing duplicate styles to be created instead of reusing existing ones.
## Description

This PR fixes a bug in NewStyle where duplicate styles were created when the input style used default font (fontID=0) or default fill (fillID=0). The style deduplication logic was not properly handling these default values, causing the existence check to fail even when identical styles already existed.

Changes made:
- Updated the style comparison logic in NewStyle to properly handle fontID=0 and fillID=0 as valid default values
- Modified the deduplication check to account for styles using default font/fill properties
- Added comprehensive test cases to verify the fix
## Related Issue
Fixes #2254

## Motivation and Context
See #2254 

## How Has This Been Tested
### Test Environment
Go version: 1.24.3
OS: Ubuntu 24.04 x86_64
All existing tests pass
### New test cases added
`TestNewStyle>recreate_default_style`: Tests getting and recreating the default style (style ID 0)
## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
