### PR TITLE
feat: add UseSharedStrings option for streaming writes (D1)

### DIFF
--- a/excelize.go
+++ b/excelize.go
@@ -122,6 +122,11 @@ type Options struct {
 	LongDatePattern   string
 	LongTimePattern   string
 	CultureInfo       CultureName
+	// UseSharedStrings enables shared string table generation during
+	// streaming. When true, string values are stored once in
+	// xl/sharedStrings.xml and referenced by index in cells, reducing
+	// file size when many cells contain duplicate string values.
+	UseSharedStrings bool
 }
 
 // OpenFile take the name of a spreadsheet file and returns a populated

--- a/stream.go
+++ b/stream.go
@@ -25,16 +25,19 @@ import (
 
 // StreamWriter defined the type of stream writer.
 type StreamWriter struct {
-	file            *File
-	Sheet           string
-	SheetID         int
-	sheetWritten    bool
-	worksheet       *xlsxWorksheet
-	rawData         bufferedWriter
-	rows            int
-	mergeCellsCount int
-	mergeCells      strings.Builder
-	tableParts      string
+	file             *File
+	Sheet            string
+	SheetID          int
+	sheetWritten     bool
+	worksheet        *xlsxWorksheet
+	rawData          bufferedWriter
+	rows             int
+	mergeCellsCount  int
+	mergeCells       strings.Builder
+	tableParts       string
+	useSharedStrings bool
+	sharedStrings    []string
+	sharedStringsMap map[string]int
 }
 
 // NewStreamWriter returns stream writer struct by given worksheet name used for
@@ -124,6 +127,10 @@ func (f *File) NewStreamWriter(sheet string) (*StreamWriter, error) {
 		Sheet:   sheet,
 		SheetID: sheetID,
 		rawData: bufferedWriter{tmpDir: f.options.TmpDir},
+	}
+	if f.options != nil && f.options.UseSharedStrings {
+		sw.useSharedStrings = true
+		sw.sharedStringsMap = make(map[string]int, 1024)
 	}
 	var err error
 	sw.worksheet, err = f.workSheetReader(sheet)
@@ -429,6 +436,12 @@ func (sw *StreamWriter) SetRow(cell string, values []interface{}, opts ...RowOpt
 			_, _ = sw.rawData.WriteString(`</row>`)
 			return err
 		}
+		if sw.useSharedStrings && c.T == "inlineStr" && c.IS != nil && c.IS.T != nil && len(c.IS.R) == 0 {
+			idx := sw.getOrAddSharedString(c.IS.T.Val)
+			c.T = "s"
+			c.V = strconv.Itoa(idx)
+			c.IS = nil
+		}
 		writeCell(&sw.rawData, c)
 	}
 	_, _ = sw.rawData.WriteString(`</row>`)
@@ -704,6 +717,61 @@ func writeCell(buf *bufferedWriter, c xlsxC) {
 	_, _ = buf.WriteString(`</c>`)
 }
 
+// getOrAddSharedString returns the index of a string in the shared string
+// table, adding it if not already present.
+func (sw *StreamWriter) getOrAddSharedString(s string) int {
+	if idx, ok := sw.sharedStringsMap[s]; ok {
+		return idx
+	}
+	idx := len(sw.sharedStrings)
+	sw.sharedStrings = append(sw.sharedStrings, s)
+	sw.sharedStringsMap[s] = idx
+	return idx
+}
+
+// writeSharedStrings writes xl/sharedStrings.xml and registers the content
+// type and workbook relationship for the shared string table.
+func (sw *StreamWriter) writeSharedStrings() error {
+	var buf bytes.Buffer
+	buf.WriteString(xml.Header)
+	buf.WriteString(`<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="`)
+	buf.WriteString(strconv.Itoa(len(sw.sharedStrings)))
+	buf.WriteString(`" uniqueCount="`)
+	buf.WriteString(strconv.Itoa(len(sw.sharedStrings)))
+	buf.WriteString(`">`)
+
+	for _, s := range sw.sharedStrings {
+		buf.WriteString(`<si><t`)
+		if len(s) > 0 {
+			first, last := s[0], s[len(s)-1]
+			if first == ' ' || first == '\t' || first == '\n' || first == '\r' ||
+				last == ' ' || last == '\t' || last == '\n' || last == '\r' {
+				buf.WriteString(` xml:space="preserve"`)
+			}
+		}
+		buf.WriteString(`>`)
+		_ = xml.EscapeText(&buf, []byte(s))
+		buf.WriteString(`</t></si>`)
+	}
+	buf.WriteString(`</sst>`)
+
+	sw.file.Pkg.Store(defaultXMLPathSharedStrings, buf.Bytes())
+
+	if err := sw.file.addContentTypePart(0, "sharedStrings"); err != nil {
+		return err
+	}
+
+	relPath := sw.file.getWorkbookRelsPath()
+	rels, _ := sw.file.relsReader(relPath)
+	for _, rel := range rels.Relationships {
+		if rel.Target == "/xl/sharedStrings.xml" {
+			return nil
+		}
+	}
+	sw.file.addRels(relPath, SourceRelationshipSharedStrings, "/xl/sharedStrings.xml", "")
+	return nil
+}
+
 // writeSheetData prepares the element preceding sheetData and writes the
 // sheetData XML start element to the buffer.
 func (sw *StreamWriter) writeSheetData() {
@@ -764,6 +832,12 @@ func (sw *StreamWriter) Flush() error {
 	_, _ = sw.rawData.WriteString(`</worksheet>`)
 	if err := sw.rawData.Flush(); err != nil {
 		return err
+	}
+
+	if sw.useSharedStrings && len(sw.sharedStrings) > 0 {
+		if err := sw.writeSharedStrings(); err != nil {
+			return err
+		}
 	}
 
 	sheetPath := sw.file.sheetMap[sw.Sheet]

--- a/stream_test.go
+++ b/stream_test.go
@@ -532,3 +532,159 @@ func TestStreamWriterGetRowElement(t *testing.T) {
 		assert.False(t, ok)
 	}
 }
+
+func TestStreamWriterUseSharedStrings(t *testing.T) {
+	// Test basic UseSharedStrings functionality
+	f := NewFile(Options{UseSharedStrings: true})
+	defer f.Close()
+
+	sw, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+	assert.True(t, sw.useSharedStrings)
+	assert.NotNil(t, sw.sharedStringsMap)
+
+	// Write rows with duplicate strings
+	assert.NoError(t, sw.SetRow("A1", []interface{}{"hello", "world", "hello"}))
+	assert.NoError(t, sw.SetRow("A2", []interface{}{"world", "new", "hello"}))
+
+	assert.NoError(t, sw.Flush())
+
+	// Verify shared strings were created
+	data, ok := f.Pkg.Load(defaultXMLPathSharedStrings)
+	assert.True(t, ok)
+	sstXML := string(data.([]byte))
+	assert.Contains(t, sstXML, `<si><t>hello</t></si>`)
+	assert.Contains(t, sstXML, `<si><t>world</t></si>`)
+	assert.Contains(t, sstXML, `<si><t>new</t></si>`)
+	assert.Contains(t, sstXML, `uniqueCount="3"`)
+
+	// Save and re-read to verify file is valid
+	tmpPath := filepath.Join(t.TempDir(), "shared_strings.xlsx")
+	assert.NoError(t, f.SaveAs(tmpPath))
+
+	f2, err := OpenFile(tmpPath)
+	assert.NoError(t, err)
+	defer f2.Close()
+
+	val, err := f2.GetCellValue("Sheet1", "A1")
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", val)
+
+	val, err = f2.GetCellValue("Sheet1", "B1")
+	assert.NoError(t, err)
+	assert.Equal(t, "world", val)
+
+	val, err = f2.GetCellValue("Sheet1", "C1")
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", val)
+
+	val, err = f2.GetCellValue("Sheet1", "B2")
+	assert.NoError(t, err)
+	assert.Equal(t, "new", val)
+}
+
+func TestStreamWriterSharedStringsPreserveSpace(t *testing.T) {
+	// Test that strings with leading/trailing whitespace get xml:space="preserve"
+	f := NewFile(Options{UseSharedStrings: true})
+	defer f.Close()
+
+	sw, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+
+	assert.NoError(t, sw.SetRow("A1", []interface{}{" leading", "trailing ", "\tnewline\n"}))
+	assert.NoError(t, sw.Flush())
+
+	data, ok := f.Pkg.Load(defaultXMLPathSharedStrings)
+	assert.True(t, ok)
+	sstXML := string(data.([]byte))
+	assert.Contains(t, sstXML, `xml:space="preserve"`)
+}
+
+func TestStreamWriterSharedStringsDedup(t *testing.T) {
+	// Test that getOrAddSharedString deduplicates correctly
+	f := NewFile(Options{UseSharedStrings: true})
+	defer f.Close()
+
+	sw, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+
+	// Same string should return same index
+	idx1 := sw.getOrAddSharedString("test")
+	idx2 := sw.getOrAddSharedString("test")
+	idx3 := sw.getOrAddSharedString("other")
+	assert.Equal(t, 0, idx1)
+	assert.Equal(t, 0, idx2)
+	assert.Equal(t, 1, idx3)
+	assert.Equal(t, 2, len(sw.sharedStrings))
+}
+
+func TestStreamWriterSharedStringsDisabled(t *testing.T) {
+	// Test that without UseSharedStrings, inline strings are used
+	f := NewFile()
+	defer f.Close()
+
+	sw, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+	assert.False(t, sw.useSharedStrings)
+
+	assert.NoError(t, sw.SetRow("A1", []interface{}{"hello"}))
+	assert.NoError(t, sw.Flush())
+
+	// No shared strings file should be created
+	_, ok := f.Pkg.Load(defaultXMLPathSharedStrings)
+	assert.False(t, ok)
+}
+
+func TestStreamWriterSharedStringsEmptyStrings(t *testing.T) {
+	// Test with empty string values (no shared strings generated)
+	f := NewFile(Options{UseSharedStrings: true})
+	defer f.Close()
+
+	sw, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+
+	// Write only numeric values - no shared strings
+	assert.NoError(t, sw.SetRow("A1", []interface{}{42, 3.14, true}))
+	assert.NoError(t, sw.Flush())
+
+	// No shared strings should be written (empty table)
+	_, ok := f.Pkg.Load(defaultXMLPathSharedStrings)
+	assert.False(t, ok)
+}
+
+func TestStreamWriterSharedStringsRelationship(t *testing.T) {
+	// Test that writeSharedStrings adds content type and relationship
+	f := NewFile(Options{UseSharedStrings: true})
+	defer f.Close()
+
+	sw, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+
+	assert.NoError(t, sw.SetRow("A1", []interface{}{"test"}))
+	assert.NoError(t, sw.Flush())
+
+	// Call Flush again with another stream writer to verify relationship dedup
+	sw2, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+	assert.NoError(t, sw2.SetRow("A1", []interface{}{"test2"}))
+	assert.NoError(t, sw2.Flush())
+}
+
+func TestStreamWriterSharedStringsError(t *testing.T) {
+	// Test writeSharedStrings error path (corrupted content types)
+	f := NewFile(Options{UseSharedStrings: true})
+	defer f.Close()
+
+	sw, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+
+	assert.NoError(t, sw.SetRow("A1", []interface{}{"trigger_sst"}))
+
+	// Corrupt content types with invalid XML that triggers a decode error
+	// (unclosed element causes syntax error, not EOF)
+	f.Pkg.Store(defaultXMLPathContentTypes, []byte(`<Types xmlns="x"><Override PartName="/xl`))
+	f.ContentTypes = nil
+
+	err = sw.Flush()
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Add `UseSharedStrings` option for streaming writes. When enabled, the stream writer stores unique string values once in `xl/sharedStrings.xml` and references them by index in cell elements (`t="s"` with `<v>idx</v>`), instead of writing inline strings for every cell.

This can significantly reduce output file size when many cells contain duplicate string values.

## Implementation

- Add `UseSharedStrings bool` to `Options` struct
- Add `useSharedStrings`, `sharedStrings`, `sharedStringsMap` fields to `StreamWriter`; initialized from `Options` in `NewStreamWriter`
- After `setCellValFunc` produces an `inlineStr` cell with a simple `<t>` value, convert it to a shared string reference (`t="s"`)
- `getOrAddSharedString`: dedup via map, returns shared string index
- `writeSharedStrings`: on `Flush`, writes `xl/sharedStrings.xml` with proper `xml:space="preserve"` for whitespace-padded strings, adds content type part and workbook relationship if not already present

## Usage

```go
f := excelize.NewFile()
f.SetOptions(excelize.Options{UseSharedStrings: true})
sw, err := f.NewStreamWriter("Sheet1")
// ... write rows as usual ...
sw.Flush()
f.SaveAs("output.xlsx")
```