### PR TITLE
This closes #GHSA-5h23-36rv-pm65, fix panic on negative style index

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -1171,17 +1171,17 @@ var (
 		"fill": func(xf xlsxXf, s *xlsxStyleSheet) bool {
 			return (xf.ApplyFill == nil || (xf.ApplyFill != nil && *xf.ApplyFill)) &&
 				xf.FillID != nil && s.Fills != nil &&
-				*xf.FillID >= 0 && *xf.FillID < len(s.Fills.Fill)
+				0 <= *xf.FillID && *xf.FillID < len(s.Fills.Fill)
 		},
 		"border": func(xf xlsxXf, s *xlsxStyleSheet) bool {
 			return (xf.ApplyBorder == nil || (xf.ApplyBorder != nil && *xf.ApplyBorder)) &&
 				xf.BorderID != nil && s.Borders != nil &&
-				*xf.BorderID >= 0 && *xf.BorderID < len(s.Borders.Border)
+				0 <= *xf.BorderID && *xf.BorderID < len(s.Borders.Border)
 		},
 		"font": func(xf xlsxXf, s *xlsxStyleSheet) bool {
 			return (xf.ApplyFont == nil || (xf.ApplyFont != nil && *xf.ApplyFont)) &&
 				xf.FontID != nil && s.Fonts != nil &&
-				*xf.FontID >= 0 && *xf.FontID < len(s.Fonts.Font)
+				0 <= *xf.FontID && *xf.FontID < len(s.Fonts.Font)
 		},
 		"alignment": func(xf xlsxXf, s *xlsxStyleSheet) bool {
 			return xf.ApplyAlignment == nil || (xf.ApplyAlignment != nil && *xf.ApplyAlignment)

--- a/styles.go
+++ b/styles.go
@@ -1171,17 +1171,17 @@ var (
 		"fill": func(xf xlsxXf, s *xlsxStyleSheet) bool {
 			return (xf.ApplyFill == nil || (xf.ApplyFill != nil && *xf.ApplyFill)) &&
 				xf.FillID != nil && s.Fills != nil &&
-				*xf.FillID < len(s.Fills.Fill)
+				*xf.FillID >= 0 && *xf.FillID < len(s.Fills.Fill)
 		},
 		"border": func(xf xlsxXf, s *xlsxStyleSheet) bool {
 			return (xf.ApplyBorder == nil || (xf.ApplyBorder != nil && *xf.ApplyBorder)) &&
 				xf.BorderID != nil && s.Borders != nil &&
-				*xf.BorderID < len(s.Borders.Border)
+				*xf.BorderID >= 0 && *xf.BorderID < len(s.Borders.Border)
 		},
 		"font": func(xf xlsxXf, s *xlsxStyleSheet) bool {
 			return (xf.ApplyFont == nil || (xf.ApplyFont != nil && *xf.ApplyFont)) &&
 				xf.FontID != nil && s.Fonts != nil &&
-				*xf.FontID < len(s.Fonts.Font)
+				*xf.FontID >= 0 && *xf.FontID < len(s.Fonts.Font)
 		},
 		"alignment": func(xf xlsxXf, s *xlsxStyleSheet) bool {
 			return xf.ApplyAlignment == nil || (xf.ApplyAlignment != nil && *xf.ApplyAlignment)

--- a/styles_test.go
+++ b/styles_test.go
@@ -897,30 +897,24 @@ func TestGetStyle(t *testing.T) {
 	style, err = f.GetStyle(1)
 	assert.Nil(t, style)
 	assert.EqualError(t, err, "XML syntax error on line 1: invalid UTF-8")
-}
 
-func TestGetStyleWithNegativeIndex(t *testing.T) {
-	styleSheet := `<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">` +
-		`<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>` +
-		`<fills count="1"><fill><patternFill patternType="none"/></fill></fills>` +
-		`<borders count="1"><border/></borders>` +
-		`<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>` +
-		`<cellXfs count="2"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>` +
-		`<xf numFmtId="0" %s xfId="0" applyFont="1" applyFill="1" applyBorder="1"/></cellXfs></styleSheet>`
-	for _, testCase := range []struct {
-		label string
-		attrs string
-	}{
-		{"negative fill index", `fontId="0" fillId="-1" borderId="0"`},
-		{"negative border index", `fontId="0" fillId="0" borderId="-1"`},
-		{"negative font index", `fontId="-1" fillId="0" borderId="0"`},
-	} {
-		f := NewFile()
-		f.Styles = nil
-		f.Pkg.Store(defaultXMLPathStyles, []byte(fmt.Sprintf(styleSheet, testCase.attrs)))
-		style, err := f.GetStyle(1)
-		assert.NoError(t, err, testCase.label)
-		assert.NotNil(t, style, testCase.label)
-		assert.NoError(t, f.Close(), testCase.label)
-	}
+	t.Run("with_negative_index", func(t *testing.T) {
+		styleSheet := `<styleSheet xmlns="%s"><fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts><fills count="1"><fill><patternFill patternType="none"/></fill></fills><borders count="1"><border/></borders><cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs><cellXfs count="2"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/><xf numFmtId="0" %s xfId="0" applyFont="1" applyFill="1" applyBorder="1"/></cellXfs></styleSheet>`
+		for _, testCase := range []struct {
+			label string
+			attrs string
+		}{
+			{"negative fill index", `fontId="0" fillId="-1" borderId="0"`},
+			{"negative border index", `fontId="0" fillId="0" borderId="-1"`},
+			{"negative font index", `fontId="-1" fillId="0" borderId="0"`},
+		} {
+			f := NewFile()
+			f.Styles = nil
+			f.Pkg.Store(defaultXMLPathStyles, fmt.Appendf(nil, styleSheet, NameSpaceSpreadSheet.Value, testCase.attrs))
+			style, err := f.GetStyle(1)
+			assert.NoError(t, err, testCase.label)
+			assert.NotNil(t, style, testCase.label)
+			assert.NoError(t, f.Close(), testCase.label)
+		}
+	})
 }

--- a/styles_test.go
+++ b/styles_test.go
@@ -898,3 +898,29 @@ func TestGetStyle(t *testing.T) {
 	assert.Nil(t, style)
 	assert.EqualError(t, err, "XML syntax error on line 1: invalid UTF-8")
 }
+
+func TestGetStyleWithNegativeIndex(t *testing.T) {
+	styleSheet := `<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">` +
+		`<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>` +
+		`<fills count="1"><fill><patternFill patternType="none"/></fill></fills>` +
+		`<borders count="1"><border/></borders>` +
+		`<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>` +
+		`<cellXfs count="2"><xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>` +
+		`<xf numFmtId="0" %s xfId="0" applyFont="1" applyFill="1" applyBorder="1"/></cellXfs></styleSheet>`
+	for _, testCase := range []struct {
+		label string
+		attrs string
+	}{
+		{"negative fill index", `fontId="0" fillId="-1" borderId="0"`},
+		{"negative border index", `fontId="0" fillId="0" borderId="-1"`},
+		{"negative font index", `fontId="-1" fillId="0" borderId="0"`},
+	} {
+		f := NewFile()
+		f.Styles = nil
+		f.Pkg.Store(defaultXMLPathStyles, []byte(fmt.Sprintf(styleSheet, testCase.attrs)))
+		style, err := f.GetStyle(1)
+		assert.NoError(t, err, testCase.label)
+		assert.NotNil(t, style, testCase.label)
+		assert.NoError(t, f.Close(), testCase.label)
+	}
+}


### PR DESCRIPTION
The `fill`, `border` and `font` conditions in `extractStyleCondFuncs` bounded only the top of the range:

```go
*xf.FillID < len(s.Fills.Fill)
```

Any negative value satisfies that, so a `cellXfs` entry carrying `fillId="-1"`, `borderId="-1"` or `fontId="-1"` passed the guard and `GetStyle` then indexed the fill, border or font table with `-1`. Reading cell styling out of an untrusted workbook panicked with `index out of range [-1]`.

`GetStyle` already checks the low end for the style index itself a few lines above, so this just brings the three table lookups in line with it:

```go
if idx < 0 || s.CellXfs == nil || len(s.CellXfs.Xf) <= idx {
```

Behaviour for valid workbooks is unchanged. A negative id now makes the condition false and the style keeps its default, which is what already happened for an out-of-range positive id.

The regression test writes the styles part directly so the negative attribute goes through the real XML unmarshal rather than being set on the struct, and covers all three ids. Reverting the `styles.go` change makes it panic at `styles.go:1683`, and the full suite passes with the change in.

Same shape as the shared string index fix in #2366, in a different file.