### PR TITLE
fix(calc): anchor regex patterns for exact matching

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -1862,7 +1862,7 @@ func formulaCriteriaParser(exp formulaArg) *formulaCriteria {
 	if strings.Contains(val, "*") {
 		val = strings.ReplaceAll(val, "*", ".*")
 	}
-	fc.Type, fc.Condition = criteriaRegexp, newStringFormulaArg(val)
+	fc.Type, fc.Condition = criteriaRegexp, newStringFormulaArg("^"+val+"$")
 	if num := fc.Condition.ToNumber(); num.Type == ArgNumber {
 		fc.Condition = num
 	}


### PR DESCRIPTION
## Description

Fixed `formulaCriteriaParser` to anchor regex patterns with `^` and `$` when matching plain text criteria. Previously, a criteria like `"administrative"` was converted to an unanchored regex, causing `regexp.MatchString` to match any cell **containing** the substring (e.g., `"pro_administrative"`). This does not match Excel's behavior, where plain text criteria in SUMIF/COUNTIF/AVERAGEIF perform exact matches.

The one-line fix in `formulaCriteriaParser` changes:
```go
// Before
fc.Type, fc.Condition = criteriaRegexp, newStringFormulaArg(val)
// After
fc.Type, fc.Condition = criteriaRegexp, newStringFormulaArg("^"+val+"$")
```

Wildcard patterns continue to work correctly since `?` → `.` and `*` → `.*` compose properly with the anchors (e.g., `"*admin*"` becomes `^.*admin.*$`).

## Motivation and Context

When using a formula like `=SUMIF(B:B,"administrative",E:E)` on a sheet containing categories like `"pro_administrative"` and `"non_administrative"`, those rows were incorrectly included in the sum. This caused double-counting, which does not happen in Excel.

All functions using `formulaCriteriaParser` were affected: SUMIF, SUMIFS, COUNTIF, COUNTIFS, AVERAGEIF, AVERAGEIFS, MATCH, XLOOKUP/XMATCH, and the database functions (DSUM, DAVERAGE, DCOUNT, etc.).

## How Has This Been Tested

- Added `TestCalcSUMIFExactMatch` with a dedicated test covering:
  - Exact text match does not match substrings (`"administrative"` only matches exact cells)
  - Wildcard `*...*` still matches substrings
  - Wildcard at start/end only matches the correct positions
  - Single-char wildcard `?` works correctly
  - COUNTIF exact and wildcard matching
- Verified against an`.xlsx` file with `SUMIF` formulas in Excel
- Confirmed before/after behavior: the bug produced incorrect values, the fix produces values matching Excel
- All existing tests pass (`TestCalcCellValue`, `TestCalcSUMIFSAndAVERAGEIFS`, `TestCalcAVERAGEIF`, etc.)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.