### PR TITLE
This closes #2372, fix precision loss for time.Duration cell values

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -285,7 +285,7 @@ func (c *xlsxC) setCellTime(value time.Time, date1904 bool) (isNum bool, err err
 // setCellDuration prepares cell type and value by given Go time.Duration type
 // time duration.
 func setCellDuration(value time.Duration) (t string, v string) {
-	v = strconv.FormatFloat(value.Seconds()/86400, 'f', -1, 32)
+	v = strconv.FormatFloat(value.Seconds()/86400, 'f', -1, 64)
 	return
 }
 

--- a/cell_test.go
+++ b/cell_test.go
@@ -317,8 +317,7 @@ func TestSetCellValue(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, val)
 	}
-	// Test set cell value with a time duration whose serial number is not
-	// exactly representable, the stored value should keep float64 precision
+	// Test set cell value with time
 	for val, expected := range map[time.Duration]string{
 		time.Hour*24*100 + 123456789: "100.00000142889802",
 		time.Minute + time.Second*30: "0.0010416666666666667",
@@ -328,35 +327,19 @@ func TestSetCellValue(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, raw)
 	}
-	// Test set cell value with time
 	for val, expected := range map[time.Time]string{
 		time.Date(2024, time.October, 1, 0, 0, 0, 0, time.UTC):   "Oct-24",
 		time.Date(2024, time.October, 10, 0, 0, 0, 0, time.UTC):  "10-10-24",
 		time.Date(2024, time.October, 10, 12, 0, 0, 0, time.UTC): "10/10/24 12:00",
+		time.Date(2010, time.December, 31, 0, 0, 0, 0, time.UTC): "12-31-10",
+		// Test date value lower than min date supported by Excel
+		time.Date(1600, time.December, 31, 0, 0, 0, 0, time.UTC): "1600-12-31T00:00:00Z",
 	} {
 		assert.NoError(t, f.SetCellValue("Sheet1", "A1", val))
 		val, err := f.GetCellValue("Sheet1", "A1")
 		assert.NoError(t, err)
 		assert.Equal(t, expected, val)
 	}
-}
-
-func TestSetCellValues(t *testing.T) {
-	f := NewFile()
-	err := f.SetCellValue("Sheet1", "A1", time.Date(2010, time.December, 31, 0, 0, 0, 0, time.UTC))
-	assert.NoError(t, err)
-
-	v, err := f.GetCellValue("Sheet1", "A1")
-	assert.NoError(t, err)
-	assert.Equal(t, v, "12-31-10")
-
-	// Test date value lower than min date supported by Excel
-	err = f.SetCellValue("Sheet1", "A1", time.Date(1600, time.December, 31, 0, 0, 0, 0, time.UTC))
-	assert.NoError(t, err)
-
-	v, err = f.GetCellValue("Sheet1", "A1")
-	assert.NoError(t, err)
-	assert.Equal(t, v, "1600-12-31T00:00:00Z")
 }
 
 func TestSetCellBool(t *testing.T) {

--- a/cell_test.go
+++ b/cell_test.go
@@ -317,6 +317,17 @@ func TestSetCellValue(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, val)
 	}
+	// Test set cell value with a time duration whose serial number is not
+	// exactly representable, the stored value should keep float64 precision
+	for val, expected := range map[time.Duration]string{
+		time.Hour*24*100 + 123456789: "100.00000142889802",
+		time.Minute + time.Second*30: "0.0010416666666666667",
+	} {
+		assert.NoError(t, f.SetCellValue("Sheet1", "A1", val))
+		raw, err := f.GetCellValue("Sheet1", "A1", Options{RawCellValue: true})
+		assert.NoError(t, err)
+		assert.Equal(t, expected, raw)
+	}
 	// Test set cell value with time
 	for val, expected := range map[time.Time]string{
 		time.Date(2024, time.October, 1, 0, 0, 0, 0, time.UTC):   "Oct-24",


### PR DESCRIPTION
#### Description

`setCellDuration` formats the Excel serial number with `bitSize` 32:

```go
v = strconv.FormatFloat(value.Seconds()/86400, 'f', -1, 32)
```

`value.Seconds()` returns a `float64` and the division is done in `float64`, but `bitSize` 32 tells `FormatFloat` to emit the shortest decimal that round-trips as a `float32`, so the extra precision is thrown away on write.

It is the only float write path in the package that does this — `cell.go:278`, `cell.go:603`, `cell.go:646/648`, `lib.go:815`, `numfmt.go:5290/5544/5676`, `stream.go:358/722` and the `calc.go` sites all use 64. (`cell.go:420` takes a caller-supplied `bitSize` from `SetCellFloat`, which is by design.)

Reproduced on master before the change:

| duration | stored | with bitSize 64 |
| --- | --- | --- |
| `100*24*time.Hour + 123456789ns` | `100` | `100.00000142889802` |
| `1m30s` | `0.0010416667` | `0.0010416666666666667` |

For the first one the entire fractional part is gone. Durations whose serial is exactly representable in a few decimal digits (`25h30m`, `3h15m45s`) were already unaffected.

#### Related Issue

This closes #2372

#### Motivation and Context

Excel stores serials as IEEE doubles, so writing the full `float64` expansion is what the format expects. Note this does change the raw value written into the XML for durations that are not exactly representable — that is the point of the fix, but it is an output change worth stating.

`StreamWriter.SetRow` (`stream.go`) also goes through `setCellDuration`, so it is fixed by the same one-line change.

#### How Has This Been Tested

The existing duration table in `cell_test.go` only asserts formatted output (`"21:51:44"` and friends), which passes both before and after — those are whole-second values that the number format rounds anyway, so they could not guard this. Added a raw-value assertion using `Options{RawCellValue: true}` for two durations that are not exactly representable; it fails on master with `expected: "100.00000142889802" / actual: "100"`.

`go test -race -timeout 60m ./...` passes in full (839s — `TestZip64` needs the longer timeout), and `gofmt -s -l` is clean on both changed files.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have added tests to cover my changes.
