### PR TITLE
This related with #548, allow sheet rename for invalid source names

### DIFF
--- a/sheet.go
+++ b/sheet.go
@@ -373,9 +373,6 @@ func (f *File) getActiveSheetID() int {
 // may be problem formula error or reference missing.
 func (f *File) SetSheetName(source, target string) error {
 	var err error
-	if err = checkSheetName(source); err != nil {
-		return err
-	}
 	if err = checkSheetName(target); err != nil {
 		return err
 	}

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -479,8 +479,9 @@ func TestSetSheetName(t *testing.T) {
 	// Test set worksheet with the different name
 	assert.NoError(t, f.SetSheetName("Sheet1", "sheet1"))
 	assert.Equal(t, "sheet1", f.GetSheetName(0))
-	// Test set sheet name with invalid sheet name
-	assert.Equal(t, f.SetSheetName("Sheet:1", "Sheet1"), ErrSheetNameInvalid)
+	// Test set sheet name with invalid source name (should not error, allows
+	// renaming sheets with non-standard names created by other applications)
+	assert.NoError(t, f.SetSheetName("Sheet:1", "Sheet1"))
 	_, err := f.NewSheet("Sheet 3")
 	assert.NoError(t, err)
 


### PR DESCRIPTION
# PR Details

Do not return errors when renaming a sheet when the source sheet name is not valid to allow editing of third-party excel files.

## Description

Removed checkSheetName on the source sheet name inside SetSheetName to allow users to modify invalid names into valid ones.

## Related Issue

Related to https://github.com/qax-os/excelize/issues/548

## Motivation and Context

When opening a file created by a third-party application with a sheet name exceeding 31 characters, it's currently impossible to even rename that sheet using SetSheetName, because the validation also rejects the source parameter. This effectively makes the file unusable through excelize.

## How Has This Been Tested

updated unit test modifying an invalid sheet name.

## Types of changes


- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
