### PR TITLE
Fix worksheet dimension after cell writes

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -2104,6 +2104,45 @@ func (ws *xlsxWorksheet) prepareSheetXML(col, row int) {
 	}
 	rowData := &ws.SheetData.Row[row-1]
 	fillColumns(rowData, col, row)
+	ws.expandSheetDimension(col, row)
+}
+
+func (ws *xlsxWorksheet) expandSheetDimension(col, row int) {
+	if col < 1 || row < 1 {
+		return
+	}
+	cell, err := CoordinatesToCellName(col, row)
+	if err != nil {
+		return
+	}
+	if ws.Dimension == nil || ws.Dimension.Ref == "" {
+		ws.Dimension = &xlsxDimension{Ref: cell}
+		return
+	}
+	coordinates, err := rangeRefToCoordinates(ws.Dimension.Ref)
+	if err != nil {
+		ws.Dimension = &xlsxDimension{Ref: cell}
+		return
+	}
+	_ = sortCoordinates(coordinates)
+	if col < coordinates[0] {
+		coordinates[0] = col
+	}
+	if row < coordinates[1] {
+		coordinates[1] = row
+	}
+	if col > coordinates[2] {
+		coordinates[2] = col
+	}
+	if row > coordinates[3] {
+		coordinates[3] = row
+	}
+	ref, err := coordinatesToRangeRef(coordinates)
+	if err != nil {
+		ws.Dimension = &xlsxDimension{Ref: cell}
+		return
+	}
+	ws.Dimension = &xlsxDimension{Ref: ref}
 }
 
 // fillColumns fill cells in the column of the row as contiguous.

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -513,13 +513,14 @@ func TestWorksheetWriter(t *testing.T) {
 	// Test set cell value with alternate content
 	f.Sheet.Delete("xl/worksheets/sheet1.xml")
 	worksheet := xml.Header + `<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheetData><row r="1"><c r="A1"><v>%d</v></c></row></sheetData><mc:AlternateContent xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"><mc:Choice xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main" Requires="a14"><xdr:twoCellAnchor editAs="oneCell"></xdr:twoCellAnchor></mc:Choice><mc:Fallback/></mc:AlternateContent></worksheet>`
+	updatedWorksheet := xml.Header + `<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><dimension ref="A1"></dimension><sheetData><row r="1"><c r="A1"><v>%d</v></c></row></sheetData><mc:AlternateContent xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"><mc:Choice xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main" Requires="a14"><xdr:twoCellAnchor editAs="oneCell"></xdr:twoCellAnchor></mc:Choice><mc:Fallback/></mc:AlternateContent></worksheet>`
 	f.Pkg.Store("xl/worksheets/sheet1.xml", []byte(fmt.Sprintf(worksheet, 1)))
 	f.checked = sync.Map{}
 	assert.NoError(t, f.SetCellValue("Sheet1", "A1", 2))
 	f.workSheetWriter()
 	value, ok := f.Pkg.Load("xl/worksheets/sheet1.xml")
 	assert.True(t, ok)
-	assert.Equal(t, fmt.Sprintf(worksheet, 2), string(value.([]byte)))
+	assert.Equal(t, fmt.Sprintf(updatedWorksheet, 2), string(value.([]byte)))
 }
 
 func TestGetWorkbookPath(t *testing.T) {
@@ -839,6 +840,31 @@ func TestSheetDimension(t *testing.T) {
 	dimension, err = f.GetSheetDimension("")
 	assert.Empty(t, dimension)
 	assert.Equal(t, err, ErrSheetNameBlank)
+
+	f = NewFile()
+	assert.NoError(t, f.SetCellValue(sheetName, "C5", "value"))
+	dimension, err = f.GetSheetDimension(sheetName)
+	assert.NoError(t, err)
+	assert.Equal(t, "C5", dimension)
+
+	filePath := filepath.Join(t.TempDir(), "sheet-dimension.xlsx")
+	assert.NoError(t, f.SaveAs(filePath))
+	assert.NoError(t, f.Close())
+
+	f, err = OpenFile(filePath)
+	assert.NoError(t, err)
+	dimension, err = f.GetSheetDimension(sheetName)
+	assert.NoError(t, err)
+	assert.Equal(t, "C5", dimension)
+	assert.NoError(t, f.Close())
+
+	f = NewFile()
+	assert.NoError(t, f.SetSheetDimension(sheetName, "B2:E61"))
+	assert.NoError(t, f.SetCellValue(sheetName, "G64", "value"))
+	dimension, err = f.GetSheetDimension(sheetName)
+	assert.NoError(t, err)
+	assert.Equal(t, "B2:G64", dimension)
+	assert.NoError(t, f.Close())
 
 	// Test get the worksheet dimension with in mode
 	f, err = OpenFile(filepath.Join("test", "Book1.xlsx"), Options{UnzipXMLSizeLimit: 128})


### PR DESCRIPTION
## Summary

This change keeps worksheet `<dimension>` metadata in sync when cell writes expand the used range.

Today the cell-writing paths grow `SheetData`, but they do not update `ws.Dimension`. As a result, the serialized worksheet can keep an old `<dimension ref="...">` even after writing cells outside that range.

A simple repro before this change:

```go
f := excelize.NewFile()
_ = f.SetCellValue("Sheet1", "C5", "value")
_ = f.SaveAs("out.xlsx")
```

The saved worksheet still reports `A1` as its dimension instead of `C5`.

The same problem shows up for existing workbooks too. If a worksheet starts with `B2:E61` and a write lands at `G64`, the saved worksheet still reports `B2:E61`.

Some readers and validators trust worksheet dimensions as the authoritative used range. When that metadata stays stale, the sheet can be interpreted as truncated, and stricter consumers may treat the workbook as inconsistent.

## Root Cause

All of the common cell write paths eventually call `prepareSheetXML(col, row)` so that the target row and cell nodes exist before writing.

`prepareSheetXML` currently:
- appends missing rows
- fills contiguous cells in the target row

But it does **not** expand `ws.Dimension`.

That means the actual worksheet data grows while the dimension element remains frozen at its previous value.

## Fix

This patch adds `expandSheetDimension(col, row)` and calls it from `prepareSheetXML`.

Behavior:
- no-op for row-only / column-only preparation (`col < 1` or `row < 1`)
- initializes the dimension when it is missing
- expands an existing range to include the written cell
- preserves non-`A1` starting bounds when the worksheet already has a non-default used range
- falls back safely if the current stored dimension cannot be parsed

This keeps dimension updates centralized in the same helper that already owns worksheet growth, so all cell-writing APIs benefit without duplicating logic.

## Tests

The change adds coverage for the two cases above:
- writing `C5` in a new workbook updates the worksheet dimension to `C5`
- writing `G64` to a sheet whose dimension is `B2:E61` updates it to `B2:G64`

It also updates `TestWorksheetWriter` to reflect that a worksheet modified through `SetCellValue` now serializes with a maintained `<dimension>` element.

## Validation

I validated this in three ways:
- focused unit coverage for worksheet dimension behavior
- full `go test ./...`
- manual reproduction on existing `.xlsx` files where writes outside the prior used range previously left stale dimensions in the saved XML

## Compatibility Notes

This does not change how cell values are written. It only keeps the worksheet metadata aligned with the cells that were actually prepared and written.

For new workbooks, the resulting dimension is the exact used range (`C5`, not `A1:C5`) which matches the worksheet's real populated bounds.
