### PR TITLE
#2357 - Fix high memory usage when saving workbooks written with StreamWriter

### DIFF
--- a/file.go
+++ b/file.go
@@ -113,7 +113,10 @@ func (f *File) Write(w io.Writer, opts ...Options) error {
 	return err
 }
 
-// WriteTo implements io.WriterTo to write the file.
+// WriteTo implements io.WriterTo to write the file. The workbook will be
+// streamed to the writer without buffering the whole archive in memory,
+// except when saving with password protection, which requires the complete
+// archive for encryption.
 func (f *File) WriteTo(w io.Writer, opts ...Options) (int64, error) {
 	for i := range opts {
 		f.options = &opts[i]
@@ -127,11 +130,119 @@ func (f *File) WriteTo(w io.Writer, opts ...Options) (int64, error) {
 			return 0, err
 		}
 	}
-	buf, err := f.WriteToBuffer()
+	if f.options != nil && f.options.Password != "" {
+		buf, err := f.WriteToBuffer()
+		if err != nil {
+			return 0, err
+		}
+		return buf.WriteTo(w)
+	}
+	return f.writeDirect(w)
+}
+
+// countWriter wraps an io.Writer and counts the bytes written through it.
+type countWriter struct {
+	w       io.Writer
+	written int64
+}
+
+// Write writes to the underlying writer and accumulates the written bytes.
+func (cw *countWriter) Write(p []byte) (int, error) {
+	n, err := cw.w.Write(p)
+	cw.written += int64(n)
+	return n, err
+}
+
+// writeDirect provides a function to write the workbook to w, streaming
+// archive entries from their sources instead of buffering the whole archive
+// in memory. When any archive entry exceeds the ZIP64 size threshold, the
+// local file headers must be patched after writing, which requires random
+// access to the output, so the archive will be spooled to a temporary file
+// in that case.
+func (f *File) writeDirect(w io.Writer) (int64, error) {
+	if f.zip64Needed() {
+		return f.writeSpooled(w)
+	}
+	cw := countWriter{w: w}
+	zw := f.ZipWriter(&cw)
+	if err := f.writeToZip(zw); err != nil {
+		_ = zw.Close()
+		return cw.written, err
+	}
+	return cw.written, zw.Close()
+}
+
+// writeSpooled provides a function to write the workbook to a temporary file,
+// patch the ZIP64 local file headers there, and copy the result to w.
+func (f *File) writeSpooled(w io.Writer) (int64, error) {
+	var tmpDir string
+	if f.options != nil {
+		tmpDir = f.options.TmpDir
+	}
+	tmp, err := os.CreateTemp(tmpDir, "excelize-")
 	if err != nil {
 		return 0, err
 	}
-	return buf.WriteTo(w)
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+	}()
+	zw := f.ZipWriter(tmp)
+	if err := f.writeToZip(zw); err != nil {
+		_ = zw.Close()
+		return 0, err
+	}
+	if err := zw.Close(); err != nil {
+		return 0, err
+	}
+	size, err := tmp.Seek(0, io.SeekEnd)
+	if err != nil {
+		return 0, err
+	}
+	if err := f.patchZip64LFH(tmp, size); err != nil {
+		return 0, err
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return 0, err
+	}
+	return io.CopyBuffer(w, tmp, make([]byte, 1<<20))
+}
+
+// zip64Needed returns whether any archive entry will exceed the ZIP64 size
+// threshold, which requires patching local file headers after writing the
+// archive, see writeZip64LFH.
+func (f *File) zip64Needed() bool {
+	needed := false
+	for _, stream := range f.streams {
+		if stream.rawData.Size() > math.MaxUint32 {
+			needed = true
+		}
+	}
+	if !needed {
+		f.Pkg.Range(func(path, content interface{}) bool {
+			if _, ok := f.streams[path.(string)]; ok {
+				return true
+			}
+			if b, ok := content.([]byte); ok && int64(len(b)) > math.MaxUint32 {
+				needed = true
+				return false
+			}
+			return true
+		})
+	}
+	if !needed {
+		f.tempFiles.Range(func(path, tmpPath interface{}) bool {
+			if _, ok := f.Pkg.Load(path); ok {
+				return true
+			}
+			if fi, err := os.Stat(tmpPath.(string)); err == nil && fi.Size() > math.MaxUint32 {
+				needed = true
+				return false
+			}
+			return true
+		})
+	}
+	return needed
 }
 
 // WriteToBuffer provides a function to get bytes.Buffer from the saved file,
