### PR TITLE
fix: compact sparse worksheet rows in linear time

### DIFF
--- a/merge_test.go
+++ b/merge_test.go
@@ -1,7 +1,10 @@
 package excelize
 
 import (
+	"encoding/xml"
+	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,6 +109,20 @@ func TestMergeCellOverlap(t *testing.T) {
 	assert.Equal(t, "D3", mc[0].GetEndAxis())
 	assert.Empty(t, mc[0].GetCellValue())
 	assert.NoError(t, f.Close())
+
+	t.Run("for_worksheet_with_max_cells", func(t *testing.T) {
+		f := NewFile()
+		f.Sheet.Delete("xl/worksheets/sheet1.xml")
+		worksheet := xml.Header + `<worksheet xmlns="%s"><sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData><mergeCells count="1"><mergeCell ref="A1:XFD1048576"/></mergeCells></worksheet>`
+		f.Pkg.Store("xl/worksheets/sheet1.xml", fmt.Appendf(nil, worksheet, NameSpaceSpreadSheet.Value))
+		f.checked = sync.Map{}
+		mergeCells, err := f.GetMergeCells("Sheet1")
+		assert.NoError(t, err)
+		mergeCell := mergeCells[0]
+		assert.Equal(t, "A1", mergeCell.GetStartAxis())
+		assert.Equal(t, "XFD1048576", mergeCell.GetEndAxis())
+		assert.NoError(t, f.Close())
+	})
 }
 
 func TestGetMergeCells(t *testing.T) {

--- a/sheet.go
+++ b/sheet.go
@@ -197,16 +197,14 @@ func trimRow(sheetData *xlsxSheetData) []xlsxRow {
 		i   int
 	)
 
-	for k := 0; k < len(sheetData.Row); k++ {
+	for k := range sheetData.Row {
 		row = sheetData.Row[k]
 		if row = trimCell(row); len(row.C) != 0 || row.hasAttr() {
 			sheetData.Row[i] = row
 			i++
-			continue
 		}
-		sheetData.Row = append(sheetData.Row[:k], sheetData.Row[k+1:]...)
-		k--
 	}
+	clear(sheetData.Row[i:])
 	return sheetData.Row[:i]
 }
 

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -520,6 +520,18 @@ func TestWorksheetWriter(t *testing.T) {
 	value, ok := f.Pkg.Load("xl/worksheets/sheet1.xml")
 	assert.True(t, ok)
 	assert.Equal(t, fmt.Sprintf(worksheet, 2), string(value.([]byte)))
+
+	t.Run("for_worksheet_with_max_rows", func(t *testing.T) {
+		f := NewFile()
+		f.Sheet.Delete("xl/worksheets/sheet1.xml")
+		worksheet := xml.Header + `<worksheet xmlns="%s"><dimension ref="A1048576"/><sheetData><row r="1048576" spans="1:1"><c r="A1048576" s="0"/></row></sheetData></worksheet>`
+		f.Pkg.Store("xl/worksheets/sheet1.xml", fmt.Appendf(nil, worksheet, NameSpaceSpreadSheet.Value))
+		f.checked = sync.Map{}
+		assert.NoError(t, f.SetCellValue("Sheet1", "A1", 1))
+		f.workSheetWriter()
+		assert.Equal(t, fmt.Sprintf(xml.Header+`<worksheet xmlns="%s" xmlns:r="%s"><dimension ref="A1048576"></dimension><sheetData><row r="1"><c r="A1"><v>1</v></c></row><row r="1048576" spans="1:1"></row></sheetData></worksheet>`, NameSpaceSpreadSheet.Value, SourceRelationship.Value), string(f.readXML("xl/worksheets/sheet1.xml")))
+		assert.NoError(t, f.Close())
+	})
 }
 
 func TestGetWorkbookPath(t *testing.T) {

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -704,6 +704,22 @@ func newSheetWithSave() {
 	_ = file.Save()
 }
 
+func BenchmarkTrimRowSparseRows(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		trimRow(newSparseRowsSheetData(50000))
+	}
+}
+
+func newSparseRowsSheetData(rows int) *xlsxSheetData {
+	sheetData := &xlsxSheetData{Row: make([]xlsxRow, rows)}
+	for i := range sheetData.Row {
+		sheetData.Row[i].R = i + 1
+	}
+	sheetData.Row[1].C = []xlsxC{{R: "A2", V: "value"}, {R: "B2"}}
+	sheetData.Row[rows-1] = xlsxRow{R: TotalRows, Hidden: true}
+	return sheetData
+}
+
 func TestAttrValToBool(t *testing.T) {
 	_, err := attrValToBool("hidden", []xml.Attr{
 		{Name: xml.Name{Local: "hidden"}},
@@ -864,6 +880,24 @@ func TestSheetDimension(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, dimension)
 	assert.NoError(t, f.Close())
+}
+
+func TestTrimRowCompactsSparseRows(t *testing.T) {
+	sheetData := &xlsxSheetData{Row: []xlsxRow{
+		{R: 1, C: []xlsxC{{R: "A1"}}},
+		{R: 2, C: []xlsxC{{R: "A2", V: "value"}, {R: "B2"}}},
+		{R: 3},
+		{R: TotalRows, Hidden: true},
+	}}
+
+	rows := trimRow(sheetData)
+	assert.Len(t, rows, 2)
+	assert.Equal(t, 2, rows[0].R)
+	assert.Len(t, rows[0].C, 1)
+	assert.Equal(t, "A2", rows[0].C[0].R)
+	assert.Equal(t, "value", rows[0].C[0].V)
+	assert.Equal(t, TotalRows, rows[1].R)
+	assert.True(t, rows[1].Hidden)
 }
 
 func TestAddIgnoredErrors(t *testing.T) {

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -704,22 +704,6 @@ func newSheetWithSave() {
 	_ = file.Save()
 }
 
-func BenchmarkTrimRowSparseRows(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		trimRow(newSparseRowsSheetData(50000))
-	}
-}
-
-func newSparseRowsSheetData(rows int) *xlsxSheetData {
-	sheetData := &xlsxSheetData{Row: make([]xlsxRow, rows)}
-	for i := range sheetData.Row {
-		sheetData.Row[i].R = i + 1
-	}
-	sheetData.Row[1].C = []xlsxC{{R: "A2", V: "value"}, {R: "B2"}}
-	sheetData.Row[rows-1] = xlsxRow{R: TotalRows, Hidden: true}
-	return sheetData
-}
-
 func TestAttrValToBool(t *testing.T) {
 	_, err := attrValToBool("hidden", []xml.Attr{
 		{Name: xml.Name{Local: "hidden"}},
@@ -882,22 +866,16 @@ func TestSheetDimension(t *testing.T) {
 	assert.NoError(t, f.Close())
 }
 
-func TestTrimRowCompactsSparseRows(t *testing.T) {
-	sheetData := &xlsxSheetData{Row: []xlsxRow{
+func TestTrimRow(t *testing.T) {
+	assert.Equal(t, []xlsxRow{
+		{R: 2, C: []xlsxC{{R: "A2", V: "value"}}},
+		{R: TotalRows, Hidden: true},
+	}, trimRow(&xlsxSheetData{Row: []xlsxRow{
 		{R: 1, C: []xlsxC{{R: "A1"}}},
 		{R: 2, C: []xlsxC{{R: "A2", V: "value"}, {R: "B2"}}},
 		{R: 3},
 		{R: TotalRows, Hidden: true},
-	}}
-
-	rows := trimRow(sheetData)
-	assert.Len(t, rows, 2)
-	assert.Equal(t, 2, rows[0].R)
-	assert.Len(t, rows[0].C, 1)
-	assert.Equal(t, "A2", rows[0].C[0].R)
-	assert.Equal(t, "value", rows[0].C[0].V)
-	assert.Equal(t, TotalRows, rows[1].R)
-	assert.True(t, rows[1].Hidden)
+	}}))
 }
 
 func TestAddIgnoredErrors(t *testing.T) {


### PR DESCRIPTION
## What changed

This changes `trimRow` to compact worksheet rows in place with a write index instead of deleting each empty row from the middle of the backing slice.

The observable behavior is the same: empty rows are removed, cells inside retained rows are still trimmed, and rows with attributes such as `hidden` are preserved.

## Why

Some valid XLSX files have a very sparse worksheet row list, for example when the sheet dimension reaches Excel's maximum row because of a single far-down cell. In that case, many intermediate rows can be empty.

The previous implementation used:

```go
sheetData.Row = append(sheetData.Row[:k], sheetData.Row[k+1:]...)
```

inside the scan loop. When many empty rows are present, that repeatedly shifts the remaining slice contents and can make saving sparse worksheets take quadratic time.

## How this fixes it

The new implementation performs one forward pass:

- trim cells in each row
- copy retained rows to the next write position
- clear the unused tail so discarded rows can be collected
- return the compacted slice

This avoids repeated large memory moves while preserving row order and the existing trim semantics.

## Tests

Added synthetic coverage only; no external or private workbook fixtures are included.

- `TestTrimRowCompactsSparseRows` verifies blank rows and blank cells are removed while rows with attributes are retained.
- `BenchmarkTrimRowSparseRows` covers a sparse worksheet shape with 50,000 row entries and only a small number of retained rows.

Local verification:

```text
go test ./...
go test ./... -run '^$' -bench '^BenchmarkTrimRowSparseRows$' -benchmem
```