### PR TITLE
fix(comment): assign correct authorID in addComment when author already exists

### DIFF
--- a/vml.go
+++ b/vml.go
@@ -282,9 +282,11 @@ func (f *File) addComment(commentsXML string, opts vmlOptions) error {
 	if inStrSlice(cmts.cells, opts.Comment.Cell, true) != -1 {
 		return newAddCommentError(opts.Comment.Cell)
 	}
-	if inStrSlice(cmts.Authors.Author, opts.Author, true) == -1 {
+	if idx := inStrSlice(cmts.Authors.Author, opts.Author, true); idx == -1 {
 		cmts.Authors.Author = append(cmts.Authors.Author, opts.Author)
 		authorID = len(cmts.Authors.Author) - 1
+	} else {
+		authorID = idx
 	}
 	defaultFont, err := f.GetDefaultFont()
 	if err != nil {

--- a/vml_test.go
+++ b/vml_test.go
@@ -83,6 +83,30 @@ func TestAddComment(t *testing.T) {
 	assert.EqualError(t, err, "sheet SheetN does not exist")
 }
 
+func TestAddCommentExistingAuthorID(t *testing.T) {
+	// Regression: AddComment defaulted authorID to 0 when the author already
+	// existed in the list, misattributing comments to whichever author was at
+	// index 0 instead of the correct one.
+	f := NewFile()
+
+	assert.NoError(t, f.AddComment("Sheet1", Comment{Cell: "A1", Author: "ExistingUser", Paragraph: []RichTextRun{{Text: "pre-existing"}}}))
+	assert.NoError(t, f.AddComment("Sheet1", Comment{Cell: "B1", Author: "Agent", Paragraph: []RichTextRun{{Text: "first"}}}))
+	assert.NoError(t, f.AddComment("Sheet1", Comment{Cell: "C1", Author: "Agent", Paragraph: []RichTextRun{{Text: "second"}}}))
+	assert.NoError(t, f.AddComment("Sheet1", Comment{Cell: "D1", Author: "Agent", Paragraph: []RichTextRun{{Text: "third"}}}))
+
+	comments, err := f.GetComments("Sheet1")
+	assert.NoError(t, err)
+	assert.Len(t, comments, 4)
+
+	for _, c := range comments {
+		if c.Cell == "A1" {
+			assert.Equal(t, "ExistingUser", c.Author)
+		} else {
+			assert.Equal(t, "Agent", c.Author, "cell %s should have author Agent, got %s", c.Cell, c.Author)
+		}
+	}
+}
+
 func TestDeleteComment(t *testing.T) {
 	f, err := prepareTestBook1()
 	if !assert.NoError(t, err) {


### PR DESCRIPTION
# PR Details

## Description

`addComment()` in `vml.go` has a bug where `authorID` defaults to `0` when the author already exists in the comment authors list. only the first `AddComment` call for a new author correctly creates the author entry and assigns the right index. all subsequent calls with the same author skip the append but never set `authorID` to the found index — it stays at its zero-value `0`.

the fix stores the return value of `inStrSlice` and uses it as `authorID` in the `else` branch:

```go
// before
var authorID int
if inStrSlice(cmts.Authors.Author, opts.Author, true) == -1 {
    cmts.Authors.Author = append(cmts.Authors.Author, opts.Author)
    authorID = len(cmts.Authors.Author) - 1
}

// after
var authorID int
if idx := inStrSlice(cmts.Authors.Author, opts.Author, true); idx == -1 {
    cmts.Authors.Author = append(cmts.Authors.Author, opts.Author)
    authorID = len(cmts.Authors.Author) - 1
} else {
    authorID = idx
}
```

## Related Issue

Closes #2289

## Motivation and Context

when a workbook already contains comments from other authors (e.g. threaded comments created by Excel), every new comment written by a second author gets silently attributed to index 0 instead. in practice this turns yellow sticky-note comments into threaded discussion comments (because the author at index 0 may be a `tc={GUID}` threaded-comment author), which changes their behavior and length limits in Excel.

## How Has This Been Tested

- added `TestAddCommentExistingAuthorID` regression test
  - creates a comment with author "ExistingUser" (authorId=0)
  - adds 3 comments with author "Agent"
  - asserts all 3 "Agent" comments have `Author == "Agent"`, not "ExistingUser"
- confirmed the test **fails** on `v2.10.0` (C1 and D1 get "ExistingUser") and **passes** with this fix
- all existing tests pass (`go test ./...`)

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
