### PR TITLE
Fix nil pointer panic in getOptions when File.options is nil and no opts are passed

### DIFF
--- a/col.go
+++ b/col.go
@@ -214,8 +214,7 @@ func (f *File) Cols(sheet string) (*Cols, error) {
 		output, _ := xml.Marshal(ws)
 		f.saveFileList(name, f.replaceNameSpaceBytes(name, output))
 	}
-	var colIterator columnXMLIterator
-	colIterator.cols.sheetXML = f.readBytes(name)
+	colIterator := columnXMLIterator{cols: Cols{f: f, sheetXML: f.readBytes(name)}}
 	decoder := f.xmlNewDecoder(bytes.NewReader(colIterator.cols.sheetXML))
 	for {
 		token, _ := decoder.Token()
@@ -230,7 +229,6 @@ func (f *File) Cols(sheet string) (*Cols, error) {
 			}
 		case xml.EndElement:
 			if xmlElement.Name.Local == "sheetData" {
-				colIterator.cols.f = f
 				colIterator.cols.sheet = sheet
 				return &colIterator.cols, nil
 			}

--- a/col_test.go
+++ b/col_test.go
@@ -164,6 +164,38 @@ func TestGetColsError(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestColsIteratorRetainsFilePointer(t *testing.T) {
+	// Regression for #2299: when worksheet XML is truncated before the
+	// </sheetData> close element, the SAX loop in Cols falls through to
+	// the final return. Prior to #2300 the *File pointer was only wired
+	// into the iterator inside the sheetData EndElement branch, so this
+	// path returned a Cols whose f field was nil, and a subsequent
+	// Cols.Rows call would nil-dereference on cols.f.getOptions. Make
+	// sure the iterator carries a live *File regardless of where the
+	// parse exits.
+	f := NewFile()
+	f.Sheet.Delete("xl/worksheets/sheet1.xml")
+	// Missing </sheetData> and </worksheet> close tags simulate the
+	// truncation seen by the fuzzer in #2299.
+	f.Pkg.Store("xl/worksheets/sheet1.xml", []byte(fmt.Sprintf(
+		`<worksheet xmlns="%s"><sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>v</t></is></c></row>`,
+		NameSpaceSpreadSheet.Value)))
+	f.checked = sync.Map{}
+
+	cols, err := f.Cols("Sheet1")
+	require.NoError(t, err)
+	require.NotNil(t, cols)
+	assert.NotNil(t, cols.f, "cols.f must be set even when sheetData close element is missing")
+
+	// Walking the iterator must not panic, even though the XML is truncated.
+	assert.NotPanics(t, func() {
+		for cols.Next() {
+			_, _ = cols.Rows()
+		}
+	})
+	assert.NoError(t, f.Close())
+}
+
 func TestColsRows(t *testing.T) {
 	f := NewFile()
 

--- a/col_test.go
+++ b/col_test.go
@@ -86,6 +86,24 @@ func TestCols(t *testing.T) {
 	f.Pkg.Store("xl/worksheets/sheet1.xml", []byte(`<worksheet><sheetData><row r="2"><c r="A" t="inlineStr"><is><t>B</t></is></c></row></sheetData></worksheet>`))
 	_, err = f.Cols("Sheet1")
 	assert.EqualError(t, err, newCellNameToCoordinatesError("A", newInvalidCellNameError("A")).Error())
+
+	t.Run("with_invalid_worksheet_xml", func(t *testing.T) {
+		f := NewFile()
+		f.Sheet.Delete("xl/worksheets/sheet1.xml")
+		f.Pkg.Store("xl/worksheets/sheet1.xml", []byte(`<worksheet><sheetData><row r="1"><c r="A1"><v>1</v></c></row><row r="2"><c r="A"2><v>2</v></c></row></sheetData></worksheet>`))
+		cols, err := f.Cols("Sheet1")
+		assert.NoError(t, err)
+		cnt := 0
+		row := []string{}
+		for cols.Next() {
+			cnt++
+			row, err = cols.Rows()
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, 1, cnt)
+		assert.Equal(t, []string{"1"}, row)
+		assert.NoError(t, f.Close())
+	})
 }
 
 func TestColumnsIterator(t *testing.T) {
@@ -162,38 +180,6 @@ func TestGetColsError(t *testing.T) {
 	f.Sheet.Store("xl/worksheets/sheet1.xml", nil)
 	_, err = f.Cols("Sheet1")
 	assert.NoError(t, err)
-}
-
-func TestColsIteratorRetainsFilePointer(t *testing.T) {
-	// Regression for #2299: when worksheet XML is truncated before the
-	// </sheetData> close element, the SAX loop in Cols falls through to
-	// the final return. Prior to #2300 the *File pointer was only wired
-	// into the iterator inside the sheetData EndElement branch, so this
-	// path returned a Cols whose f field was nil, and a subsequent
-	// Cols.Rows call would nil-dereference on cols.f.getOptions. Make
-	// sure the iterator carries a live *File regardless of where the
-	// parse exits.
-	f := NewFile()
-	f.Sheet.Delete("xl/worksheets/sheet1.xml")
-	// Missing </sheetData> and </worksheet> close tags simulate the
-	// truncation seen by the fuzzer in #2299.
-	f.Pkg.Store("xl/worksheets/sheet1.xml", []byte(fmt.Sprintf(
-		`<worksheet xmlns="%s"><sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>v</t></is></c></row>`,
-		NameSpaceSpreadSheet.Value)))
-	f.checked = sync.Map{}
-
-	cols, err := f.Cols("Sheet1")
-	require.NoError(t, err)
-	require.NotNil(t, cols)
-	assert.NotNil(t, cols.f, "cols.f must be set even when sheetData close element is missing")
-
-	// Walking the iterator must not panic, even though the XML is truncated.
-	assert.NotPanics(t, func() {
-		for cols.Next() {
-			_, _ = cols.Rows()
-		}
-	})
-	assert.NoError(t, f.Close())
 }
 
 func TestColsRows(t *testing.T) {


### PR DESCRIPTION
## What

`getOptions` returned `File.options` verbatim when the caller didn't override with explicit opts. On the `OpenReader` path, `File.options` is populated via the same function:

```go
f := newFile()
f.options = f.getOptions(opts...)
```

So when `OpenReader` is invoked with no opts, `getOptions` sees the zero-value `f.options` (`nil`), returns `nil`, and `f.options` stays `nil` for the lifetime of the `*File`. Later readers — `(*Cols).Rows` at `col.go:94`:

```go
cols.rawCellValue = cols.f.getOptions(opts...).RawCellValue
```

then nil-deref:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/xuri/excelize/v2.(*File).getOptions(...)
    excelize.go:238
github.com/xuri/excelize/v2.(*Cols).Rows(0xc001320d30, ...)
    col.go:94
```

This is reachable by feeding fuzz-generated XLSX data into `OpenReader` (the reporter in #2299 triggers it with Go's built-in fuzzer), which makes it a crash-on-untrusted-input for any service that parses user-supplied spreadsheets.

## Fix

Anchor `getOptions` to a fresh empty `*Options` when `f.options` is `nil` so its callers always get a safe pointer back. Explicit `opts` still override the resulting pointer as before:

```go
func (f *File) getOptions(opts ...Options) *Options {
    options := f.options
    if options == nil {
        options = &Options{}
    }
    for _, opt := range opts {
        options = &opt
    }
    return options
}
```

## Test plan

- Repro on `master` using the reporter's Go program and the attached `fuzzInput.xlsx` in #2299: `(*Cols).Rows` panics inside `getOptions`.
- Apply patch: same program returns the ORM-level error (`Rows error:`) for any invalid sheet instead of crashing, matching the documented "return an error" contract for `Rows()`. No explicit-opts path changes behaviour.

Fixes #2299