### PR TITLE
Bound flatCols to MaxColumns when flattening worksheet columns

### DIFF
--- a/col.go
+++ b/col.go
@@ -545,24 +545,8 @@ func (ws *xlsxWorksheet) setColWidth(minVal, maxVal int, width float64) {
 // flatCols provides a method for the column's operation functions to flatten
 // and check the worksheet columns.
 func flatCols(col xlsxCol, cols []xlsxCol, replacer func(fc, c xlsxCol) xlsxCol) []xlsxCol {
-	// The min and max attributes of a col element are read straight from the
-	// worksheet XML and are not otherwise bounded. A worksheet cannot hold more
-	// than MaxColumns columns, so flattening past that is meaningless, while a
-	// crafted file declaring max="2147483647" would otherwise have this function
-	// allocate one xlsxCol per declared column.
-	clamp := func(c xlsxCol) (int, int) {
-		minVal, maxVal := c.Min, c.Max
-		if minVal < MinColumns {
-			minVal = MinColumns
-		}
-		if maxVal > MaxColumns {
-			maxVal = MaxColumns
-		}
-		return minVal, maxVal
-	}
 	var fc []xlsxCol
-	colMin, colMax := clamp(col)
-	for i := colMin; i <= colMax; i++ {
+	for i := max(MinColumns, col.Min); i <= min(MaxColumns, col.Max); i++ {
 		var c xlsxCol
 		_ = deepcopy.Copy(&c, col)
 		c.Min, c.Max = i, i
@@ -577,8 +561,7 @@ func flatCols(col xlsxCol, cols []xlsxCol, replacer func(fc, c xlsxCol) xlsxCol)
 		return -1, false
 	}
 	for _, column := range cols {
-		columnMin, columnMax := clamp(column)
-		for i := columnMin; i <= columnMax; i++ {
+		for i := max(MinColumns, column.Min); i <= min(MaxColumns, column.Max); i++ {
 			if idx, ok := inFlat(i, fc); ok {
 				fc[idx] = replacer(fc[idx], column)
 				continue

--- a/col.go
+++ b/col.go
@@ -545,8 +545,24 @@ func (ws *xlsxWorksheet) setColWidth(minVal, maxVal int, width float64) {
 // flatCols provides a method for the column's operation functions to flatten
 // and check the worksheet columns.
 func flatCols(col xlsxCol, cols []xlsxCol, replacer func(fc, c xlsxCol) xlsxCol) []xlsxCol {
+	// The min and max attributes of a col element are read straight from the
+	// worksheet XML and are not otherwise bounded. A worksheet cannot hold more
+	// than MaxColumns columns, so flattening past that is meaningless, while a
+	// crafted file declaring max="2147483647" would otherwise have this function
+	// allocate one xlsxCol per declared column.
+	clamp := func(c xlsxCol) (int, int) {
+		minVal, maxVal := c.Min, c.Max
+		if minVal < MinColumns {
+			minVal = MinColumns
+		}
+		if maxVal > MaxColumns {
+			maxVal = MaxColumns
+		}
+		return minVal, maxVal
+	}
 	var fc []xlsxCol
-	for i := col.Min; i <= col.Max; i++ {
+	colMin, colMax := clamp(col)
+	for i := colMin; i <= colMax; i++ {
 		var c xlsxCol
 		_ = deepcopy.Copy(&c, col)
 		c.Min, c.Max = i, i
@@ -561,7 +577,8 @@ func flatCols(col xlsxCol, cols []xlsxCol, replacer func(fc, c xlsxCol) xlsxCol)
 		return -1, false
 	}
 	for _, column := range cols {
-		for i := column.Min; i <= column.Max; i++ {
+		columnMin, columnMax := clamp(column)
+		for i := columnMin; i <= columnMax; i++ {
 			if idx, ok := inFlat(i, fc); ok {
 				fc[idx] = replacer(fc[idx], column)
 				continue

--- a/col_test.go
+++ b/col_test.go
@@ -436,6 +436,19 @@ func TestColWidth(t *testing.T) {
 
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestColWidth.xlsx")))
 	convertRowHeightToPixels(0)
+
+	t.Run("with_invalid_column_number", func(t *testing.T) {
+		f := NewFile()
+		ws, err := f.workSheetReader("Sheet1")
+		assert.NoError(t, err)
+		ws.Cols = &xlsxCols{Col: []xlsxCol{{Min: 0, Max: MaxColumns + 1, Width: float64Ptr(9)}}}
+		assert.NoError(t, f.SetColWidth("Sheet1", "A", "A", 12))
+		assert.Equal(t, len(ws.Cols.Col), MaxColumns)
+		width, err := f.GetColWidth("Sheet1", "A")
+		assert.NoError(t, err)
+		assert.Equal(t, 12.0, width)
+		assert.NoError(t, f.Close())
+	})
 }
 
 func TestGetColStyle(t *testing.T) {
@@ -584,24 +597,4 @@ func TestAutoFitColWidth(t *testing.T) {
 	})
 	_, err = f.autoFitColWidth("Sheet1", 1, 1, &Font{})
 	assert.Equal(t, err, newInvalidStyleID(1))
-}
-
-func TestFlatColsBounded(t *testing.T) {
-	// A col element's min and max come from the worksheet XML unvalidated. A
-	// crafted file can declare a range far beyond the MaxColumns a worksheet can
-	// actually hold, which previously made flatCols allocate one entry per
-	// declared column.
-	f := NewFile()
-	ws, err := f.workSheetReader("Sheet1")
-	assert.NoError(t, err)
-	ws.Cols = &xlsxCols{Col: []xlsxCol{{Min: 1, Max: 2147483647, Width: float64Ptr(9)}}}
-
-	assert.NoError(t, f.SetColWidth("Sheet1", "A", "A", 12))
-	assert.LessOrEqual(t, len(ws.Cols.Col), MaxColumns)
-
-	// The columns a worksheet can genuinely hold are still flattened.
-	width, err := f.GetColWidth("Sheet1", "A")
-	assert.NoError(t, err)
-	assert.Equal(t, 12.0, width)
-	assert.NoError(t, f.Close())
 }

--- a/col_test.go
+++ b/col_test.go
@@ -585,3 +585,23 @@ func TestAutoFitColWidth(t *testing.T) {
 	_, err = f.autoFitColWidth("Sheet1", 1, 1, &Font{})
 	assert.Equal(t, err, newInvalidStyleID(1))
 }
+
+func TestFlatColsBounded(t *testing.T) {
+	// A col element's min and max come from the worksheet XML unvalidated. A
+	// crafted file can declare a range far beyond the MaxColumns a worksheet can
+	// actually hold, which previously made flatCols allocate one entry per
+	// declared column.
+	f := NewFile()
+	ws, err := f.workSheetReader("Sheet1")
+	assert.NoError(t, err)
+	ws.Cols = &xlsxCols{Col: []xlsxCol{{Min: 1, Max: 2147483647, Width: float64Ptr(9)}}}
+
+	assert.NoError(t, f.SetColWidth("Sheet1", "A", "A", 12))
+	assert.LessOrEqual(t, len(ws.Cols.Col), MaxColumns)
+
+	// The columns a worksheet can genuinely hold are still flattened.
+	width, err := f.GetColWidth("Sheet1", "A")
+	assert.NoError(t, err)
+	assert.Equal(t, 12.0, width)
+	assert.NoError(t, f.Close())
+}


### PR DESCRIPTION
`flatCols` materializes one `xlsxCol` per column in the range a `<col>` element declares. Those `min` and `max` attributes come straight from the worksheet XML and are not validated anywhere on the way in, so the size of that loop is whatever the file says it is.

A worksheet cannot hold more than `MaxColumns` columns, so flattening past that bound cannot produce anything usable. This clamps both loops to `MinColumns..MaxColumns`.

For any range a worksheet can genuinely contain the result is unchanged, since the clamp only takes effect outside the representable range. The four column mutators that call `flatCols` (`setColVisible`, `setColOutlineLevel`, `setColStyle`, `setColWidth`) keep their signatures, so nothing changes for callers.

I went with clamping rather than returning `ErrColumnNumber` to keep this to `flatCols`. Returning an error would mean threading it through those four helpers and their nine call sites across `col.go` and `stream.go`. Happy to redo it that way if you would rather reject such a file outright, and equally happy to move the check to parse time instead.

Verified:

- `go build ./...` clean, `gofmt` clean
- full `go test ./...` passes (71s)
- added `TestFlatColsBounded`, which sets a `<col>` range of `1..2147483647` on a sheet, calls `SetColWidth`, and asserts the flattened set stays within `MaxColumns` while a real column is still flattened and readable

Filed at your request from the report on the advisory.
