### PR TITLE
Related to #1164: fix errors pushed as extra func arguments

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -1118,7 +1118,7 @@ func (f *File) evalInfixExp(ctx *calcContext, sheet, cell string, tokens []efp.T
 					// calculate trigger
 					topOpt := opftStack.Peek().(efp.Token)
 					if err := calculate(opfdStack, topOpt); err != nil {
-						argsStack.Peek().(*list.List).PushFront(newErrorFormulaArg(formulaErrorVALUE, err.Error()))
+						opfdStack.Push(newErrorFormulaArg(err.Error(), err.Error()))
 					}
 					opftStack.Pop()
 				}
@@ -1585,7 +1585,7 @@ func (f *File) parseToken(ctx *calcContext, sheet string, token efp.Token, opdSt
 			if err := calculate(opdStack, topOpt); err != nil {
 				opdStack.Push(newErrorFormulaArg(err.Error(), err.Error()))
 				optStack.Pop()
-				break
+				continue
 			}
 			optStack.Pop()
 		}
@@ -15029,6 +15029,8 @@ func (fn *formulaFuncs) IF(argsList *list.List) formulaArg {
 		result formulaArg
 	)
 	switch token.Type {
+	case ArgError:
+		return token
 	case ArgString:
 		if cond, err = strconv.ParseBool(token.Value()); err != nil {
 			return newErrorFormulaArg(formulaErrorVALUE, err.Error())

--- a/calc.go
+++ b/calc.go
@@ -1204,7 +1204,7 @@ func prepareEvalInfixExp(opfStack, opftStack, opfdStack, argsStack *Stack) {
 		// calculate trigger
 		topOpt := opftStack.Peek().(efp.Token)
 		if err := calculate(opfdStack, topOpt); err != nil {
-			argsStack.Peek().(*list.List).PushBack(newErrorFormulaArg(err.Error(), err.Error()))
+			opfdStack.Push(newErrorFormulaArg(err.Error(), err.Error()))
 			opftStack.Pop()
 			continue
 		}

--- a/calc_test.go
+++ b/calc_test.go
@@ -2001,6 +2001,7 @@ func TestCalcCellValue(t *testing.T) {
 		"IF(TRUE,ROUND(4/2,0),0)":                   "2",
 		"IF(A4>0.4,\"TRUE\",\"FALSE\")":             "FALSE",
 		"IF(A1=0,0,1+(SUM(ABS(A1))))":               "2",
+		"IF(C1=0,0,A1/C1+B1/C1)":                    "0",
 		// Excel Lookup and Reference Functions
 		// ADDRESS
 		"ADDRESS(1,1,1,TRUE)":            "$A$1",

--- a/calc_test.go
+++ b/calc_test.go
@@ -2325,18 +2325,19 @@ func TestCalcCellValue(t *testing.T) {
 		assert.Equal(t, expected, result, formula)
 	}
 	mathCalcError := map[string][]string{
-		"1/0":        {"", "#DIV/0!"},
-		"(1/0)":      {"", "#DIV/0!"},
-		"1^\"text\"": {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
-		"\"text\"^1": {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
-		"1+\"text\"": {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
-		"\"text\"+1": {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
-		"1-\"text\"": {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
-		"\"text\"-1": {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
-		"1*\"text\"": {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
-		"\"text\"*1": {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
-		"1/\"text\"": {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
-		"\"text\"/1": {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
+		"1/0":         {"", "#DIV/0!"},
+		"(1/0)":       {"", "#DIV/0!"},
+		"(A1/0+B1/0)": {"", "#DIV/0!"},
+		"1^\"text\"":  {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
+		"\"text\"^1":  {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
+		"1+\"text\"":  {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
+		"\"text\"+1":  {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
+		"1-\"text\"":  {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
+		"\"text\"-1":  {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
+		"1*\"text\"":  {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
+		"\"text\"*1":  {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
+		"1/\"text\"":  {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
+		"\"text\"/1":  {"", "strconv.ParseFloat: parsing \"text\": invalid syntax"},
 		// Engineering Functions
 		// BESSELI
 		"BESSELI()":       {"#VALUE!", "BESSELI requires 2 numeric arguments"},
@@ -4058,9 +4059,10 @@ func TestCalcCellValue(t *testing.T) {
 		"UPPER(1,2)": {"#VALUE!", "UPPER requires 1 argument"},
 		// Conditional Functions
 		// IF
-		"IF()":        {"#VALUE!", "IF requires at least 1 argument"},
-		"IF(0,1,2,3)": {"#VALUE!", "IF accepts at most 3 arguments"},
-		"IF(D1,1,2)":  {"#VALUE!", "strconv.ParseBool: parsing \"Month\": invalid syntax"},
+		"IF(A1/C1+B1/C1,0,1)": {"#DIV/0!", "#DIV/0!"},
+		"IF()":                {"#VALUE!", "IF requires at least 1 argument"},
+		"IF(0,1,2,3)":         {"#VALUE!", "IF accepts at most 3 arguments"},
+		"IF(D1,1,2)":          {"#VALUE!", "strconv.ParseBool: parsing \"Month\": invalid syntax"},
 		// Excel Lookup and Reference Functions
 		// ADDRESS
 		"ADDRESS()":                        {"#VALUE!", "ADDRESS requires at least 2 arguments"},
@@ -4749,7 +4751,7 @@ func TestCalcCellValue(t *testing.T) {
 		// MDETERM
 		"MDETERM(A1:B3)": {"#VALUE!", "#VALUE!"},
 		// SUM
-		"1+SUM(SUM(A1+A2/A4)*(2-3),2)": {"#VALUE!", "#DIV/0!"},
+		"1+SUM(SUM(A1+A2/A4)*(2-3),2)": {"#DIV/0!", "#DIV/0!"},
 	}
 	for formula, expected := range referenceCalcError {
 		f := prepareCalcData(cellData)

--- a/pivotTable.go
+++ b/pivotTable.go
@@ -66,7 +66,6 @@ type PivotTableOptions struct {
 	PivotTableStyleName string
 }
 
-
 // PivotTableShowValuesAsType is the type of calculation for showing values in a
 // pivot table.
 type PivotTableShowValuesAsType byte


### PR DESCRIPTION
# PR Details

Fix calculation error propagation in function argument expressions

## Description

This fixes incorrect error propagation in `prepareEvalInfixExp` when an arithmetic error (e.g. `#DIV/0!`) occurs while evaluating an expression inside a function argument. 
Previously, when `calculate()` returned an error, the error was pushed to `argsStack` (the function's argument list) instead of `opfdStack` (the operand stack of the current expression). This caused each failed operation to be counted as an additional argument of the enclosing function. For example, `IF(C1=0,0,A1/C1+B1/C1)` with `C1=0` would fail with "IF accepts at most 3 arguments".

## Related Issue

Related to recent PR https://github.com/qax-os/excelize/pull/2348 and also related to https://github.com/qax-os/excelize/issues/2344

## Motivation and Context

Formulas like =IF(C1=0,0,A1/C1+B1/C1) would fail while still being a valid excel formula.

## How Has This Been Tested

Added unit test

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
