### PR TITLE
This closes #GHSA-48hm-4h8j-58fg, fix panic on negative shared string index

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -619,7 +619,11 @@ func (c *xlsxC) getValueFrom(f *File, d *xlsxSST, raw bool) (string, error) {
 		if c.V != "" {
 			xlsxSI, _ := strconv.Atoi(strings.TrimSpace(c.V))
 			if _, ok := f.tempFiles.Load(defaultXMLPathSharedStrings); ok {
-				return f.formattedValue(&xlsxC{S: c.S, V: f.getFromStringItem(xlsxSI)}, raw, CellTypeSharedString)
+				val, err := f.getFromStringItem(xlsxSI)
+				if err != nil {
+					return "", err
+				}
+				return f.formattedValue(&xlsxC{S: c.S, V: val}, raw, CellTypeSharedString)
 			}
 			d.mu.Lock()
 			defer d.mu.Unlock()

--- a/cell_test.go
+++ b/cell_test.go
@@ -574,6 +574,16 @@ func TestGetValueFrom(t *testing.T) {
 	value, err = c.getValueFrom(f, &xlsxSST{Count: 1, SI: []xlsxSI{{}, {T: &xlsxT{Val: "s"}}}}, false)
 	assert.Equal(t, newInvalidSharedStringIndex(-1), err)
 	assert.Empty(t, value)
+
+	f.tempFiles.Store(defaultXMLPathSharedStrings, "")
+	f.sharedStringTemp, err = os.CreateTemp(os.TempDir(), "excelize-")
+	assert.NoError(t, err)
+	c = xlsxC{T: "s", V: "-1"}
+	value, err = c.getValueFrom(f, sst, false)
+	assert.Equal(t, newInvalidSharedStringIndex(-1), err)
+	assert.Empty(t, value)
+	assert.NoError(t, f.sharedStringTemp.Close())
+	assert.NoError(t, os.Remove(f.sharedStringTemp.Name()))
 }
 
 func TestGetCellFormula(t *testing.T) {

--- a/cell_test.go
+++ b/cell_test.go
@@ -1199,10 +1199,14 @@ func TestSharedStringsError(t *testing.T) {
 	tempFile, ok := f.tempFiles.Load(defaultXMLPathSharedStrings)
 	assert.True(t, ok)
 	f.tempFiles.Store(defaultXMLPathSharedStrings, "")
-	assert.Equal(t, "1", f.getFromStringItem(1))
+	value, err := f.getFromStringItem(1)
+	assert.Equal(t, newInvalidSharedStringIndex(1), err)
+	assert.Empty(t, value)
 	// Test get from string item with invalid offset range
 	f.sharedStringItem = [][]uint{{0}}
-	assert.Equal(t, "0", f.getFromStringItem(0))
+	value, err = f.getFromStringItem(0)
+	assert.NoError(t, err)
+	assert.Equal(t, "0", value)
 	// Cleanup undelete temporary files
 	assert.NoError(t, os.Remove(tempFile.(string)))
 	// Test reload the file error on set cell value and rich text. The error message was different between macOS and Windows
@@ -1227,7 +1231,9 @@ func TestSharedStringsError(t *testing.T) {
 			assert.NoError(t, err)
 			// Test get cell value from string item with invalid offset
 			f.sharedStringItem[1] = []uint{maxUint16 - 1, maxUint16}
-			assert.Equal(t, "1", f.getFromStringItem(1))
+			value, err := f.getFromStringItem(1)
+			assert.NoError(t, err)
+			assert.Equal(t, "1", value)
 			break
 		}
 	}

--- a/errors.go
+++ b/errors.go
@@ -128,11 +128,11 @@ var (
 	// length.
 	ErrPasswordLengthInvalid = errors.New("password length invalid")
 	// ErrPivotTableShowValuesAsBaseField defined the error message on enable
-	// this kind of show value as type requires a base field.
-	ErrPivotTableShowValuesAsBaseField = errors.New("this kind of show value as type requires a base field")
+	// this kind of "show values as" type requires a base field.
+	ErrPivotTableShowValuesAsBaseField = errors.New("this kind of show values as type requires a base field")
 	// ErrPivotTableShowValuesAsBaseItem defined the error message on enable
-	// this kind of show value as type and base field requires a base item.
-	ErrPivotTableShowValuesAsBaseItem = errors.New("this kind of show value as type and base field requires a base item")
+	// this kind of "show values as" type and base field requires a base item.
+	ErrPivotTableShowValuesAsBaseItem = errors.New("this kind of show values as type and base field requires a base item")
 	// ErrPivotTableClassicLayout defined the error message on enable
 	// ClassicLayout and CompactData in the same time.
 	ErrPivotTableClassicLayout = errors.New("cannot enable ClassicLayout and CompactData in the same time")
@@ -199,8 +199,8 @@ var (
 	// number format expression.
 	ErrUnsupportedNumberFormat = errors.New("unsupported number format token")
 	// ErrUnsupportedPivotTableShowValuesAsType defined the error message on
-	// receiving the unsupported pivot table show value as type.
-	ErrUnsupportedPivotTableShowValuesAsType = errors.New("unsupported pivot table show value as type")
+	// receiving the unsupported pivot table "show values as" type.
+	ErrUnsupportedPivotTableShowValuesAsType = errors.New("unsupported pivot table show values as type")
 	// ErrWorkbookFileFormat defined the error message on receive an
 	// unsupported workbook file format.
 	ErrWorkbookFileFormat = errors.New("unsupported workbook file format")
@@ -376,7 +376,7 @@ func newPivotTableRangeError(msg string) error {
 }
 
 // newPivotTableShowValuesAsBaseFieldError defined the error message on receiving
-// the invalid pivot table show value as base field.
+// the invalid pivot table "show values as" base field.
 func newPivotTableShowValuesAsBaseFieldError(field string) error {
 	return fmt.Errorf("base field %s does not exist in shared items", field)
 }

--- a/pivotTable.go
+++ b/pivotTable.go
@@ -89,7 +89,7 @@ const (
 	PivotTableShowValuesAsIndex
 )
 
-// PivotTableShowValuesAs directly maps the show value as settings of the pivot
+// PivotTableShowValuesAs directly maps the show values as settings of the pivot
 // table.
 type PivotTableShowValuesAs struct {
 	Type      PivotTableShowValuesAsType
@@ -896,7 +896,7 @@ func (f *File) addPivotDataFields(pt *xlsxPivotTableDefinition, opts *PivotTable
 	return err
 }
 
-// setPivotTableShowValuesAs provides a method to set show value as for pivot
+// setPivotTableShowValuesAs provides a method to set show values as for pivot
 // table data field by given pivot table options and data field index.
 func (df *xlsxDataField) setPivotTableShowValuesAs(idx int, order []string, opts *PivotTableOptions) error {
 	showValuesAsType := opts.Data[idx].ShowValuesAs.Type
@@ -1453,7 +1453,7 @@ func (f *File) extractPivotTableFields(pt *xlsxPivotTableDefinition, pc *xlsxPiv
 	}
 }
 
-// extractPivotTableShowValuesAs provides a function to extract show value as
+// extractPivotTableShowValuesAs provides a function to extract show values as
 // settings for pivot table data field.
 func (f *File) extractPivotTableShowValuesAs(pc *xlsxPivotCacheDefinition, df *xlsxDataField, dataField *PivotTableField) {
 	order := pc.getPivotCacheFieldsName()

--- a/pivotTable_test.go
+++ b/pivotTable_test.go
@@ -100,7 +100,7 @@ func TestPivotTable(t *testing.T) {
 		ShowColHeaders:  true,
 		ShowLastColumn:  true,
 	}))
-	// Test get pivot table with show value as with base field and base item
+	// Test get pivot table with show values as with base field and base item
 	pivotTables, err = f.GetPivotTables("Sheet1")
 	assert.NoError(t, err)
 	assert.Len(t, pivotTables, 4)
@@ -331,7 +331,7 @@ func TestPivotTable(t *testing.T) {
 		Data:            []PivotTableField{{Data: "Revenue"}},
 		Filter:          []PivotTableField{{Data: "Month"}},
 	}))
-	// Test with unsupported pivot table data field show value as type
+	// Test with unsupported pivot table data field show values as type
 	assert.Equal(t, ErrUnsupportedPivotTableShowValuesAsType, f.AddPivotTable(&PivotTableOptions{
 		DataRange:       "Sheet1!A1:E31",
 		PivotTableRange: "Sheet1!G2:M34",
@@ -340,7 +340,7 @@ func TestPivotTable(t *testing.T) {
 		Data:            []PivotTableField{{Data: "Revenue", ShowValuesAs: PivotTableShowValuesAs{Type: 15}}},
 		Filter:          []PivotTableField{{Data: "Month"}},
 	}))
-	// Test set pivot table show value as type without required base field
+	// Test set pivot table show values as type without required base field
 	assert.Equal(t, ErrPivotTableShowValuesAsBaseField, f.AddPivotTable(&PivotTableOptions{
 		DataRange:       "Sheet1!A1:E31",
 		PivotTableRange: "Sheet1!G2:M34",
@@ -349,7 +349,7 @@ func TestPivotTable(t *testing.T) {
 		Data:            []PivotTableField{{Data: "Revenue", ShowValuesAs: PivotTableShowValuesAs{Type: PivotTableShowValuesAsRunningTotalIn}}},
 		Filter:          []PivotTableField{{Data: "Month"}},
 	}))
-	// Test set pivot table show value as type without required base item
+	// Test set pivot table show values as type without required base item
 	assert.Equal(t, ErrPivotTableShowValuesAsBaseItem, f.AddPivotTable(&PivotTableOptions{
 		DataRange:       "Sheet1!A1:E31",
 		PivotTableRange: "Sheet1!G2:M34",
@@ -358,7 +358,7 @@ func TestPivotTable(t *testing.T) {
 		Data:            []PivotTableField{{Data: "Revenue", ShowValuesAs: PivotTableShowValuesAs{Type: PivotTableShowValuesAsPercentOf, BaseField: "Month"}}},
 		Filter:          []PivotTableField{{Data: "Month"}},
 	}))
-	// Test with invalid pivot table show value as base field
+	// Test with invalid pivot table show values as base field
 	assert.Equal(t, newPivotTableShowValuesAsBaseFieldError("x"), f.AddPivotTable(&PivotTableOptions{
 		DataRange:       "Sheet1!A1:E31",
 		PivotTableRange: "Sheet1!G2:M34",
@@ -367,7 +367,7 @@ func TestPivotTable(t *testing.T) {
 		Data:            []PivotTableField{{Data: "Revenue", ShowValuesAs: PivotTableShowValuesAs{Type: PivotTableShowValuesAsRunningTotalIn, BaseField: "x"}}},
 		Filter:          []PivotTableField{{Data: "Month"}},
 	}))
-	// Test with invalid pivot table show value as base item
+	// Test with invalid pivot table show values as base item
 	assert.Equal(t, newPivotTableSelectedItemError("x", "Month"), f.AddPivotTable(&PivotTableOptions{
 		DataRange:       "Sheet1!A1:E31",
 		PivotTableRange: "Sheet1!G2:M34",

--- a/rows.go
+++ b/rows.go
@@ -353,21 +353,23 @@ func (f *File) Rows(sheet string) (*Rows, error) {
 }
 
 // getFromStringItem build shared string item offset list from system temporary
-// file at one time, and return value by given to string index.
-func (f *File) getFromStringItem(index int) string {
+// file at one time, and return value by given to string index. An index outside
+// the shared string table returns an error, matching the in-memory path in
+// xlsxC.getValueFrom.
+func (f *File) getFromStringItem(index int) (string, error) {
 	if f.sharedStringTemp != nil {
 		if index < 0 || len(f.sharedStringItem) <= index {
-			return strconv.Itoa(index)
+			return "", newInvalidSharedStringIndex(index)
 		}
 		offsetRange := f.sharedStringItem[index]
 		if len(offsetRange) != 2 || offsetRange[0] > offsetRange[1] {
-			return strconv.Itoa(index)
+			return strconv.Itoa(index), nil
 		}
 		buf := make([]byte, offsetRange[1]-offsetRange[0])
 		if _, err := f.sharedStringTemp.ReadAt(buf, int64(offsetRange[0])); err != nil {
-			return strconv.Itoa(index)
+			return strconv.Itoa(index), nil
 		}
-		return string(buf)
+		return string(buf), nil
 	}
 	needClose, decoder, tempFile, err := f.xmlDecoder(defaultXMLPathSharedStrings)
 	if needClose && err == nil {

--- a/rows.go
+++ b/rows.go
@@ -356,7 +356,7 @@ func (f *File) Rows(sheet string) (*Rows, error) {
 // file at one time, and return value by given to string index.
 func (f *File) getFromStringItem(index int) string {
 	if f.sharedStringTemp != nil {
-		if len(f.sharedStringItem) <= index {
+		if index < 0 || len(f.sharedStringItem) <= index {
 			return strconv.Itoa(index)
 		}
 		offsetRange := f.sharedStringItem[index]

--- a/rows_test.go
+++ b/rows_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -253,6 +254,20 @@ func TestColumns(t *testing.T) {
 	rows.decoder = f.xmlNewDecoder(bytes.NewReader(nil))
 	_, err = rows.Columns()
 	assert.NoError(t, err)
+}
+
+func TestGetFromStringItem(t *testing.T) {
+	f := NewFile()
+	// Test get shared string item by a negative index on the streaming path,
+	// which the in-memory path already rejects in xlsxC.getValueFrom
+	tempFile, err := os.CreateTemp(f.options.TmpDir, "excelize-")
+	assert.NoError(t, err)
+	f.sharedStringTemp = tempFile
+	f.sharedStringItem = [][]uint{{0, 0}}
+	assert.Equal(t, "-1", f.getFromStringItem(-1))
+	assert.Equal(t, "1", f.getFromStringItem(1))
+	assert.NoError(t, tempFile.Close())
+	assert.NoError(t, os.Remove(tempFile.Name()))
 }
 
 func TestSharedStringsReader(t *testing.T) {

--- a/rows_test.go
+++ b/rows_test.go
@@ -264,8 +264,15 @@ func TestGetFromStringItem(t *testing.T) {
 	assert.NoError(t, err)
 	f.sharedStringTemp = tempFile
 	f.sharedStringItem = [][]uint{{0, 0}}
-	assert.Equal(t, "-1", f.getFromStringItem(-1))
-	assert.Equal(t, "1", f.getFromStringItem(1))
+	value, err := f.getFromStringItem(-1)
+	assert.Equal(t, newInvalidSharedStringIndex(-1), err)
+	assert.Empty(t, value)
+	value, err = f.getFromStringItem(1)
+	assert.Equal(t, newInvalidSharedStringIndex(1), err)
+	assert.Empty(t, value)
+	value, err = f.getFromStringItem(0)
+	assert.NoError(t, err)
+	assert.Empty(t, value)
 	assert.NoError(t, tempFile.Close())
 	assert.NoError(t, os.Remove(tempFile.Name()))
 }


### PR DESCRIPTION
Fix for [GHSA-48hm-4h8j-58fg](https://github.com/qax-os/excelize/security/advisories/GHSA-48hm-4h8j-58fg).

> **Correction:** the original title and this line cited `GHSA-wcg2-648h-mhxq`, which belongs to a different project. The excelize advisory this fixes is `GHSA-48hm-4h8j-58fg`, which is what the link above always pointed to. My mistake; corrected here for anyone tracing the fix. The merge commit message still carries the wrong id and I would not suggest rewriting history over it.

`getFromStringItem` bounds the shared string index only from above:

```go
if len(f.sharedStringItem) <= index {
    return strconv.Itoa(index)
}
offsetRange := f.sharedStringItem[index]
```

so a negative index reaches the slice lookup and panics. The in-memory path already rejects this in `xlsxC.getValueFrom`:

```go
if xlsxSI < 0 || xlsxSI >= len(d.SI) {
    return "", newInvalidSharedStringIndex(xlsxSI)
}
```

but the streaming path, taken when the shared strings part exceeds `UnzipXMLSizeLimit`, had no equivalent lower bound. This adds it, so a negative index falls through to the same handling as one that is too large rather than panicking.

I kept the existing `strconv.Itoa(index)` return rather than surfacing `newInvalidSharedStringIndex`, since `getFromStringItem` returns only a string and changing that would ripple through its callers. Happy to take the other approach if you would prefer the two paths to report identically.

The test drives `getFromStringItem` directly rather than building a >16MB workbook, so it stays fast. It panics without the change and passes with it. Full suite is green (579 tests), `go vet` and `gofmt` clean.