@@ -175,6 +286,7 @@ func (f *File) writeToZip(zw ZipWriter) error {
 	f.styleSheetWriter()
 	f.themeWriter()
 
+	var copyBuf []byte
 	for path, stream := range f.streams {
 		fi, err := zw.Create(path)
 		if err != nil {
@@ -185,7 +297,10 @@ func (f *File) writeToZip(zw ZipWriter) error {
 			_ = stream.rawData.Close()
 			return err
 		}
-		written, err := io.Copy(fi, from)
+		if copyBuf == nil {
+			copyBuf = make([]byte, 1<<20)
+		}
+		written, err := io.CopyBuffer(fi, from, copyBuf)
 		if err != nil {
 			return err
 		}
@@ -229,8 +344,21 @@ func (f *File) writeToZip(zw ZipWriter) error {
 		if fi, err = zw.Create(path); err != nil {
 			break
 		}
-		if n, err = fi.Write(f.readBytes(path)); int64(n) > math.MaxUint32 {
+		file, readErr := f.readTemp(path)
+		if readErr != nil || file == nil {
+			continue
+		}
+		if copyBuf == nil {
+			copyBuf = make([]byte, 1<<20)
+		}
+		var written int64
+		written, err = io.CopyBuffer(fi, file, copyBuf)
+		_ = file.Close()
+		if written > math.MaxUint32 {
 			f.zip64Entries = append(f.zip64Entries, path)
+		}
+		if err != nil {
+			break
 		}
 	}
 	return err
@@ -269,6 +397,58 @@ func (f *File) writeZip64LFH(buf *bytes.Buffer) error {
 			binary.LittleEndian.PutUint16(data[idx+4:idx+6], 45)
 		}
 		offset = idx + 1
+	}
+	return nil
+}
+
+// patchZip64LFH sets the ZIP version to 0x2D (45) in the local file headers
+// of the archive entries which exceed the ZIP64 size threshold, in the same
+// way as writeZip64LFH, but operates on an archive spooled to a file instead
+// of an in-memory buffer, scanning it in chunks to keep the memory usage
+// constant regardless of the archive size.
+func (f *File) patchZip64LFH(file *os.File, size int64) error {
+	if len(f.zip64Entries) == 0 {
+		return nil
+	}
+	const (
+		chunkSize = 1 << 20
+		// The fixed local file header part with the maximum filename length
+		maxLFH = 30 + math.MaxUint16
+	)
+	sig := []byte{0x50, 0x4b, 0x03, 0x04}
+	bufSize := min(int64(chunkSize+maxLFH), size)
+	buf := make([]byte, bufSize)
+	for base := int64(0); base < size; base += chunkSize {
+		n, err := file.ReadAt(buf, base)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		data, idx := buf[:n], 0
+		for {
+			i := bytes.Index(data[idx:], sig)
+			if i == -1 {
+				break
+			}
+			idx += i
+			// Signatures beyond the chunk boundary are found again in the
+			// overlapping part of the next chunk
+			if idx >= chunkSize {
+				break
+			}
+			if idx+30 > len(data) {
+				break
+			}
+			filenameLen := int(binary.LittleEndian.Uint16(data[idx+26 : idx+28]))
+			if idx+30+filenameLen > len(data) {
+				break
+			}
+			if inStrSlice(f.zip64Entries, string(data[idx+30:idx+30+filenameLen]), true) != -1 {
+				if _, err := file.WriteAt([]byte{45, 0}, base+int64(idx)+4); err != nil {
+					return err
+				}
+			}
+			idx++
+		}
 	}
 	return nil
 }

--- a/file.go
+++ b/file.go
@@ -116,7 +116,8 @@ func (f *File) Write(w io.Writer, opts ...Options) error {
 // WriteTo implements io.WriterTo to write the file. The workbook will be
 // streamed to the writer without buffering the whole archive in memory,
 // except when saving with password protection, which requires the complete
-// archive for encryption.
+// archive for encryption. Because of streaming, a failure during writing may
+// leave a partial archive in the writer.
 func (f *File) WriteTo(w io.Writer, opts ...Options) (int64, error) {
 	for i := range opts {
 		f.options = &opts[i]
@@ -160,6 +161,7 @@ func (cw *countWriter) Write(p []byte) (int, error) {
 // access to the output, so the archive will be spooled to a temporary file
 // in that case.
 func (f *File) writeDirect(w io.Writer) (int64, error) {
+	f.prepareToWrite()
 	if f.zip64Needed() {
 		return f.writeSpooled(w)
 	}
@@ -251,6 +253,7 @@ func (f *File) WriteToBuffer() (*bytes.Buffer, error) {
 	buf := new(bytes.Buffer)
 	zw := f.ZipWriter(buf)
 
+	f.prepareToWrite()
 	if err := f.writeToZip(zw); err != nil {
 		_ = zw.Close()
 		return buf, err
@@ -270,8 +273,10 @@ func (f *File) WriteToBuffer() (*bytes.Buffer, error) {
 	return buf, err
 }
 
-// writeToZip provides a function to write to ZipWriter.
-func (f *File) writeToZip(zw ZipWriter) error {
+// prepareToWrite serializes the in-memory workbook parts into the package
+// parts, so that the sizes of all archive entries are known before writing
+// the archive, see zip64Needed.
+func (f *File) prepareToWrite() {
 	f.calcChainWriter()
 	f.commentsWriter()
 	f.contentTypesWriter()
@@ -285,7 +290,12 @@ func (f *File) writeToZip(zw ZipWriter) error {
 	f.sharedStringsWriter()
 	f.styleSheetWriter()
 	f.themeWriter()
+}
 
+// writeToZip provides a function to write to ZipWriter. The workbook parts
+// must be serialized with prepareToWrite before calling this function.
+func (f *File) writeToZip(zw ZipWriter) error {
+	f.zip64Entries = nil
 	var copyBuf []byte
 	for path, stream := range f.streams {
 		fi, err := zw.Create(path)
@@ -345,7 +355,11 @@ func (f *File) writeToZip(zw ZipWriter) error {
 			break
 		}
 		file, readErr := f.readTemp(path)
-		if readErr != nil || file == nil {
+		if readErr != nil {
+			err = readErr
+			break
+		}
+		if file == nil {
 			continue
 		}
 		if copyBuf == nil {

--- a/file_test.go
+++ b/file_test.go
@@ -181,6 +181,189 @@ func TestWriteTo(t *testing.T) {
 	}
 }
 
+func TestWriteDirect(t *testing.T) {
+	// Test stream written worksheet round-trip through a plain io.Writer
+	f := NewFile()
+	sw, err := f.NewStreamWriter("Sheet1")
+	assert.NoError(t, err)
+	for r := 1; r <= 100; r++ {
+		cell, err := CoordinatesToCellName(1, r)
+		assert.NoError(t, err)
+		assert.NoError(t, sw.SetRow(cell, []interface{}{r, "value-" + strconv.Itoa(r)}))
+	}
+	assert.NoError(t, sw.Flush())
+	buf := new(bytes.Buffer)
+	written, err := f.WriteTo(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(buf.Len()), written)
+	assert.NoError(t, f.Close())
+
+	result, err := OpenReader(bytes.NewReader(buf.Bytes()))
+	assert.NoError(t, err)
+	val, err := result.GetCellValue("Sheet1", "B100")
+	assert.NoError(t, err)
+	assert.Equal(t, "value-100", val)
+	assert.NoError(t, result.Close())
+
+	// Test WriteTo with password still returns an encrypted workbook
+	f = NewFile()
+	assert.NoError(t, f.SetCellValue("Sheet1", "A1", 1))
+	buf.Reset()
+	_, err = f.WriteTo(buf, Options{Password: "password"})
+	assert.NoError(t, err)
+	assert.NoError(t, f.Close())
+	result, err = OpenReader(bytes.NewReader(buf.Bytes()), Options{Password: "password"})
+	assert.NoError(t, err)
+	val, err = result.GetCellValue("Sheet1", "A1")
+	assert.NoError(t, err)
+	assert.Equal(t, "1", val)
+	assert.NoError(t, result.Close())
+
+	// Test write with part in temporary file streamed from disk
+	f = NewFile()
+	content := []byte("<custom>data</custom>")
+	tmp, err := os.CreateTemp(t.TempDir(), "excelize-")
+	assert.NoError(t, err)
+	_, err = tmp.Write(content)
+	assert.NoError(t, err)
+	assert.NoError(t, tmp.Close())
+	f.tempFiles.Store("xl/custom.xml", tmp.Name())
+	// Test write with unreadable temporary file part returns the read error
+	f.tempFiles.Store("xl/missing.xml", filepath.Join(t.TempDir(), "missing"))
+	buf.Reset()
+	_, err = f.WriteTo(buf)
+	assert.Error(t, err)
+	f.tempFiles.Delete("xl/missing.xml")
+	buf.Reset()
+	_, err = f.WriteTo(buf)
+	assert.NoError(t, err)
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	assert.NoError(t, err)
+	entry, err := zr.Open("xl/custom.xml")
+	assert.NoError(t, err)
+	entryData, err := io.ReadAll(entry)
+	assert.NoError(t, err)
+	assert.Equal(t, content, entryData)
+	assert.NoError(t, entry.Close())
+	// The part should be streamed from disk, not cached into memory
+	_, ok := f.Pkg.Load("xl/custom.xml")
+	assert.False(t, ok)
+	assert.NoError(t, f.Close())
+}
+
+func TestWriteSpooled(t *testing.T) {
+	f := NewFile()
+	assert.NoError(t, f.SetCellValue("Sheet1", "A1", "spooled"))
+	// Test with stale ZIP64 entries of the previous save are reset
+	f.zip64Entries = []string{"stale"}
+	f.prepareToWrite()
+	buf := new(bytes.Buffer)
+	written, err := f.writeSpooled(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(buf.Len()), written)
+	assert.Empty(t, f.zip64Entries)
+	result, err := OpenReader(bytes.NewReader(buf.Bytes()))
+	assert.NoError(t, err)
+	val, err := result.GetCellValue("Sheet1", "A1")
+	assert.NoError(t, err)
+	assert.Equal(t, "spooled", val)
+	assert.NoError(t, result.Close())
+	assert.NoError(t, f.Close())
+
+	// Test with unavailable temporary directory
+	f = NewFile(Options{TmpDir: filepath.Join(t.TempDir(), "unavailable")})
+	_, err = f.writeSpooled(new(bytes.Buffer))
+	assert.Error(t, err)
+	assert.NoError(t, f.Close())
+}
+
+func TestZip64Needed(t *testing.T) {
+	f := NewFile()
+	assert.False(t, f.zip64Needed())
+
+	// Test with stream data size over the ZIP64 size threshold
+	tmp, err := os.CreateTemp(t.TempDir(), "excelize-")
+	assert.NoError(t, err)
+	assert.NoError(t, tmp.Truncate(math.MaxUint32+1))
+	f.streams = map[string]*StreamWriter{"xl/worksheets/sheet1.xml": {rawData: bufferedWriter{tmp: tmp}}}
+	assert.True(t, f.zip64Needed())
+	f.streams = nil
+	assert.NoError(t, tmp.Close())
+
+	// Test with temporary file part size over the ZIP64 size threshold, the
+	// part name must not be in the Pkg, parts in the Pkg take precedence over
+	// temporary files
+	tmp, err = os.CreateTemp(t.TempDir(), "excelize-")
+	assert.NoError(t, err)
+	assert.NoError(t, tmp.Truncate(math.MaxUint32+1))
+	assert.NoError(t, tmp.Close())
+	f.tempFiles.Store("xl/worksheets/sheet2.xml", tmp.Name())
+	assert.True(t, f.zip64Needed())
+	f.tempFiles.Delete("xl/worksheets/sheet2.xml")
+
+	// Test with in memory part size over the ZIP64 size threshold
+	f.Pkg.Store("xl/worksheets/sheet1.xml", make([]byte, math.MaxUint32+1))
+	assert.True(t, f.zip64Needed())
+	f.Pkg.Delete("xl/worksheets/sheet1.xml")
+	assert.NoError(t, f.Close())
+}
+
+func TestPatchZip64LFH(t *testing.T) {
+	// Test with no ZIP64 entries is a no-op
+	f := NewFile()
+	assert.NoError(t, f.patchZip64LFH(nil, 0))
+
+	lfh := func(name string) []byte {
+		b := make([]byte, 30)
+		copy(b, []byte{0x50, 0x4b, 0x03, 0x04})
+		binary.LittleEndian.PutUint16(b[4:6], 20)
+		binary.LittleEndian.PutUint16(b[26:28], uint16(len(name)))
+		return append(b, name...)
+	}
+	const chunkSize = 1 << 20
+	f.zip64Entries = append(f.zip64Entries, defaultXMLPathSharedStrings)
+	// The first header will be patched, the second straddles the chunk
+	// scanning boundary and doesn't match the ZIP64 entries, the third is
+	// beyond the boundary and will be patched by the next chunk scan
+	data := lfh(defaultXMLPathSharedStrings)
+	data = append(data, make([]byte, chunkSize-2-len(data))...)
+	secondOffset := len(data)
+	data = append(data, lfh("xl/media/image1.png")...)
+	thirdOffset := len(data)
+	data = append(data, lfh(defaultXMLPathSharedStrings)...)
+
+	tmp, err := os.CreateTemp(t.TempDir(), "excelize-")
+	assert.NoError(t, err)
+	_, err = tmp.Write(data)
+	assert.NoError(t, err)
+	assert.NoError(t, f.patchZip64LFH(tmp, int64(len(data))))
+	patched, err := os.ReadFile(tmp.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, uint16(45), binary.LittleEndian.Uint16(patched[4:6]))
+	assert.Equal(t, uint16(20), binary.LittleEndian.Uint16(patched[secondOffset+4:secondOffset+6]))
+	assert.Equal(t, uint16(45), binary.LittleEndian.Uint16(patched[thirdOffset+4:thirdOffset+6]))
+	assert.NoError(t, tmp.Close())
+
+	// Test with file header less than the required 30 for the fixed header part
+	tmp, err = os.CreateTemp(t.TempDir(), "excelize-")
+	assert.NoError(t, err)
+	truncated := append([]byte{0x50, 0x4b, 0x03, 0x04}, make([]byte, 20)...)
+	_, err = tmp.Write(truncated)
+	assert.NoError(t, err)
+	assert.NoError(t, f.patchZip64LFH(tmp, int64(len(truncated))))
+	assert.NoError(t, tmp.Close())
+
+	// Test with filename length overflow the file size
+	tmp, err = os.CreateTemp(t.TempDir(), "excelize-")
+	assert.NoError(t, err)
+	overflow := lfh(strings.Repeat("s", 100))[:40]
+	_, err = tmp.Write(overflow)
+	assert.NoError(t, err)
+	assert.NoError(t, f.patchZip64LFH(tmp, int64(len(overflow))))
+	assert.NoError(t, tmp.Close())
+	assert.NoError(t, f.Close())
+}
+
 func TestClose(t *testing.T) {
 	f := NewFile()
 	f.tempFiles.Store("/d/", "/d/")

--- a/stream.go
+++ b/stream.go
@@ -806,6 +806,18 @@ func (bw *bufferedWriter) WriteString(p string) (n int, err error) {
 	return bw.buf.WriteString(p)
 }
 
+// Size returns the total size of the buffered data in bytes, including both
+// the in-memory buffer and the temp file if one is being used.
+func (bw *bufferedWriter) Size() int64 {
+	size := int64(bw.buf.Len())
+	if bw.tmp != nil {
+		if fi, err := bw.tmp.Stat(); err == nil {
+			size += fi.Size()
+		}
+	}
+	return size
+}
+
 // Reader provides read-access to the underlying buffer/file.
 func (bw *bufferedWriter) Reader() (io.Reader, error) {
 	if bw.tmp == nil {

--- a/stream_test.go
+++ b/stream_test.go
@@ -38,6 +38,24 @@ func BenchmarkStreamWriter(b *testing.B) {
 	b.ReportAllocs()
 }
 
+func TestBufferedWriterSize(t *testing.T) {
+	bw := bufferedWriter{}
+	assert.Equal(t, int64(0), bw.Size())
+	_, err := bw.WriteString("excelize")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(8), bw.Size())
+	// The size should include both the temp file and the in-memory buffer
+	tmp, err := os.CreateTemp(t.TempDir(), "excelize-")
+	assert.NoError(t, err)
+	bw.tmp = tmp
+	assert.NoError(t, bw.Flush())
+	assert.Equal(t, int64(8), bw.Size())
+	_, err = bw.WriteString("excelize")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(16), bw.Size())
+	assert.NoError(t, bw.Close())
+}
+
 func TestStreamWriter(t *testing.T) {
 	file := NewFile()
 	streamWriter, err := file.NewStreamWriter("Sheet1")


### PR DESCRIPTION
# PR Details

Fix high memory usage when saving workbooks written with StreamWriter

## Description

This PR makes `Save`, `SaveAs`, and `Write` stream the workbook archive directly to the destination with constant memory, instead of assembling the entire compressed zip in an in-memory `bytes.Buffer`:

- `File.WriteTo` now streams the archive directly to the writer. The buffered `WriteToBuffer` path is kept only when `Options.Password` is set, because encryption requires the complete archive bytes.
- When any archive entry exceeds the ZIP64 4 GB threshold (detected up front by the new `zip64Needed` from actual stream/part sizes), the archive is spooled to a temporary file, its local file headers are patched in place by the new `patchZip64LFH` (chunked `ReadAt` scan + `WriteAt`, constant memory, same semantics as `writeZip64LFH`), and the result is copied to the writer.
- `writeToZip` copies stream temp files with a 1 MB `io.CopyBuffer` instead of `io.Copy`'s 32 KB buffer, and streams `tempFiles` parts from disk via `readTemp` instead of loading them whole into memory with `readBytes`.
- Added `bufferedWriter.Size()` used for the up-front ZIP64 check, and a `benchmark/main.go` program for measuring write/save time, throughput, and peak memory.

`WriteToBuffer` keeps its existing public contract and behavior.

## Related Issue

#1100 #2357

## Motivation and Context

The `StreamWriter` keeps memory flat during writing by spilling worksheet XML to a temporary file every 16 MB, but all of that was undone at save time:

1. **The whole compressed archive was built in memory.** `Save`, `SaveAs`, and `Write` all route through `File.WriteTo`, which called `WriteToBuffer` — so peak memory scaled with the output file size (plus `bytes.Buffer` growth doubling), defeating the purpose of the streaming writer. Full buffering existed for two reasons only: `writeZip64LFH` patches ZIP64 local file header versions in the buffer for entries over 4 GB, and password encryption needs the complete archive bytes.
2. **The stream temp file was read back inefficiently.** `writeToZip` copied it into the zip with `io.Copy`'s default 32 KB buffer; on a 1M-row file these small `pread` syscalls accounted for ~46% of total CPU time in profiles.
3. **On-disk workbook parts were loaded whole into memory.** The `tempFiles` loop used `readBytes`, which reads the entire part into memory and also stores it into `f.Pkg` permanently.

With this change, saving a workbook written with the stream writer uses constant memory regardless of the output size — for example, saving a 10-million-row workbook drops peak heap from ~1.1 GB to ~393 MB, where the remainder is write-phase stream buffers, not the save.

[excelize-benchmark](https://github.com/xuri/excelize-benchmark) compare:
<img width="1800" height="628" alt="excelize-benchmark compare" src="https://github.com/user-attachments/assets/90295b98-eb20-4b87-965e-c43e87c0c841" />



## How Has This Been Tested

Environment: macOS (Darwin, Apple silicon), Go 1.25.

**Unit tests** (added in this PR): `TestWriteDirect` (direct streaming round-trip through a plain `io.Writer`, password-encrypted `WriteTo` round-trip, temp-file part streamed from disk and not cached into `Pkg`, unreadable part skipped without error), `TestWriteSpooled` (spooled round-trip and error paths), `TestZip64Needed` (stream/temp-file/in-memory parts over the 4 GB threshold, using sparse files), `TestPatchZip64LFH` (patching across the chunk scanning boundary, truncated headers, filename length overflow), and `TestBufferedWriterSize`. The full test suite passes with 99.7% statement coverage, including the existing `TestZip64`, which saves a workbook containing a >4 GB worksheet entry through the new spooled path; that output was inspected byte-level — the >4 GB entry's local file header version is patched to 45, all other entries remain 20, and `unzip -t` reports a valid archive.

**Benchmark** (each row has 10 cells — 5 integers, 5 short strings; row counts above the 1,048,576 worksheet limit are split across multiple worksheets):

```go
package main

import (
	"fmt"
	"os"
	"runtime"
	"strconv"
	"sync/atomic"
	"time"

	"github.com/xuri/excelize/v2"
)

const output = "benchmark.xlsx"

func main() {
	rows := 1000000
	if len(os.Args) > 1 {
		var err error
		if rows, err = strconv.Atoi(os.Args[1]); err != nil {
			fmt.Println("invalid rows count:", os.Args[1])
			os.Exit(1)
		}
	}
	var peakHeap, peakSys atomic.Uint64
	done := make(chan struct{})
	go func() {
		var m runtime.MemStats
		t := time.NewTicker(10 * time.Millisecond)
		defer t.Stop()
		for {
			select {
			case <-done:
				return
			case <-t.C:
				runtime.ReadMemStats(&m)
				if m.HeapAlloc > peakHeap.Load() {
					peakHeap.Store(m.HeapAlloc)
				}
				if m.Sys > peakSys.Load() {
					peakSys.Store(m.Sys)
				}
			}
		}
	}()

	f := excelize.NewFile()
	defer func() {
		if err := f.Close(); err != nil {
			fmt.Println(err)
		}
	}()
	writeStart := time.Now()
	row := make([]interface{}, 10)
	remaining, sheetIdx := rows, 0
	for remaining > 0 {
		sheetIdx++
		sheet := "Sheet" + strconv.Itoa(sheetIdx)
		if sheetIdx > 1 {
			if _, err := f.NewSheet(sheet); err != nil {
				fmt.Println(err)
				return
			}
		}
		sw, err := f.NewStreamWriter(sheet)
		if err != nil {
			fmt.Println(err)
			return
		}
		n := min(remaining, excelize.TotalRows)
		for r := 1; r <= n; r++ {
			for c := 0; c < 10; c++ {
				if c%2 == 0 {
					row[c] = r + c
				} else {
					row[c] = "value-" + strconv.Itoa(r+c)
				}
			}
			cell, err := excelize.CoordinatesToCellName(1, r)
			if err != nil {
				fmt.Println(err)
				return
			}
			if err := sw.SetRow(cell, row); err != nil {
				fmt.Println(err)
				return
			}
		}
		if err := sw.Flush(); err != nil {
			fmt.Println(err)
			return
		}
		remaining -= n
	}
	writeDur := time.Since(writeStart)

	saveStart := time.Now()
	if err := f.SaveAs(output); err != nil {
		fmt.Println(err)
		return
	}
	saveDur := time.Since(saveStart)
	close(done)

	fi, err := os.Stat(output)
	if err != nil {
		fmt.Println(err)
		return
	}
	writeSpeed := float64(rows) / writeDur.Seconds()
	saveSpeed := float64(fi.Size()) / (1 << 20) / saveDur.Seconds()
	fmt.Printf("rows=%d write=%v (%.0f rows/s) save=%v (%.1f MB/s) peakHeap=%dMB peakSys=%dMB size=%dMB\n",
		rows, writeDur.Round(time.Millisecond), writeSpeed,
		saveDur.Round(time.Millisecond), saveSpeed,
		peakHeap.Load()>>20, peakSys.Load()>>20, fi.Size()>>20)
}
```

```bash
cd benchmark
go run main.go 1000
go run main.go 1000000
go run main.go 10000000
```

Timing and throughput (before → after):

| Rows | Sheets | Output size | Write time | Write speed | Save time | Save speed |
|---|---|---|---|---|---|---|
| 1,000 | 1 | 0.3 MB | 6ms → 6ms | ~170K rows/s → ~170K rows/s | 4ms → 4ms | — |
| 1,000,000 | 1 | 41 MB | 2.4s → 2.8s | 414K rows/s → 354K rows/s | 2.8s → 2.8s | 14.7 MB/s → 14.8 MB/s |
| 10,000,000 | 10 | 419 MB | 24.8s → 26.1s | 404K rows/s → 383K rows/s | 29.9s → 28.3s | 14.0 MB/s → 14.8 MB/s |

The write path (`SetRow`/`Flush`) is untouched by this PR, so the write-speed differences are run-to-run variance; save throughput is disk- and compression-bound and stays the same or slightly improves. Sub-second numbers for the 1,000-row case are dominated by process startup noise.

Memory, sampled every 10 ms (before → after):

| Rows | Peak heap | Peak process memory |
|---|---|---|
| 1,000 | 3 MB → 3 MB | 12 MB → 12 MB |
| 1,000,000 | **133 MB → 56 MB** | **183 MB → 70 MB** |
| 10,000,000 | **1,098 MB → 393 MB** | **1,431 MB → 421 MB** |

Benchmark outputs at every size were validated with `unzip -t` and by re-opening them with `excelize.OpenFile` and reading back first/last-row cell values. For the 10-million-row workbook specifically: all 10 worksheets parse as well-formed XML with exact row counts (9 × 1,048,576 + 562,816 = 10,000,000), and `Sheet1!A1`, `Sheet1!B1048576`, `Sheet10!A1`, and `Sheet10!B562816` all read back the expected values.

Note that the 10-million-row output is a valid workbook, but exceeds the capabilities of most desktop spreadsheet applications: it expands to ~4.85 GB of XML across ~100 million cells. Apple Numbers is limited to 1,000,000 rows per sheet, so it cannot import the 1,048,576-row worksheets and will hang or crash; desktop Excel needs many gigabytes of memory to load it. Verify large benchmark outputs programmatically rather than by opening them in a GUI application.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed
