### PR TITLE
This closes #2363, add new GetNonEmptyCells function

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -28,6 +28,12 @@ import (
 // CellType is the type of cell value type.
 type CellType byte
 
+// CellInfo represents the reference and value of a populated cell.
+type CellInfo struct {
+	Ref   string
+	Value string
+}
+
 // Cell value types enumeration.
 const (
 	CellTypeUnset CellType = iota
@@ -77,6 +83,46 @@ func (f *File) GetCellValue(sheet, cell string, opts ...Options) (string, error)
 		val, err := c.getValueFrom(f, sst, f.getOptions(opts...).RawCellValue)
 		return val, true, err
 	})
+}
+
+// GetNonEmptyCells provides a function to get all non-empty cells from a given
+// worksheet name in spreadsheet. The return value is a slice of CellInfo structs.
+// It is returned in row-major order, meaning that cells are ordered first by row and
+// then by column within each row. This function is concurrency safe.
+func (f *File) GetNonEmptyCells(sheet string, opts ...Options) ([]CellInfo, error) {
+	f.mu.Lock()
+	ws, err := f.workSheetReader(sheet)
+	if err != nil {
+		f.mu.Unlock()
+		return nil, err
+	}
+	f.mu.Unlock()
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	sst, err := f.sharedStringsReader()
+	if err != nil {
+		return nil, err
+	}
+	raw := f.getOptions(opts...).RawCellValue
+
+	var cells []CellInfo
+
+	for _, row := range ws.SheetData.Row {
+		for colIdx := range row.C {
+			cell := &row.C[colIdx]
+			val, err := cell.getValueFrom(f, sst, raw)
+			if err != nil {
+				return nil, err
+			}
+			if val != "" || cell.F != nil {
+				cells = append(cells, CellInfo{
+					Ref:   cell.R,
+					Value: val,
+				})
+			}
+		}
+	}
+	return cells, nil
 }
 
 // GetCellType provides a function to get the cell's data type by given

--- a/cell_test.go
+++ b/cell_test.go
@@ -374,6 +374,86 @@ func TestSetCellTime(t *testing.T) {
 	}
 }
 
+func TestGetNonEmptyCells(t *testing.T) {
+	// Test get non-empty cells with plain value cells
+	cells := []string{
+		"C1", "E1", "A3", "B3", "C3", "D3", "E3",
+	}
+	var expected []CellInfo
+
+	f := NewFile()
+	for _, cell := range cells {
+		assert.NoError(t, f.SetCellValue("Sheet1", cell, cell))
+		expected = append(expected, CellInfo{Ref: cell, Value: cell})
+	}
+	cellsInSheet, err := f.GetNonEmptyCells("Sheet1")
+	assert.NoError(t, err)
+	assert.Equal(t, expected, cellsInSheet)
+	assert.NoError(t, f.Close())
+
+	// Test get non-empty cells with formula cell
+	f = NewFile()
+	assert.NoError(t, f.SetCellFormula("Sheet1", "B1", "=SUM(1,1)"))
+	expected = []CellInfo{{Ref: "B1", Value: ""}}
+	cellsInSheet, err = f.GetNonEmptyCells("Sheet1")
+	assert.NoError(t, err)
+	assert.Equal(t, expected, cellsInSheet)
+	assert.NoError(t, f.Close())
+
+	// Test styled cell without value is skipped
+	f = NewFile()
+	styleID, err := f.NewStyle(&Style{Font: &Font{Bold: true}})
+	assert.NoError(t, err)
+	assert.NoError(t, f.SetCellStyle("Sheet1", "B1", "B1", styleID))
+	cellsInSheet, err = f.GetNonEmptyCells("Sheet1")
+	assert.NoError(t, err)
+	assert.Empty(t, cellsInSheet)
+	assert.NoError(t, f.Close())
+
+	// Test raw and formatted cell values
+	f = NewFile()
+	assert.NoError(t, f.SetCellValue("Sheet1", "A1", true))
+	// Formatted
+	formatCellsInSheet, err := f.GetNonEmptyCells("Sheet1")
+	assert.NoError(t, err)
+	assert.Equal(t, []CellInfo{{Ref: "A1", Value: "TRUE"}}, formatCellsInSheet)
+	// Raw
+	rawCellsInSheet, err := f.GetNonEmptyCells("Sheet1", Options{RawCellValue: true})
+	assert.NoError(t, err)
+	assert.Equal(t, []CellInfo{{Ref: "A1", Value: "1"}}, rawCellsInSheet)
+	assert.NoError(t, f.Close())
+
+	// Test empty worksheet
+	f = NewFile()
+	cellsInSheet, err = f.GetNonEmptyCells("Sheet1")
+	assert.NoError(t, err)
+	assert.Empty(t, cellsInSheet)
+	assert.NoError(t, f.Close())
+
+	// Test invalid sheet name
+	f = NewFile()
+	_, err = f.GetNonEmptyCells("Sheet:1")
+	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
+	assert.NoError(t, f.Close())
+
+	// Test non-existent sheet
+	f = NewFile()
+	_, err = f.GetNonEmptyCells("SheetN")
+	assert.EqualError(t, err, "sheet SheetN does not exist")
+	assert.NoError(t, f.Close())
+
+	// Cell without r attribute
+	f = NewFile()
+	sheetData := `<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData>%s</sheetData></worksheet>`
+	f.Sheet.Delete("xl/worksheets/sheet1.xml")
+	f.Pkg.Store("xl/worksheets/sheet1.xml", []byte(fmt.Sprintf(sheetData, `<row r="2"><c t="str"><v>x</v></c></row>`)))
+	f.checked = sync.Map{}
+	cellsInSheet, err = f.GetNonEmptyCells("Sheet1")
+	assert.NoError(t, err)
+	assert.Equal(t, []CellInfo{{Ref: "A2", Value: "x"}}, cellsInSheet)
+	assert.NoError(t, f.Close())
+}
+
 func TestGetCellValue(t *testing.T) {
 	// Test get cell value without r attribute of the row
 	f := NewFile()


### PR DESCRIPTION
## Description

Add a new `GetNonEmptyCells` function and `CellInfo` type that return all populated cells of a worksheet (reference + value) in row-major order, without the caller having to iterate empty cells. A cell is populated if its formatted value is non-empty or it contains a formula; styled-but-blank cells are skipped — the same rule the internal rows reader already applies.
Supports the `RawCellValue` option like `GetRows`.

## Related Issue

Closes #2363

## Motivation and Context

Reading sparse worksheets today requires `GetRows()` plus manual filtering of empty cells. The library already knows which cells are populated while parsing; this exposes that directly with a minimal API.

## How Has This Been Tested

New `TestGetNonEmptyCells` covering: sparse sheet ordering, formula-only cells, styled-only cells, `RawCellValue`, invalid/nonexistent sheet names, empty worksheet, and cells without an `r` attribute. Full package suite run locally with `go test -race` on macOS/arm64 (Go 1.26); `gofmt -s`, `go vet` and `golangci-lint` clean.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Notes

Kept the API deliberately minimal. Happy to rework and introduce e.g. a streaming iterator variant (as discussed in the issue), different naming etc.
If you'd prefer; the iterator could also come as a follow-up.