### PR TITLE
This closes #2191, add Rows.IterateColumns to stream cells without []string allocation

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -151,14 +151,36 @@ func (rows *Rows) Close() error {
 // data as a stream, returns each cell in a row as is, and will not skip empty
 // rows in the tail of the worksheet.
 func (rows *Rows) Columns(opts ...Options) ([]string, error) {
-	if rows.curRow > rows.seekRow {
-		return nil, nil
-	}
 	var rowIterator rowXMLIterator
+	err := rows.iterate(&rowIterator, opts...)
+	return rowIterator.cells, err
+}
+
+// IterateColumns streams each non-empty cell of the current row through fn
+// with its 1-based column index, avoiding the []string allocation that
+// Columns performs.
+//
+//	rows.IterateColumns(func(colIndex int, cellValue string) {
+//	    fmt.Printf("col %d: %s\n", colIndex, cellValue)
+//	})
+func (rows *Rows) IterateColumns(fn func(colIndex int, cellValue string), opts ...Options) error {
+	if fn == nil {
+		return nil
+	}
+	rowIterator := rowXMLIterator{yield: fn}
+	return rows.iterate(&rowIterator, opts...)
+}
+
+// iterate drives the SAX parser for the current row, streaming cells via
+// rowIterator.yield when set or accumulating them into rowIterator.cells.
+func (rows *Rows) iterate(rowIterator *rowXMLIterator, opts ...Options) error {
+	if rows.curRow > rows.seekRow {
+		return nil
+	}
 	var token xml.Token
 	rows.rawCellValue = rows.f.getOptions(opts...).RawCellValue
 	if rows.sst, rowIterator.err = rows.f.sharedStringsReader(); rowIterator.err != nil {
-		return rowIterator.cells, rowIterator.err
+		return rowIterator.err
 	}
 	for {
 		if rows.token != nil {
@@ -180,21 +202,21 @@ func (rows *Rows) Columns(opts ...Options) ([]string, error) {
 				rows.seekRowOpts = extractRowOpts(xmlElement.Attr)
 				if rows.curRow > rows.seekRow {
 					rows.token = nil
-					return rowIterator.cells, rowIterator.err
+					return rowIterator.err
 				}
 			}
-			if rows.rowXMLHandler(&rowIterator, &xmlElement, rows.rawCellValue); rowIterator.err != nil {
+			if rows.rowXMLHandler(rowIterator, &xmlElement, rows.rawCellValue); rowIterator.err != nil {
 				rows.token = nil
-				return rowIterator.cells, rowIterator.err
+				return rowIterator.err
 			}
 			rows.token = nil
 		case xml.EndElement:
 			if xmlElement.Name.Local == "sheetData" {
-				return rowIterator.cells, rowIterator.err
+				return rowIterator.err
 			}
 		}
 	}
-	return rowIterator.cells, rowIterator.err
+	return rowIterator.err
 }
 
 // extractRowOpts extract row element attributes.
@@ -221,11 +243,14 @@ func appendSpace(l int, s []string) []string {
 }
 
 // rowXMLIterator defined runtime use field for the worksheet row SAX parser.
+// When yield is non-nil cells are streamed through it; otherwise they are
+// accumulated into cells.
 type rowXMLIterator struct {
 	err              error
 	inElement        string
 	cellCol, cellRow int
 	cells            []string
+	yield            func(colIndex int, cellValue string)
 }
 
 // rowXMLHandler parse the row XML element of the worksheet.
@@ -239,10 +264,16 @@ func (rows *Rows) rowXMLHandler(rowIterator *rowXMLIterator, xmlElement *xml.Sta
 				return
 			}
 		}
-		blank := rowIterator.cellCol - len(rowIterator.cells)
-		if val, _ := colCell.getValueFrom(rows.f, rows.sst, raw); val != "" || colCell.F != nil {
-			rowIterator.cells = append(appendSpace(blank, rowIterator.cells), val)
+		val, _ := colCell.getValueFrom(rows.f, rows.sst, raw)
+		if val == "" && colCell.F == nil {
+			return
 		}
+		if rowIterator.yield != nil {
+			rowIterator.yield(rowIterator.cellCol, val)
+			return
+		}
+		blank := rowIterator.cellCol - len(rowIterator.cells)
+		rowIterator.cells = append(appendSpace(blank, rowIterator.cells), val)
 	}
 }
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -82,6 +82,87 @@ func TestRows(t *testing.T) {
 	assert.EqualError(t, err, "XML syntax error on line 1: invalid UTF-8")
 }
 
+func TestIterateColumns(t *testing.T) {
+	const sheet2 = "Sheet2"
+	f, err := OpenFile(filepath.Join("test", "Book1.xlsx"))
+	assert.NoError(t, err)
+
+	// Compare IterateColumns output against Columns row-by-row on the same file.
+	expectedRows, err := f.GetRows(sheet2)
+	assert.NoError(t, err)
+
+	rows, err := f.Rows(sheet2)
+	assert.NoError(t, err)
+	var streamed [][]string
+	for rows.Next() {
+		var row []string
+		err := rows.IterateColumns(func(colIndex int, cellValue string) {
+			for len(row) < colIndex-1 {
+				row = append(row, "")
+			}
+			row = append(row, cellValue)
+		})
+		assert.NoError(t, err)
+		streamed = append(streamed, row)
+	}
+	assert.NoError(t, rows.Error())
+	assert.NoError(t, rows.Close())
+
+	// GetRows skips wholly empty rows in the tail; align lengths before compare.
+	if len(streamed) > len(expectedRows) {
+		streamed = streamed[:len(expectedRows)]
+	}
+	for i := range streamed {
+		assert.Equal(t, trimSliceSpace(expectedRows[i]), trimSliceSpace(streamed[i]),
+			"row %d mismatch", i+1)
+	}
+	assert.NoError(t, f.Close())
+
+	// Test sparse sheet: indices must reflect actual column positions, not
+	// the order non-empty cells were emitted in.
+	f = NewFile()
+	cells := map[string]string{"C1": "c", "E1": "e", "A3": "a", "B3": "b", "E3": "e"}
+	for cell, val := range cells {
+		assert.NoError(t, f.SetCellValue("Sheet1", cell, val))
+	}
+	rows, err = f.Rows("Sheet1")
+	assert.NoError(t, err)
+	collected := make(map[string]string)
+	rowIdx := 0
+	for rows.Next() {
+		rowIdx++
+		assert.NoError(t, rows.IterateColumns(func(colIndex int, cellValue string) {
+			ref, err := CoordinatesToCellName(colIndex, rowIdx)
+			assert.NoError(t, err)
+			collected[ref] = cellValue
+		}))
+	}
+	assert.NoError(t, rows.Close())
+	assert.Equal(t, cells, collected)
+
+	// Test nil callback is a safe no-op.
+	rows, err = f.Rows("Sheet1")
+	assert.NoError(t, err)
+	assert.True(t, rows.Next())
+	assert.NoError(t, rows.IterateColumns(nil))
+	assert.NoError(t, rows.Close())
+
+	// Test RawCellValue option propagates through.
+	f = NewFile()
+	assert.NoError(t, f.SetCellValue("Sheet1", "A1", 1.5))
+	assert.NoError(t, f.SetCellStyle("Sheet1", "A1", "A1", 0))
+	rows, err = f.Rows("Sheet1")
+	assert.NoError(t, err)
+	assert.True(t, rows.Next())
+	var raw string
+	assert.NoError(t, rows.IterateColumns(func(_ int, cellValue string) {
+		raw = cellValue
+	}, Options{RawCellValue: true}))
+	assert.Equal(t, "1.5", raw)
+	assert.NoError(t, rows.Close())
+	assert.NoError(t, f.Close())
+}
+
 func TestRowsIterator(t *testing.T) {
 	sheetName, rowCount, expectedNumRow := "Sheet2", 0, 11
 	f, err := OpenFile(filepath.Join("test", "Book1.xlsx"))


### PR DESCRIPTION
  ## Description

  Adds a new `Rows.IterateColumns` method that streams each non-empty cell of the current row through a user-supplied callback `func(colIndex int, cellValue string)`, instead of
  returning a `[]string` like `Rows.Columns` does.

  Internally, the SAX parse loop in `Columns` is extracted into a private `iterate` helper that both methods share. `rowXMLIterator` gains a `yield` field; when set, `rowXMLHandler`
  calls it per cell and skips the `append(appendSpace(...), val)` accumulation. When unset, the original code path runs verbatim — `Columns` keeps its existing behavior and pays only
   a single nil check per cell.
  
  ## Related Issue

Closes: https://github.com/qax-os/excelize/issues/2191.

  ## Motivation and Context
  
  `Rows.Columns` allocates and grows a `[]string` for every row, and fills middle gaps between non-empty cells with `""`. On wide or sparse rows this is a significant amount of work
  the caller doesn't actually need — most callers immediately iterate the slice and never retain it. `IterateColumns` lets callers consume cells directly, eliminating the slice
  allocation, the `append` regrowth chain, and the gap-filling loop, while preserving the existing `Columns` API and performance.
  
  Usage:

  ```go
  rows, _ := f.Rows("Sheet1")
  for rows.Next() {
      err := rows.IterateColumns(func(colIndex int, cellValue string) {
          fmt.Printf("col %d: %s\n", colIndex, cellValue)
      })
      if err != nil { /* ... */ }
  }
  rows.Close()
  ```

  ## How Has This Been Tested
  
  Added `TestIterateColumns` in `rows_test.go` covering:

  - **Parity with `Columns`**: iterates `test/Book1.xlsx` Sheet2 with both APIs and compares the resulting rows after trimming trailing empties.
  - **Sparse data**: builds a sheet with values at `C1`, `E1`, `A3`, `B3`, `E3` and reconstructs the cell map from `(rowIdx, colIndex)` pairs — verifies column indices reflect actual
   positions, not emission order.
  - **Nil callback**: confirms passing `nil` is a safe no-op and returns no error.
  - **Options propagation**: sets a styled numeric cell and verifies `Options{RawCellValue: true}` yields the unformatted raw value through `IterateColumns` exactly as it does
  through `Columns`.

  Ran the existing `TestRows`, `TestGetRows`, and `TestRowsIterator` to confirm no regression on the shared `iterate` path.

  ## Types of changes
  
  - [ ] Docs change / refactoring / dependency upgrade
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist

  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [x] I have read the **CONTRIBUTING** document.
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.