### PR TITLE
Related to #1164: fix incorrect argument count with nested func in parenthesized sub-exporessions

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -1213,11 +1213,11 @@ func prepareEvalInfixExp(opfStack, opftStack, opfdStack, argsStack *Stack) {
 	argument := true
 	if opftStack.Len() > 2 && opfdStack.Len() == 1 {
 		topOpt := opftStack.Pop()
-		// Look past any subexpression start and function start tokens.
+		// Look past any subexpression start, function start, and prefix operator tokens
 		var savedTokens []efp.Token
 		for opftStack.Len() > 0 {
-			tok := opftStack.Peek().(efp.Token)
-			if !isBeginParenthesesToken(tok) && !isFunctionStartToken(tok) {
+			token := opftStack.Peek().(efp.Token)
+			if !isBeginParenthesesToken(token) && !isFunctionStartToken(token) && token.TType != efp.TokenTypeOperatorPrefix {
 				break
 			}
 			savedTokens = append(savedTokens, opftStack.Pop().(efp.Token))

--- a/calc.go
+++ b/calc.go
@@ -1213,8 +1213,21 @@ func prepareEvalInfixExp(opfStack, opftStack, opfdStack, argsStack *Stack) {
 	argument := true
 	if opftStack.Len() > 2 && opfdStack.Len() == 1 {
 		topOpt := opftStack.Pop()
-		if opftStack.Peek().(efp.Token).TType == efp.TokenTypeOperatorInfix {
+		// Look past any subexpression start and function start tokens.
+		var savedTokens []efp.Token
+		for opftStack.Len() > 0 {
+			tok := opftStack.Peek().(efp.Token)
+			if !isBeginParenthesesToken(tok) && !isFunctionStartToken(tok) {
+				break
+			}
+			savedTokens = append(savedTokens, opftStack.Pop().(efp.Token))
+		}
+		if opftStack.Len() > 0 && opftStack.Peek().(efp.Token).TType == efp.TokenTypeOperatorInfix {
 			argument = false
+		}
+		// Restore saved tokens
+		for i := len(savedTokens) - 1; i >= 0; i-- {
+			opftStack.Push(savedTokens[i])
 		}
 		opftStack.Push(topOpt)
 	}

--- a/calc_test.go
+++ b/calc_test.go
@@ -895,6 +895,7 @@ func TestCalcCellValue(t *testing.T) {
 		"SUM(1+ROW())":                       "2",
 		"SUM((SUM(2))+1)":                    "3",
 		"SUM(1+(ABS(A1)+A1)/2)":              "2",
+		"SUM(1+(-ABS(A1)))":                  "0",
 		"IF(2<0, 1, (4))":                    "4",
 		"IF(2>0, (1), 4)":                    "1",
 		"IF(2>0, (A1)*2.5, 4)":               "2.5",

--- a/calc_test.go
+++ b/calc_test.go
@@ -894,6 +894,7 @@ func TestCalcCellValue(t *testing.T) {
 		"1+SUM(SUM(1,2*3),4)*4/3+5+(4+2)*3":  "38.6666666666667",
 		"SUM(1+ROW())":                       "2",
 		"SUM((SUM(2))+1)":                    "3",
+		"SUM(1+(ABS(A1)+A1)/2)":              "2",
 		"IF(2<0, 1, (4))":                    "4",
 		"IF(2>0, (1), 4)":                    "1",
 		"IF(2>0, (A1)*2.5, 4)":               "2.5",
@@ -1998,6 +1999,7 @@ func TestCalcCellValue(t *testing.T) {
 		"IF(FALSE,0,ROUND(4/2,0))":                  "2",
 		"IF(TRUE,ROUND(4/2,0),0)":                   "2",
 		"IF(A4>0.4,\"TRUE\",\"FALSE\")":             "FALSE",
+		"IF(A1=0,0,1+(SUM(ABS(A1))))":               "2",
 		// Excel Lookup and Reference Functions
 		// ADDRESS
 		"ADDRESS(1,1,1,TRUE)":            "$A$1",


### PR DESCRIPTION
## Description

When a function argument contains an expression like 1+(ABS(A1)+A1)/2, the formula parser in prepareEvalInfixExp miscounts the outer function's arguments (e.g. IF or SUM), throwing errors like "IF accepts at most 3 arguments".

Root cause: when an inner function closes, the code checks whether the operand on opfdStack belongs to the current function or an outer expression by looking at the token directly below on opftStack. If a subexpression-start token "(" or another function-start token (e.g. SUM) sits between the function marker and the actual infix operator (e.g. +), this check fails and the operand gets wrongly consumed as a function argument.

## Related Issue

https://github.com/qax-os/excelize/issues/1164

## Motivation and Context

The added unit tests would fail without this fix while they are valid in MS Excel.

## How Has This Been Tested

Added unit tests

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
