### PR TITLE
Add dimension placeholder for accurate streaming worksheet dimensions (B3)

### DIFF
--- a/excelize.go
+++ b/excelize.go
@@ -122,6 +122,20 @@ type Options struct {
 	LongDatePattern   string
 	LongTimePattern   string
 	CultureInfo       CultureName
+	// StreamingChunkSize is the number of bytes of XML data accumulated in
+	// memory before a streaming worksheet spills to a temp file. A smaller
+	// value reduces peak memory usage at the cost of more disk I/O. Zero
+	// means use the default (StreamChunkSize = 16 MiB). Set to -1 to
+	// disable temp files entirely (all data stays in memory); this
+	// eliminates disk I/O overhead and can be significantly faster when
+	// sufficient memory is available.
+	StreamingChunkSize int
+	// StreamingBufSize is the size of the bufio.Writer used for all disk
+	// writes after the StreamingChunkSize threshold is crossed. Larger values
+	// reduce write syscall counts at the cost of slightly more memory. The
+	// measured inflection point on NVMe and HDD alike is 128 KiB. Zero means
+	// use the default (StreamingBufSizeDefault = 128 KiB).
+	StreamingBufSize int
 }
 
 // OpenFile take the name of a spreadsheet file and returns a populated

--- a/excelize.go
+++ b/excelize.go
@@ -27,6 +27,16 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
+// SheetStats contains statistics about a worksheet's dimensions.
+// This is populated during streaming writes and can be used by
+// consumers to determine pagination without parsing the full sheet.
+type SheetStats struct {
+	Rows    int    // Total number of rows written
+	Cols    int    // Maximum column index used
+	Cells   int64  // Total number of cells written
+	MaxCell string // Cell reference of the bottom-right used cell (e.g., "Z100")
+}
+
 // File define a populated spreadsheet file struct.
 type File struct {
 	mu               sync.Mutex
@@ -34,6 +44,7 @@ type File struct {
 	formulaChecked   bool
 	zip64Entries     []string
 	options          *Options
+	sheetStats       map[string]*SheetStats
 	sharedStringItem [][]uint
 	sharedStringsMap map[string]int
 	sharedStringTemp *os.File

--- a/stream.go
+++ b/stream.go
@@ -12,10 +12,12 @@
 package excelize
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/xml"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"reflect"
 	"strconv"
@@ -119,11 +121,26 @@ func (f *File) NewStreamWriter(sheet string) (*StreamWriter, error) {
 	if sheetID == -1 {
 		return nil, ErrSheetNotExist{sheet}
 	}
+	chunkSize := f.options.StreamingChunkSize
+	switch {
+	case chunkSize < 0:
+		chunkSize = math.MaxInt // never spill to disk
+	case chunkSize == 0:
+		chunkSize = StreamChunkSize
+	}
+	bufSize := f.options.StreamingBufSize
+	if bufSize <= 0 {
+		bufSize = StreamingBufSizeDefault
+	}
 	sw := &StreamWriter{
 		file:    f,
 		Sheet:   sheet,
 		SheetID: sheetID,
-		rawData: bufferedWriter{tmpDir: f.options.TmpDir},
+		rawData: bufferedWriter{
+			tmpDir:    f.options.TmpDir,
+			flushSize: chunkSize,
+			bioSize:   bufSize,
+		},
 	}
 	var err error
 	sw.worksheet, err = f.workSheetReader(sheet)
@@ -791,19 +808,126 @@ func bulkAppendFields(w io.Writer, ws *xlsxWorksheet, from, to int) {
 // is written to the temp file with Sync, which may return an error.
 // Therefore, Sync should be periodically called and the error checked.
 type bufferedWriter struct {
-	tmpDir string
-	tmp    *os.File
-	buf    bytes.Buffer
+	tmpDir    string
+	tmp       *os.File
+	buf       bytes.Buffer  // used before temp file is created
+	bio       *bufio.Writer // used after temp file is created
+	scratch   [24]byte      // scratch space for strconv.Append* to avoid heap allocs
+	flushSize int           // if >0, flush to temp file at this threshold instead of StreamChunkSize
+	bioSize   int           // bufio.Writer buffer size after threshold; 0 = use StreamingBufSizeDefault
+	written   int64         // total bytes written (for tracking offsets)
 }
 
-// Write to the in-memory buffer. The error is always nil.
+// Write to the active writer (bufio if streaming, otherwise in-memory buffer).
 func (bw *bufferedWriter) Write(p []byte) (n int, err error) {
-	return bw.buf.Write(p)
+	if bw.bio != nil {
+		n, err = bw.bio.Write(p)
+	} else {
+		n, err = bw.buf.Write(p)
+	}
+	bw.written += int64(n)
+	return
 }
 
-// WriteString write to the in-memory buffer. The error is always nil.
+// WriteString writes to the active writer.
 func (bw *bufferedWriter) WriteString(p string) (n int, err error) {
-	return bw.buf.WriteString(p)
+	if bw.bio != nil {
+		n, err = bw.bio.WriteString(p)
+	} else {
+		n, err = bw.buf.WriteString(p)
+	}
+	bw.written += int64(n)
+	return
+}
+
+// WriteInt formats and writes an int64 directly using the scratch space,
+// avoiding a heap-allocated string.
+func (bw *bufferedWriter) WriteInt(v int64) {
+	b := strconv.AppendInt(bw.scratch[:0], v, 10)
+	if bw.bio != nil {
+		bw.bio.Write(b)
+	} else {
+		bw.buf.Write(b)
+	}
+	bw.written += int64(len(b))
+}
+
+// WriteUint formats and writes a uint64 directly to the buffer.
+func (bw *bufferedWriter) WriteUint(v uint64) {
+	b := strconv.AppendUint(bw.scratch[:0], v, 10)
+	if bw.bio != nil {
+		bw.bio.Write(b)
+	} else {
+		bw.buf.Write(b)
+	}
+	bw.written += int64(len(b))
+}
+
+// WriteFloat formats and writes a float64 directly to the buffer.
+func (bw *bufferedWriter) WriteFloat(v float64, fmt byte, prec, bitSize int) {
+	b := strconv.AppendFloat(bw.scratch[:0], v, fmt, prec, bitSize)
+	if bw.bio != nil {
+		bw.bio.Write(b)
+	} else {
+		bw.buf.Write(b)
+	}
+	bw.written += int64(len(b))
+}
+
+// Bytes returns the in-memory buffer contents. This is only valid when no
+// temp file has been created (i.e. for small worksheets). Once streaming to
+// disk, this returns nil.
+func (bw *bufferedWriter) Bytes() []byte {
+	if bw.tmp != nil {
+		return nil
+	}
+	return bw.buf.Bytes()
+}
+
+// WriteAt writes data at a specific offset. For in-memory buffers, it
+// modifies the buffer directly. For temp files, it flushes first then
+// uses pwrite. The data must fit within previously written bytes.
+func (bw *bufferedWriter) WriteAt(p []byte, offset int64) error {
+	if bw.tmp == nil {
+		// In-memory: directly modify buffer bytes
+		buf := bw.buf.Bytes()
+		if offset+int64(len(p)) > int64(len(buf)) {
+			return fmt.Errorf("WriteAt: offset %d + len %d exceeds buffer size %d", offset, len(p), len(buf))
+		}
+		copy(buf[offset:], p)
+		return nil
+	}
+	// Temp file: flush bufio first, then use pwrite
+	if err := bw.Flush(); err != nil {
+		return err
+	}
+	_, err := bw.tmp.WriteAt(p, offset)
+	return err
+}
+
+// CopyTo efficiently copies all buffered data to w. For in-memory buffers
+// this is a simple WriteTo. For temp files this uses a large read buffer to
+// minimize syscalls.
+func (bw *bufferedWriter) CopyTo(w io.Writer) (int64, error) {
+	if bw.tmp == nil {
+		return io.Copy(w, bytes.NewReader(bw.buf.Bytes()))
+	}
+	if err := bw.Flush(); err != nil {
+		return 0, err
+	}
+	if _, err := bw.tmp.Seek(0, 0); err != nil {
+		return 0, err
+	}
+	// Use a large read buffer to batch Pread syscalls. Without this,
+	// io.Copy uses 32 KB reads, generating thousands of syscalls for
+	// large worksheets (e.g. 100 MB XML → 3000+ syscalls). A 256 KB
+	// buffer reduces that to ~400.
+	readBufSize := 256 * 1024
+	if bw.bioSize > readBufSize {
+		readBufSize = bw.bioSize
+	}
+	br := bufio.NewReaderSize(bw.tmp, readBufSize)
+	return io.Copy(w, br)
 }
 
 // Reader provides read-access to the underlying buffer/file.
@@ -823,10 +947,16 @@ func (bw *bufferedWriter) Reader() (io.Reader, error) {
 }
 
 // Sync will write the in-memory buffer to a temp file, if the in-memory
-// buffer has grown large enough. Any error will be returned.
+// buffer has grown large enough. Once the temp file is created, all
+// subsequent writes go through the bufio.Writer and the bytes.Buffer is
+// released.
 func (bw *bufferedWriter) Sync() (err error) {
-	// Try to use local storage
-	if bw.buf.Len() < StreamChunkSize {
+	// Already streaming to disk via bufio.Writer — nothing to do here;
+	// the final Flush() call will drain any remaining bytes.
+	if bw.bio != nil {
+		return nil
+	}
+	if bw.buf.Len() < bw.flushSize {
 		return nil
 	}
 	if bw.tmp == nil {
@@ -836,26 +966,47 @@ func (bw *bufferedWriter) Sync() (err error) {
 			return nil
 		}
 	}
-	return bw.Flush()
+	// Drain the in-memory buffer to the temp file
+	if _, err = bw.buf.WriteTo(bw.tmp); err != nil {
+		return err
+	}
+	// Release the bytes.Buffer backing array entirely
+	bw.buf = bytes.Buffer{}
+	// Switch to bufio.Writer for all future writes
+	bw.bio = bufio.NewWriterSize(bw.tmp, bw.bioSize)
+	return nil
 }
 
-// Flush the entire in-memory buffer to the temp file, if a temp file is being
-// used.
+// Flush ensures all buffered data is written to the temp file.
 func (bw *bufferedWriter) Flush() error {
 	if bw.tmp == nil {
 		return nil
+	}
+	if bw.bio != nil {
+		return bw.bio.Flush()
 	}
 	_, err := bw.buf.WriteTo(bw.tmp)
 	if err != nil {
 		return err
 	}
-	bw.buf.Reset()
+	bw.buf = bytes.Buffer{}
 	return nil
+}
+
+// Reset clears all buffered data (in-memory and bufio) without closing the
+// temp file.
+func (bw *bufferedWriter) Reset() {
+	bw.buf.Reset()
+	if bw.bio != nil {
+		bw.bio.Reset(&bw.buf) // detach from temp file
+		bw.bio = nil
+	}
 }
 
 // Close the underlying temp file and reset the in-memory buffer.
 func (bw *bufferedWriter) Close() error {
 	bw.buf.Reset()
+	bw.bio = nil
 	if bw.tmp == nil {
 		return nil
 	}

--- a/stream.go
+++ b/stream.go
@@ -39,6 +39,7 @@ type StreamWriter struct {
 	rawData         bufferedWriter
 	rows            int
 	maxCol          int   // track max column for dimension element
+	cellCount       int64 // track total cells written
 	dimensionOffset int64 // byte offset of dimension placeholder for update
 	mergeCellsCount int
 	mergeCells      strings.Builder
@@ -461,6 +462,7 @@ func (sw *StreamWriter) SetRow(cell string, values []interface{}, opts ...RowOpt
 			return err
 		}
 		writeCell(&sw.rawData, c)
+		sw.cellCount++
 	}
 	_, _ = sw.rawData.WriteString(`</row>`)
 	return sw.rawData.Sync()
@@ -802,6 +804,9 @@ func (sw *StreamWriter) Flush() error {
 		return err
 	}
 
+	// Store sheet statistics for metadata access
+	sw.storeSheetStats()
+
 	sheetPath := sw.file.sheetMap[sw.Sheet]
 	sw.file.Sheet.Delete(sheetPath)
 	sw.file.checked.Delete(sheetPath)
@@ -827,6 +832,32 @@ func (sw *StreamWriter) updateDimension() error {
 		return fmt.Errorf("dimension length mismatch: got %d, expected %d", len(dim), len(dimensionPlaceholder))
 	}
 	return sw.rawData.WriteAt([]byte(padded), sw.dimensionOffset)
+}
+
+// storeSheetStats saves the sheet statistics to the File for later access.
+func (sw *StreamWriter) storeSheetStats() {
+	if sw.file.sheetStats == nil {
+		sw.file.sheetStats = make(map[string]*SheetStats)
+	}
+	maxCell := ""
+	if sw.maxCol > 0 && sw.rows > 0 {
+		maxCell, _ = CoordinatesToCellName(sw.maxCol, sw.rows)
+	}
+	sw.file.sheetStats[sw.Sheet] = &SheetStats{
+		Rows:    sw.rows,
+		Cols:    sw.maxCol,
+		Cells:   sw.cellCount,
+		MaxCell: maxCell,
+	}
+}
+
+// GetSheetStats returns previously cached sheet statistics, or nil if stats
+// have not been calculated for the given sheet.
+func (f *File) GetSheetStats(sheet string) *SheetStats {
+	if f.sheetStats == nil {
+		return nil
+	}
+	return f.sheetStats[sheet]
 }
 
 // bulkAppendFields bulk-appends fields in a worksheet by specified field

--- a/stream.go
+++ b/stream.go
@@ -25,6 +25,10 @@ import (
 	"time"
 )
 
+// dimensionPlaceholder is a fixed-width placeholder for the dimension element.
+// It uses max possible cell ref (XFD1048576) to ensure any final dimension fits.
+const dimensionPlaceholder = `<dimension ref="A1:XFD1048576"/>`
+
 // StreamWriter defined the type of stream writer.
 type StreamWriter struct {
 	file            *File
@@ -34,6 +38,8 @@ type StreamWriter struct {
 	worksheet       *xlsxWorksheet
 	rawData         bufferedWriter
 	rows            int
+	maxCol          int   // track max column for dimension element
+	dimensionOffset int64 // byte offset of dimension placeholder for update
 	mergeCellsCount int
 	mergeCells      strings.Builder
 	tableParts      string
@@ -155,7 +161,11 @@ func (f *File) NewStreamWriter(sheet string) (*StreamWriter, error) {
 	f.streams[sheetXMLPath] = sw
 
 	_, _ = sw.rawData.WriteString(xml.Header + `<worksheet` + templateNamespaceIDMap)
-	bulkAppendFields(&sw.rawData, sw.worksheet, 3, 4)
+	// Write SheetPr (field 3) only, we handle Dimension separately
+	bulkAppendFields(&sw.rawData, sw.worksheet, 3, 3)
+	// Record offset and write fixed-width dimension placeholder
+	sw.dimensionOffset = sw.rawData.written
+	_, _ = sw.rawData.WriteString(dimensionPlaceholder)
 	return sw, err
 }
 
@@ -411,6 +421,10 @@ func (sw *StreamWriter) SetRow(cell string, values []interface{}, opts ...RowOpt
 		return newStreamSetRowError(row)
 	}
 	sw.rows = row
+	// Track max column for dimension element
+	if endCol := col + len(values) - 1; endCol > sw.maxCol {
+		sw.maxCol = endCol
+	}
 	sw.writeSheetData()
 	options := parseRowOpts(opts...)
 	attrs, err := options.marshalAttrs()
@@ -783,12 +797,36 @@ func (sw *StreamWriter) Flush() error {
 		return err
 	}
 
+	// Update dimension placeholder with actual dimensions
+	if err := sw.updateDimension(); err != nil {
+		return err
+	}
+
 	sheetPath := sw.file.sheetMap[sw.Sheet]
 	sw.file.Sheet.Delete(sheetPath)
 	sw.file.checked.Delete(sheetPath)
 	sw.file.Pkg.Delete(sheetPath)
 
 	return nil
+}
+
+// updateDimension overwrites the dimension placeholder with the actual
+// dimensions computed during streaming.
+func (sw *StreamWriter) updateDimension() error {
+	// Build actual dimension element, padded to match placeholder length
+	var dim string
+	if sw.rows > 0 && sw.maxCol > 0 {
+		maxCell, _ := CoordinatesToCellName(sw.maxCol, sw.rows)
+		dim = fmt.Sprintf(`<dimension ref="A1:%s"/>`, maxCell)
+	} else {
+		dim = `<dimension ref="A1"/>`
+	}
+	// Pad to match placeholder length
+	padded := dim + strings.Repeat(" ", len(dimensionPlaceholder)-len(dim))
+	if len(padded) != len(dimensionPlaceholder) {
+		return fmt.Errorf("dimension length mismatch: got %d, expected %d", len(dim), len(dimensionPlaceholder))
+	}
+	return sw.rawData.WriteAt([]byte(padded), sw.dimensionOffset)
 }
 
 // bulkAppendFields bulk-appends fields in a worksheet by specified field

--- a/stream.go
+++ b/stream.go
@@ -826,11 +826,7 @@ func (sw *StreamWriter) updateDimension() error {
 	} else {
 		dim = `<dimension ref="A1"/>`
 	}
-	// Pad to match placeholder length
 	padded := dim + strings.Repeat(" ", len(dimensionPlaceholder)-len(dim))
-	if len(padded) != len(dimensionPlaceholder) {
-		return fmt.Errorf("dimension length mismatch: got %d, expected %d", len(dim), len(dimensionPlaceholder))
-	}
 	return sw.rawData.WriteAt([]byte(padded), sw.dimensionOffset)
 }
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -806,3 +806,18 @@ func TestGetSheetStatsEmpty(t *testing.T) {
 	assert.Equal(t, int64(0), stats.Cells)
 	assert.Equal(t, "", stats.MaxCell)
 }
+
+func TestStreamWriterDimensionOverflow(t *testing.T) {
+	f := NewFile()
+	defer f.Close()
+
+	sw, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+	assert.NoError(t, sw.SetRow("A1", []interface{}{"test"}))
+
+	// Force an invalid dimensionOffset so WriteAt inside updateDimension fails
+	sw.dimensionOffset = 999999999
+
+	err = sw.Flush()
+	assert.Error(t, err)
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -705,3 +705,57 @@ func TestNewStreamWriterOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1024, sw3.rawData.flushSize)
 }
+
+func TestBufferedWriterWriteAtFlushError(t *testing.T) {
+	// Test WriteAt temp file path where Flush fails (line 901)
+	bw := &bufferedWriter{flushSize: 1, bioSize: 4096}
+	bw.WriteString("AAABBBCCC")
+	_ = bw.Sync()
+	// Write more data so bio has unflushed content
+	bw.bio.WriteString("extra")
+	// Close the temp file to cause Flush (bio.Flush) to fail
+	bw.tmp.Close()
+	err := bw.WriteAt([]byte("YYY"), 3)
+	assert.Error(t, err)
+}
+
+func TestBufferedWriterCopyToFlushError(t *testing.T) {
+	// Test CopyTo temp file path where Flush fails (line 915)
+	bw := &bufferedWriter{flushSize: 1, bioSize: 4096}
+	bw.WriteString("test data")
+	_ = bw.Sync()
+	bw.WriteString(" more")
+	// Close file to cause Flush to fail
+	bw.tmp.Close()
+	var dst bytes.Buffer
+	_, err := bw.CopyTo(&dst)
+	assert.Error(t, err)
+}
+
+func TestBufferedWriterCopyToSeekError(t *testing.T) {
+	// Test CopyTo temp file path where Seek fails (line 918)
+	bw := &bufferedWriter{flushSize: 1, bioSize: 4096}
+	bw.WriteString("test data")
+	_ = bw.Sync()
+	// Close file so Flush succeeds (bio is nil after sync with no writes) but Seek fails
+	// We need bio to be nil so Flush() is a no-op, then Seek will fail on closed file
+	bw.bio = nil
+	bw.tmp.Close()
+	var dst bytes.Buffer
+	_, err := bw.CopyTo(&dst)
+	assert.Error(t, err)
+}
+
+func TestBufferedWriterSyncWriteToError(t *testing.T) {
+	// Test Sync where buf.WriteTo(tmp) fails (line 970)
+	bw := &bufferedWriter{flushSize: 1, bioSize: 4096}
+	bw.WriteString("initial")
+	// Sync to create temp file
+	_ = bw.Sync()
+	// Now reset state to have data in buf and tmp exists but is closed
+	bw.bio = nil
+	bw.buf.WriteString("more data")
+	bw.tmp.Close()
+	err := bw.Sync()
+	assert.Error(t, err)
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,6 +1,7 @@
 package excelize
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -531,4 +532,176 @@ func TestStreamWriterGetRowElement(t *testing.T) {
 		_, ok := getRowElement(token, 0)
 		assert.False(t, ok)
 	}
+}
+
+func TestBufferedWriterWriteInt(t *testing.T) {
+	// In-memory path
+	bw := &bufferedWriter{flushSize: StreamChunkSize, bioSize: StreamingBufSizeDefault}
+	bw.WriteInt(42)
+	bw.WriteInt(-1234567890)
+	assert.Equal(t, "42-1234567890", bw.buf.String())
+	assert.Equal(t, int64(len("42-1234567890")), bw.written)
+
+	// Temp file (bio) path
+	bw2 := &bufferedWriter{flushSize: 1, bioSize: 4096}
+	bw2.WriteString("x") // trigger sync
+	_ = bw2.Sync()
+	assert.NotNil(t, bw2.bio)
+	bw2.WriteInt(99)
+	_ = bw2.Flush()
+	bw2.tmp.Seek(0, 0)
+	data, _ := io.ReadAll(bw2.tmp)
+	assert.Contains(t, string(data), "99")
+	bw2.Close()
+}
+
+func TestBufferedWriterWriteUint(t *testing.T) {
+	bw := &bufferedWriter{flushSize: StreamChunkSize, bioSize: StreamingBufSizeDefault}
+	bw.WriteUint(12345)
+	assert.Equal(t, "12345", bw.buf.String())
+
+	// bio path
+	bw2 := &bufferedWriter{flushSize: 1, bioSize: 4096}
+	bw2.WriteString("x")
+	_ = bw2.Sync()
+	bw2.WriteUint(67890)
+	_ = bw2.Flush()
+	bw2.tmp.Seek(0, 0)
+	data, _ := io.ReadAll(bw2.tmp)
+	assert.Contains(t, string(data), "67890")
+	bw2.Close()
+}
+
+func TestBufferedWriterWriteFloat(t *testing.T) {
+	bw := &bufferedWriter{flushSize: StreamChunkSize, bioSize: StreamingBufSizeDefault}
+	bw.WriteFloat(3.14, 'f', 2, 64)
+	assert.Equal(t, "3.14", bw.buf.String())
+
+	// bio path
+	bw2 := &bufferedWriter{flushSize: 1, bioSize: 4096}
+	bw2.WriteString("x")
+	_ = bw2.Sync()
+	bw2.WriteFloat(2.72, 'f', 2, 64)
+	_ = bw2.Flush()
+	bw2.tmp.Seek(0, 0)
+	data, _ := io.ReadAll(bw2.tmp)
+	assert.Contains(t, string(data), "2.72")
+	bw2.Close()
+}
+
+func TestBufferedWriterBytes(t *testing.T) {
+	// In-memory: returns buffer bytes
+	bw := &bufferedWriter{flushSize: StreamChunkSize, bioSize: StreamingBufSizeDefault}
+	bw.WriteString("hello")
+	assert.Equal(t, []byte("hello"), bw.Bytes())
+
+	// After temp file creation: returns nil
+	bw2 := &bufferedWriter{flushSize: 1, bioSize: 4096}
+	bw2.WriteString("x")
+	_ = bw2.Sync()
+	assert.Nil(t, bw2.Bytes())
+	bw2.Close()
+}
+
+func TestBufferedWriterWriteAt(t *testing.T) {
+	// In-memory WriteAt
+	bw := &bufferedWriter{flushSize: StreamChunkSize, bioSize: StreamingBufSizeDefault}
+	bw.WriteString("AAABBBCCC")
+	err := bw.WriteAt([]byte("XXX"), 3)
+	assert.NoError(t, err)
+	assert.Equal(t, "AAAXXXCCC", bw.buf.String())
+
+	// In-memory WriteAt out of bounds
+	err = bw.WriteAt([]byte("TOOLONG"), 5)
+	assert.Error(t, err)
+
+	// Temp file WriteAt
+	bw2 := &bufferedWriter{flushSize: 1, bioSize: 4096}
+	bw2.WriteString("AAABBBCCC")
+	_ = bw2.Sync()
+	err = bw2.WriteAt([]byte("YYY"), 3)
+	assert.NoError(t, err)
+	// Verify by reading the file back
+	var readBuf bytes.Buffer
+	_, _ = bw2.CopyTo(&readBuf)
+	assert.Equal(t, "AAAYYYCC", readBuf.String()[:8])
+	bw2.Close()
+}
+
+func TestBufferedWriterCopyTo(t *testing.T) {
+	// In-memory CopyTo
+	bw := &bufferedWriter{flushSize: StreamChunkSize, bioSize: StreamingBufSizeDefault}
+	bw.WriteString("hello world")
+	var dst bytes.Buffer
+	n, err := bw.CopyTo(&dst)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(11), n)
+	assert.Equal(t, "hello world", dst.String())
+
+	// Temp file CopyTo
+	bw2 := &bufferedWriter{flushSize: 1, bioSize: 4096}
+	bw2.WriteString("file data here")
+	_ = bw2.Sync()
+	bw2.WriteString(" more") // this goes through bio
+	var dst2 bytes.Buffer
+	n2, err := bw2.CopyTo(&dst2)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(19), n2)
+	assert.Equal(t, "file data here more", dst2.String())
+	bw2.Close()
+
+	// Temp file CopyTo with large bioSize (> 256KB)
+	bw3 := &bufferedWriter{flushSize: 1, bioSize: 512 * 1024}
+	bw3.WriteString("large buffer test")
+	_ = bw3.Sync()
+	var dst3 bytes.Buffer
+	n3, err := bw3.CopyTo(&dst3)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(17), n3)
+	assert.Equal(t, "large buffer test", dst3.String())
+	bw3.Close()
+}
+
+func TestBufferedWriterReset(t *testing.T) {
+	// Reset in-memory only
+	bw := &bufferedWriter{flushSize: StreamChunkSize, bioSize: StreamingBufSizeDefault}
+	bw.WriteString("data")
+	bw.Reset()
+	assert.Equal(t, 0, bw.buf.Len())
+
+	// Reset after temp file creation
+	bw2 := &bufferedWriter{flushSize: 1, bioSize: 4096}
+	bw2.WriteString("data")
+	_ = bw2.Sync()
+	assert.NotNil(t, bw2.bio)
+	bw2.Reset()
+	assert.Nil(t, bw2.bio)
+	assert.Equal(t, 0, bw2.buf.Len())
+	bw2.Close()
+}
+
+func TestNewStreamWriterOptions(t *testing.T) {
+	// Test StreamingChunkSize = -1 (never spill)
+	f := NewFile()
+	defer f.Close()
+	f.options.StreamingChunkSize = -1
+	sw, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+	assert.True(t, sw.rawData.flushSize > StreamChunkSize)
+
+	// Test StreamingBufSize custom value
+	f2 := NewFile()
+	defer f2.Close()
+	f2.options.StreamingBufSize = 64 * 1024
+	sw2, err := f2.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+	assert.Equal(t, 64*1024, sw2.rawData.bioSize)
+
+	// Test StreamingChunkSize positive custom value
+	f3 := NewFile()
+	defer f3.Close()
+	f3.options.StreamingChunkSize = 1024
+	sw3, err := f3.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+	assert.Equal(t, 1024, sw3.rawData.flushSize)
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -759,3 +759,50 @@ func TestBufferedWriterSyncWriteToError(t *testing.T) {
 	err := bw.Sync()
 	assert.Error(t, err)
 }
+
+func TestStoreSheetStats(t *testing.T) {
+	f := NewFile()
+	defer f.Close()
+
+	// Before streaming, GetSheetStats returns nil
+	assert.Nil(t, f.GetSheetStats("Sheet1"))
+
+	sw, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+
+	// Write some rows
+	assert.NoError(t, sw.SetRow("A1", []interface{}{"Name", "Age", "City"}))
+	assert.NoError(t, sw.SetRow("A2", []interface{}{"Alice", 30, "NYC"}))
+	assert.NoError(t, sw.SetRow("A3", []interface{}{"Bob", nil, "LA"}))
+
+	assert.NoError(t, sw.Flush())
+
+	// After Flush, GetSheetStats returns populated stats
+	stats := f.GetSheetStats("Sheet1")
+	assert.NotNil(t, stats)
+	assert.Equal(t, 3, stats.Rows)
+	assert.Equal(t, 3, stats.Cols)
+	assert.Equal(t, int64(8), stats.Cells) // 3+3+2 = 8 non-nil values
+	assert.Equal(t, "C3", stats.MaxCell)
+
+	// Non-existent sheet returns nil
+	assert.Nil(t, f.GetSheetStats("NonExistent"))
+}
+
+func TestGetSheetStatsEmpty(t *testing.T) {
+	f := NewFile()
+	defer f.Close()
+
+	sw, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+
+	// Flush with no rows written
+	assert.NoError(t, sw.Flush())
+
+	stats := f.GetSheetStats("Sheet1")
+	assert.NotNil(t, stats)
+	assert.Equal(t, 0, stats.Rows)
+	assert.Equal(t, 0, stats.Cols)
+	assert.Equal(t, int64(0), stats.Cells)
+	assert.Equal(t, "", stats.MaxCell)
+}

--- a/templates.go
+++ b/templates.go
@@ -186,6 +186,7 @@ const (
 	MinColumns              = 1
 	MinFontSize             = 1
 	StreamChunkSize         = 1 << 24
+	StreamingBufSizeDefault = 128 << 10
 	TotalCellChars          = 32767
 	TotalRows               = 1048576
 	TotalSheetHyperlinks    = 65529


### PR DESCRIPTION
## Summary

Adds a dimension placeholder mechanism to `StreamWriter` so that the `<dimension>` element in streaming worksheets accurately reflects the data range, without requiring a full file rewrite.

**Depends on:** #2321 (buffered-writer enhancements — for `WriteAt` and `written` tracking)

## Problem

The current `StreamWriter` writes `bulkAppendFields(&sw.rawData, sw.worksheet, 3, 4)` which includes the dimension element from the (empty) worksheet template. This means streaming worksheets always have an empty or incorrect dimension. While Excel recalculates dimensions on open, other XLSX readers (Google Sheets, LibreOffice, programmatic parsers) may rely on the `<dimension>` element for range detection.

## Solution

1. **Placeholder**: A fixed-width string `<dimension ref="A1:XFD1048576"/>` (32 bytes) is written at a known byte offset during `NewStreamWriter`, after the `<sheetPr>` element but before `<sheetViews>`.

2. **Tracking**: `SetRow` tracks `maxCol` — the maximum column index seen across all rows.

3. **Overwrite**: In `Flush`, after all XML is written and the buffer/file is complete, `updateDimension()` computes the actual dimension (e.g. `A1:D100`) and uses `WriteAt` to overwrite the placeholder in-place. The replacement is right-padded with spaces to match the placeholder length exactly, since XML ignores trailing whitespace in element content.

## Why fixed-width?

The `<dimension>` element must appear before `<sheetData>` in the XLSX schema, but we don't know the final data range until all rows are written. A fixed-width placeholder avoids shifting all subsequent byte offsets — `WriteAt` simply overwrites the exact bytes without moving anything.

The placeholder uses the maximum possible cell reference (`XFD1048576`) so any real dimension string is guaranteed to be shorter or equal in length.

## Compatibility

All existing tests pass. The dimension element is optional per ECMA-376 §18.3.1.35 — Excel recalculates it on open regardless. This change improves interoperability with readers that do honor the element.