### PR TITLE
Reject a Zip64 uncompressed size that does not fit a signed int64

### DIFF
--- a/excelize_test.go
+++ b/excelize_test.go
@@ -303,6 +303,8 @@ func TestOpenReader(t *testing.T) {
 	}
 
 	// Test open spreadsheet with unzip size limit
+	_, err = OpenFile(filepath.Join("test", "Book1.xlsx"), Options{UnzipSizeLimit: -1})
+	assert.EqualError(t, err, newUnzipSizeLimitError(-1).Error())
 	_, err = OpenFile(filepath.Join("test", "Book1.xlsx"), Options{UnzipSizeLimit: 100})
 	assert.EqualError(t, err, newUnzipSizeLimitError(100).Error())
 

--- a/lib.go
+++ b/lib.go
@@ -28,6 +28,18 @@ import (
 	"unicode/utf16"
 )
 
+// checkFileSize checks if the file size and unzip size exceed the limit set in
+// options.
+func (f *File) checkFileSize(fileSize, unzipSize int64) error {
+	if f.options.UnzipSizeLimit < 0 || uint64(f.options.UnzipSizeLimit) < uint64(fileSize) || fileSize < 0 {
+		return newUnzipSizeLimitError(f.options.UnzipSizeLimit)
+	}
+	if unzipSize > f.options.UnzipSizeLimit {
+		return newUnzipSizeLimitError(f.options.UnzipSizeLimit)
+	}
+	return nil
+}
+
 // ReadZipReader extract spreadsheet with given options.
 func (f *File) ReadZipReader(r *zip.Reader) (map[string][]byte, int, error) {
 	var (
@@ -41,17 +53,10 @@ func (f *File) ReadZipReader(r *zip.Reader) (map[string][]byte, int, error) {
 		unzipSize  int64
 	)
 	for _, v := range r.File {
-		// The declared uncompressed size is a 64-bit field in the Zip64 extra
-		// record, so compare it before it gets narrowed to a signed int64.
-		// A value of 2^63 or above would otherwise turn negative and slip past
-		// the checks below.
-		if f.options.UnzipSizeLimit < 0 || v.UncompressedSize64 > uint64(f.options.UnzipSizeLimit) {
-			return fileList, worksheets, newUnzipSizeLimitError(f.options.UnzipSizeLimit)
-		}
 		fileSize := v.FileInfo().Size()
 		unzipSize += fileSize
-		if unzipSize > f.options.UnzipSizeLimit {
-			return fileList, worksheets, newUnzipSizeLimitError(f.options.UnzipSizeLimit)
+		if err := f.checkFileSize(fileSize, unzipSize); err != nil {
+			return fileList, worksheets, err
 		}
 		fileName := strings.ReplaceAll(v.Name, "\\", "/")
 		if partName, ok := docPart[strings.ToLower(fileName)]; ok {
@@ -78,7 +83,7 @@ func (f *File) ReadZipReader(r *zip.Reader) (map[string][]byte, int, error) {
 				}
 			}
 		}
-		if fileList[fileName], err = readFile(v, f.options.UnzipSizeLimit); err != nil {
+		if fileList[fileName], err = readFile(v); err != nil {
 			return nil, 0, err
 		}
 	}
@@ -149,20 +154,12 @@ func (f *File) saveFileList(name string, content []byte) {
 }
 
 // Read file content as string in an archive file.
-func readFile(file *zip.File, unzipSizeLimit int64) ([]byte, error) {
+func readFile(file *zip.File) ([]byte, error) {
 	rc, err := file.Open()
 	if err != nil {
 		return nil, err
 	}
-	// Keep the capacity hint within the limit. The declared size comes from the
-	// archive, so it can be negative once a Zip64 size of 2^63 or above has been
-	// narrowed to a signed int64, which make would reject.
-	size := file.FileInfo().Size()
-	if size < 0 || size > unzipSizeLimit {
-		_ = rc.Close()
-		return nil, newUnzipSizeLimitError(unzipSizeLimit)
-	}
-	dat := make([]byte, 0, size)
+	dat := make([]byte, 0, file.FileInfo().Size())
 	buff := bytes.NewBuffer(dat)
 	_, _ = io.Copy(buff, rc)
 	return buff.Bytes(), rc.Close()

--- a/lib.go
+++ b/lib.go
@@ -41,6 +41,13 @@ func (f *File) ReadZipReader(r *zip.Reader) (map[string][]byte, int, error) {
 		unzipSize  int64
 	)
 	for _, v := range r.File {
+		// The declared uncompressed size is a 64-bit field in the Zip64 extra
+		// record, so compare it before it gets narrowed to a signed int64.
+		// A value of 2^63 or above would otherwise turn negative and slip past
+		// the checks below.
+		if f.options.UnzipSizeLimit < 0 || v.UncompressedSize64 > uint64(f.options.UnzipSizeLimit) {
+			return fileList, worksheets, newUnzipSizeLimitError(f.options.UnzipSizeLimit)
+		}
 		fileSize := v.FileInfo().Size()
 		unzipSize += fileSize
 		if unzipSize > f.options.UnzipSizeLimit {
@@ -71,7 +78,7 @@ func (f *File) ReadZipReader(r *zip.Reader) (map[string][]byte, int, error) {
 				}
 			}
 		}
-		if fileList[fileName], err = readFile(v); err != nil {
+		if fileList[fileName], err = readFile(v, f.options.UnzipSizeLimit); err != nil {
 			return nil, 0, err
 		}
 	}
@@ -142,12 +149,20 @@ func (f *File) saveFileList(name string, content []byte) {
 }
 
 // Read file content as string in an archive file.
-func readFile(file *zip.File) ([]byte, error) {
+func readFile(file *zip.File, unzipSizeLimit int64) ([]byte, error) {
 	rc, err := file.Open()
 	if err != nil {
 		return nil, err
 	}
-	dat := make([]byte, 0, file.FileInfo().Size())
+	// Keep the capacity hint within the limit. The declared size comes from the
+	// archive, so it can be negative once a Zip64 size of 2^63 or above has been
+	// narrowed to a signed int64, which make would reject.
+	size := file.FileInfo().Size()
+	if size < 0 || size > unzipSizeLimit {
+		_ = rc.Close()
+		return nil, newUnzipSizeLimitError(unzipSizeLimit)
+	}
+	dat := make([]byte, 0, size)
 	buff := bytes.NewBuffer(dat)
 	_, _ = io.Copy(buff, rc)
 	return buff.Bytes(), rc.Close()

--- a/lib_test.go
+++ b/lib_test.go
@@ -3,7 +3,6 @@ package excelize
 import (
 	"archive/zip"
 	"bytes"
-	"encoding/binary"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -424,67 +423,10 @@ func TestFloat2Frac(t *testing.T) {
 	assert.Equal(t, "954888175898973913/351283728530932463", floatToFraction(math.E, 1, 18))
 }
 
-func TestZip64UncompressedSizeOverflow(t *testing.T) {
-	// buildZip64Archive returns a stored-entry archive whose central directory
-	// carries the 0xFFFFFFFF sentinel for the 32-bit uncompressed size and a
-	// Zip64 extended information extra field declaring declaredSize.
-	buildZip64Archive := func(declaredSize uint64) []byte {
-		entryName, payload := "xl/worksheets/sheet1.xml", []byte("A")
-
-		var local bytes.Buffer
-		for _, field := range []any{
-			uint32(0x04034b50), uint16(45), uint16(0), uint16(0), uint16(0), uint16(0),
-			uint32(0), uint32(len(payload)), uint32(len(payload)),
-			uint16(len(entryName)), uint16(0),
-		} {
-			assert.NoError(t, binary.Write(&local, binary.LittleEndian, field))
-		}
-		local.WriteString(entryName)
-		local.Write(payload)
-
-		var extra bytes.Buffer
-		for _, field := range []any{uint16(1), uint16(8), declaredSize} {
-			assert.NoError(t, binary.Write(&extra, binary.LittleEndian, field))
-		}
-
-		var central bytes.Buffer
-		for _, field := range []any{
-			uint32(0x02014b50), uint16(45), uint16(45), uint16(0), uint16(0),
-			uint16(0), uint16(0), uint32(0), uint32(len(payload)), uint32(0xFFFFFFFF),
-			uint16(len(entryName)), uint16(extra.Len()), uint16(0), uint16(0), uint16(0),
-			uint32(0), uint32(0),
-		} {
-			assert.NoError(t, binary.Write(&central, binary.LittleEndian, field))
-		}
-		central.WriteString(entryName)
-		central.Write(extra.Bytes())
-
-		var buf bytes.Buffer
-		buf.Write(local.Bytes())
-		offset := buf.Len()
-		buf.Write(central.Bytes())
-		for _, field := range []any{
-			uint32(0x06054b50), uint16(0), uint16(0), uint16(1), uint16(1),
-			uint32(central.Len()), uint32(offset), uint16(0),
-		} {
-			assert.NoError(t, binary.Write(&buf, binary.LittleEndian, field))
-		}
-		return buf.Bytes()
-	}
-
-	// A declared size of 2^63 is negative once narrowed to a signed int64, which
-	// used to slip past the unzip size limit and panic on the allocation.
-	raw := buildZip64Archive(1 << 63)
-	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
-	assert.NoError(t, err)
-	assert.Negative(t, zr.File[0].FileInfo().Size())
-
-	_, err = OpenReader(bytes.NewReader(raw))
-	assert.EqualError(t, err, newUnzipSizeLimitError(UnzipSizeLimit).Error())
-
-	// Control: the same archive one byte below the sign flip already reported the
-	// limit error, so the fix is about the conversion and not the magnitude.
-	raw = buildZip64Archive(1<<63 - 1)
-	_, err = OpenReader(bytes.NewReader(raw))
-	assert.EqualError(t, err, newUnzipSizeLimitError(UnzipSizeLimit).Error())
+func TestCheckFileSize(t *testing.T) {
+	f := NewFile()
+	assert.NoError(t, f.checkFileSize(1, 1))
+	assert.EqualError(t, f.checkFileSize(UnzipSizeLimit+1, 1), newUnzipSizeLimitError(UnzipSizeLimit).Error())
+	assert.EqualError(t, f.checkFileSize(1, UnzipSizeLimit+1), newUnzipSizeLimitError(UnzipSizeLimit).Error())
+	assert.EqualError(t, f.checkFileSize(-1, 1), newUnzipSizeLimitError(UnzipSizeLimit).Error())
 }

--- a/lib_test.go
+++ b/lib_test.go
@@ -3,6 +3,7 @@ package excelize
 import (
 	"archive/zip"
 	"bytes"
+	"encoding/binary"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -421,4 +422,69 @@ func TestFloat2Frac(t *testing.T) {
 	assert.Equal(t, "1/5", floatToFraction(0.19, 1, 1))
 	assert.Equal(t, "9999/10000", strings.Trim(floatToFraction(0.9999, 10, 10), " "))
 	assert.Equal(t, "954888175898973913/351283728530932463", floatToFraction(math.E, 1, 18))
+}
+
+func TestZip64UncompressedSizeOverflow(t *testing.T) {
+	// buildZip64Archive returns a stored-entry archive whose central directory
+	// carries the 0xFFFFFFFF sentinel for the 32-bit uncompressed size and a
+	// Zip64 extended information extra field declaring declaredSize.
+	buildZip64Archive := func(declaredSize uint64) []byte {
+		entryName, payload := "xl/worksheets/sheet1.xml", []byte("A")
+
+		var local bytes.Buffer
+		for _, field := range []any{
+			uint32(0x04034b50), uint16(45), uint16(0), uint16(0), uint16(0), uint16(0),
+			uint32(0), uint32(len(payload)), uint32(len(payload)),
+			uint16(len(entryName)), uint16(0),
+		} {
+			assert.NoError(t, binary.Write(&local, binary.LittleEndian, field))
+		}
+		local.WriteString(entryName)
+		local.Write(payload)
+
+		var extra bytes.Buffer
+		for _, field := range []any{uint16(1), uint16(8), declaredSize} {
+			assert.NoError(t, binary.Write(&extra, binary.LittleEndian, field))
+		}
+
+		var central bytes.Buffer
+		for _, field := range []any{
+			uint32(0x02014b50), uint16(45), uint16(45), uint16(0), uint16(0),
+			uint16(0), uint16(0), uint32(0), uint32(len(payload)), uint32(0xFFFFFFFF),
+			uint16(len(entryName)), uint16(extra.Len()), uint16(0), uint16(0), uint16(0),
+			uint32(0), uint32(0),
+		} {
+			assert.NoError(t, binary.Write(&central, binary.LittleEndian, field))
+		}
+		central.WriteString(entryName)
+		central.Write(extra.Bytes())
+
+		var buf bytes.Buffer
+		buf.Write(local.Bytes())
+		offset := buf.Len()
+		buf.Write(central.Bytes())
+		for _, field := range []any{
+			uint32(0x06054b50), uint16(0), uint16(0), uint16(1), uint16(1),
+			uint32(central.Len()), uint32(offset), uint16(0),
+		} {
+			assert.NoError(t, binary.Write(&buf, binary.LittleEndian, field))
+		}
+		return buf.Bytes()
+	}
+
+	// A declared size of 2^63 is negative once narrowed to a signed int64, which
+	// used to slip past the unzip size limit and panic on the allocation.
+	raw := buildZip64Archive(1 << 63)
+	zr, err := zip.NewReader(bytes.NewReader(raw), int64(len(raw)))
+	assert.NoError(t, err)
+	assert.Negative(t, zr.File[0].FileInfo().Size())
+
+	_, err = OpenReader(bytes.NewReader(raw))
+	assert.EqualError(t, err, newUnzipSizeLimitError(UnzipSizeLimit).Error())
+
+	// Control: the same archive one byte below the sign flip already reported the
+	// limit error, so the fix is about the conversion and not the magnitude.
+	raw = buildZip64Archive(1<<63 - 1)
+	_, err = OpenReader(bytes.NewReader(raw))
+	assert.EqualError(t, err, newUnzipSizeLimitError(UnzipSizeLimit).Error())
 }


### PR DESCRIPTION
Follows up on the advisory discussion, where you asked whether I wanted to send a patch.

`zip.File.FileInfo().Size()` returns `int64(UncompressedSize64)`, and `UncompressedSize64` comes from the Zip64 extended information extra field in the central directory. Any declared value in `[2^63, 2^64)` turns negative on that conversion, and the guard in `ReadZipReader` is signed arithmetic, so:

- `unzipSize += fileSize` makes the running total negative, and `unzipSize > f.options.UnzipSizeLimit` stays false, so the decompression cap never fires
- the two `UnzipXMLSizeLimit` comparisons are false as well, so a large part is never routed to a temporary file
- `readFile` reaches `make([]byte, 0, negative)`, which panics with `makeslice: cap out of range`

A 159 byte archive is enough to reach it through `OpenFile`, `OpenReader` or `ReadZipReader`, and nothing in the library recovers, so the panic propagates to the caller.

## The change

Compare the declared size against the limit as a `uint64` before it is narrowed. An entry that cannot fit is rejected on its own, so the signed arithmetic below only ever sees a value already within the limit, and `fileSize` can no longer be negative. The `UnzipSizeLimit < 0` clause keeps the conversion honest if someone configures a negative limit.

`readFile` also bounds its capacity hint, so the allocation is safe regardless of how that function is reached. It takes the limit as a parameter since it is package level and has no access to `f.options`; there is one caller.

## Testing

`TestZip64UncompressedSizeOverflow` builds the archive in memory rather than committing a fixture. It asserts the declared size really is negative after conversion, then that `OpenReader` returns the unzip size limit error instead of panicking. It also runs a control at `2^63-1`, one below the sign flip, which already returned the limit error before this change. That is what pins the bug to the conversion rather than to the size being large.

Verified fail before and pass after: on master the new test panics with `makeslice: cap out of range`, and with the fix it passes. Full suite is green locally on go1.26.5 darwin/arm64.