### PR TITLE
fix: prevent panic on invalid row reference in CalcCellValue

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -1542,7 +1542,7 @@ func parseRef(ref string) (cellRef, bool, bool, error) {
 		}
 		if cr.Row, rowErr = strconv.Atoi(cell); rowErr == nil { // cast to row
 			if cr.Row < 1 || cr.Row > TotalRows {
-				return cr, false, false, fmt.Errorf("invalid row number %q", cell)
+				return cr, false, false, err
 			}
 			return cr, false, true, nil
 		}
@@ -1780,7 +1780,7 @@ func (f *File) rangeResolver(ctx *calcContext, cellRefs, cellRanges *list.List) 
 
 		for row := valueRange[0]; row <= valueRange[1]; row++ {
 			colMax := 0
-			if row >= 1 && row <= len(ws.SheetData.Row) {
+			if 0 < row && row <= len(ws.SheetData.Row) {
 				rowData := &ws.SheetData.Row[row-1]
 				colMax = min(valueRange[3], len(rowData.C))
 			}

--- a/calc_test.go
+++ b/calc_test.go
@@ -2908,6 +2908,8 @@ func TestCalcCellValue(t *testing.T) {
 		"SUM(1/)":           {ErrInvalidFormula.Error(), ErrInvalidFormula.Error()},
 		"SUM(1*SUM(1/0))":   {"#DIV/0!", "#DIV/0!"},
 		"SUM(1*SUM(1/0)*1)": {"", "#DIV/0!"},
+		"SUM(0:2)":          {"#NAME?", "invalid reference"},
+		"SUM(1:1048577)":    {"#NAME?", "invalid reference"},
 		// SUMIF
 		"SUMIF()": {"#VALUE!", "SUMIF requires at least 2 arguments"},
 		// SUMSQ


### PR DESCRIPTION
# PR Details

Prevent `index out of range [-1]` panic in `CalcCellValue` when a formula contains an invalid row reference such as `ROW($0:$9)`.

## Description

- In `parseRef`: reject row numbers less than 1, returning an error instead of proceeding with an invalid value.
- In `rangeResolver`: add a bounds check (`row >= 1`) before accessing `ws.SheetData.Row[row-1]` .

## Related Issue

Fixes #2263 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->
Refer to #2263

Before：
<img width="1093" height="422" alt="image" src="https://github.com/user-attachments/assets/a8a775c2-cd41-4947-abce-42215e6576fa" />
After:
<img width="545" height="54" alt="image" src="https://github.com/user-attachments/assets/0b5463fb-c763-4f50-9deb-e1eb5133164b" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
