### PR TITLE
Fix StreamWriter duration number formatting

### DIFF
--- a/adjust_test.go
+++ b/adjust_test.go
@@ -1217,8 +1217,8 @@ func TestAdjustDrawings(t *testing.T) {
 	cells, err := f.GetPictureCells("Sheet1")
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"D3", "B21", "D13"}, cells)
-	wb := filepath.Join("test", "TestAdjustDrawings.xlsx")
-	assert.NoError(t, f.SaveAs(wb))
+	savePath := filepath.Join("test", "TestAdjustDrawings.xlsx")
+	assert.NoError(t, f.SaveAs(savePath))
 
 	// Test adjust pictures on deleting columns and rows
 	assert.NoError(t, f.RemoveCol("Sheet1", "A"))
@@ -1228,7 +1228,7 @@ func TestAdjustDrawings(t *testing.T) {
 	assert.Equal(t, []string{"C2", "B21", "C12"}, cells)
 
 	// Test adjust existing pictures on inserting columns and rows
-	f, err = OpenFile(wb)
+	f, err = OpenFile(savePath)
 	assert.NoError(t, err)
 	assert.NoError(t, f.InsertCols("Sheet1", "A", 1))
 	assert.NoError(t, f.InsertRows("Sheet1", 1, 1))
@@ -1240,7 +1240,7 @@ func TestAdjustDrawings(t *testing.T) {
 	assert.Equal(t, []string{"F4", "B21", "F15"}, cells)
 
 	// Test adjust drawings with unsupported charset
-	f, err = OpenFile(wb)
+	f, err = OpenFile(savePath)
 	assert.NoError(t, err)
 	f.Pkg.Store("xl/drawings/drawing1.xml", MacintoshCyrillicCharset)
 	assert.EqualError(t, f.InsertCols("Sheet1", "A", 1), "XML syntax error on line 1: invalid UTF-8")
@@ -1251,8 +1251,8 @@ func TestAdjustDrawings(t *testing.T) {
 		f = NewFile()
 		assert.NoError(t, f.AddPicture("Sheet1", cell, filepath.Join("test", "images", "excel.jpg"), nil))
 		assert.Equal(t, errors[i], f.InsertCols("Sheet1", "A", 1))
-		assert.NoError(t, f.SaveAs(wb))
-		f, err = OpenFile(wb)
+		assert.NoError(t, f.SaveAs(savePath))
+		f, err = OpenFile(savePath)
 		assert.NoError(t, err)
 		assert.Equal(t, errors[i], f.InsertCols("Sheet1", "A", 1))
 	}
@@ -1262,8 +1262,8 @@ func TestAdjustDrawings(t *testing.T) {
 		f = NewFile()
 		assert.NoError(t, f.AddPicture("Sheet1", cell, filepath.Join("test", "images", "excel.jpg"), nil))
 		assert.Equal(t, errors[i], f.InsertRows("Sheet1", 1, 1))
-		assert.NoError(t, f.SaveAs(wb))
-		f, err = OpenFile(wb)
+		assert.NoError(t, f.SaveAs(savePath))
+		f, err = OpenFile(savePath)
 		assert.NoError(t, err)
 		assert.Equal(t, errors[i], f.InsertRows("Sheet1", 1, 1))
 	}
@@ -1273,12 +1273,12 @@ func TestAdjustDrawings(t *testing.T) {
 	p := xlsxCellAnchorPos{}
 	assert.NoError(t, p.adjustDrawings(columns, 0, 0, ""))
 
-	f, err = OpenFile(wb)
+	f, err = OpenFile(savePath)
 	assert.NoError(t, err)
 	f.Pkg.Store("xl/drawings/drawing1.xml", []byte(xml.Header+`<wsDr xmlns="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"><twoCellAnchor><from><col>0</col><colOff>0</colOff><row>0</row><rowOff>0</rowOff></from><to><col>1</col><colOff>0</colOff><row>1</row><rowOff>0</rowOff></to><mc:AlternateContent xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"></mc:AlternateContent><clientData/></twoCellAnchor></wsDr>`))
 	assert.NoError(t, f.InsertCols("Sheet1", "A", 1))
 
-	f, err = OpenFile(wb)
+	f, err = OpenFile(savePath)
 	assert.NoError(t, err)
 	f.Pkg.Store("xl/drawings/drawing1.xml", []byte(xml.Header+fmt.Sprintf(`<wsDr xmlns="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"><oneCellAnchor><from><col>%d</col><row>0</row></from><mc:AlternateContent xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"></mc:AlternateContent><clientData/></oneCellAnchor></wsDr>`, MaxColumns)))
 	assert.Equal(t, ErrColumnNumber, f.InsertCols("Sheet1", "A", 1))

--- a/cell_test.go
+++ b/cell_test.go
@@ -226,10 +226,10 @@ func TestSetCellValuesMultiByte(t *testing.T) {
 	// Test set cell value with XML escape characters in stream writer
 	_, err := f.NewSheet("Sheet2")
 	assert.NoError(t, err)
-	streamWriter, err := f.NewStreamWriter("Sheet2")
+	sw, err := f.NewStreamWriter("Sheet2")
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.SetRow("A1", row))
-	assert.NoError(t, streamWriter.Flush())
+	assert.NoError(t, sw.SetRow("A1", row))
+	assert.NoError(t, sw.Flush())
 	for _, sheetName := range []string{"Sheet1", "Sheet2"} {
 		for cell, expected := range map[string]int{
 			"A1": TotalCellChars,

--- a/datavalidation_test.go
+++ b/datavalidation_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestDataValidation(t *testing.T) {
-	resultFile := filepath.Join("test", "TestDataValidation.xlsx")
+	savePath := filepath.Join("test", "TestDataValidation.xlsx")
 
 	f := NewFile()
 
@@ -39,7 +39,7 @@ func TestDataValidation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, dataValidations, 1)
 
-	assert.NoError(t, f.SaveAs(resultFile))
+	assert.NoError(t, f.SaveAs(savePath))
 
 	dv = NewDataValidation(true)
 	dv.Sqref = "A3:B4"
@@ -51,7 +51,7 @@ func TestDataValidation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, dataValidations, 2)
 
-	assert.NoError(t, f.SaveAs(resultFile))
+	assert.NoError(t, f.SaveAs(savePath))
 
 	_, err = f.NewSheet("Sheet2")
 	assert.NoError(t, err)
@@ -99,7 +99,7 @@ func TestDataValidation(t *testing.T) {
 	_, err = f.GetDataValidations("Sheet:1")
 	assert.EqualError(t, err, ErrSheetNameInvalid.Error())
 
-	assert.NoError(t, f.SaveAs(resultFile))
+	assert.NoError(t, f.SaveAs(savePath))
 
 	// Test get data validation on a worksheet without data validation settings
 	f = NewFile()
@@ -134,7 +134,7 @@ func TestDataValidation(t *testing.T) {
 }
 
 func TestDataValidationError(t *testing.T) {
-	resultFile := filepath.Join("test", "TestDataValidationError.xlsx")
+	savePath := filepath.Join("test", "TestDataValidationError.xlsx")
 
 	f := NewFile()
 	assert.NoError(t, f.SetCellStr("Sheet1", "E1", "E1"))
@@ -186,7 +186,7 @@ func TestDataValidationError(t *testing.T) {
 	assert.EqualError(t, dv.SetRange(
 		math.SmallestNonzeroFloat64, math.MaxFloat64,
 		DataValidationTypeWhole, DataValidationOperatorGreaterThan), ErrDataValidationRange.Error())
-	assert.NoError(t, f.SaveAs(resultFile))
+	assert.NoError(t, f.SaveAs(savePath))
 
 	// Test add data validation on no exists worksheet
 	f = NewFile()

--- a/rows_test.go
+++ b/rows_test.go
@@ -462,7 +462,7 @@ func prepareTestBook2() (*File, error) {
 
 func TestDuplicateRowFromSingleRow(t *testing.T) {
 	const sheet = "Sheet1"
-	outFile := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
+	savePath := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
 
 	cells := map[string]string{
 		"A1": "A1 Value",
@@ -479,7 +479,7 @@ func TestDuplicateRowFromSingleRow(t *testing.T) {
 		assert.NoError(t, f.SetCellStr(sheet, "B1", cells["B1"]))
 
 		assert.NoError(t, f.DuplicateRow(sheet, 1))
-		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, "FromSingleRow_1"))) {
+		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, "FromSingleRow_1"))) {
 			t.FailNow()
 		}
 		expect := map[string]string{
@@ -495,7 +495,7 @@ func TestDuplicateRowFromSingleRow(t *testing.T) {
 		}
 
 		assert.NoError(t, f.DuplicateRow(sheet, 2))
-		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, "FromSingleRow_2"))) {
+		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, "FromSingleRow_2"))) {
 			t.FailNow()
 		}
 		expect = map[string]string{
@@ -515,7 +515,7 @@ func TestDuplicateRowFromSingleRow(t *testing.T) {
 
 func TestDuplicateRowUpdateDuplicatedRows(t *testing.T) {
 	const sheet = "Sheet1"
-	outFile := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
+	savePath := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
 
 	cells := map[string]string{
 		"A1": "A1 Value",
@@ -536,7 +536,7 @@ func TestDuplicateRowUpdateDuplicatedRows(t *testing.T) {
 		assert.NoError(t, f.SetCellStr(sheet, "A2", cells["A2"]))
 		assert.NoError(t, f.SetCellStr(sheet, "B2", cells["B2"]))
 
-		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, "UpdateDuplicatedRows"))) {
+		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, "UpdateDuplicatedRows"))) {
 			t.FailNow()
 		}
 		expect := map[string]string{
@@ -555,7 +555,7 @@ func TestDuplicateRowUpdateDuplicatedRows(t *testing.T) {
 
 func TestDuplicateRowFirstOfMultipleRows(t *testing.T) {
 	const sheet = "Sheet1"
-	outFile := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
+	savePath := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
 	cells := map[string]string{
 		"A1": "A1 Value",
 		"A2": "A2 Value",
@@ -569,7 +569,7 @@ func TestDuplicateRowFirstOfMultipleRows(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, f.DuplicateRow(sheet, 1))
 
-		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, "FirstOfMultipleRows"))) {
+		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, "FirstOfMultipleRows"))) {
 			t.FailNow()
 		}
 		expect := map[string]string{
@@ -590,14 +590,14 @@ func TestDuplicateRowFirstOfMultipleRows(t *testing.T) {
 
 func TestDuplicateRowZeroWithNoRows(t *testing.T) {
 	const sheet = "Sheet1"
-	outFile := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
+	savePath := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
 
 	t.Run("ZeroWithNoRows", func(t *testing.T) {
 		f := NewFile()
 
 		assert.EqualError(t, f.DuplicateRow(sheet, 0), newInvalidRowNumberError(0).Error())
 
-		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, "ZeroWithNoRows"))) {
+		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, "ZeroWithNoRows"))) {
 			t.FailNow()
 		}
 
@@ -632,14 +632,14 @@ func TestDuplicateRowZeroWithNoRows(t *testing.T) {
 
 func TestDuplicateRowMiddleRowOfEmptyFile(t *testing.T) {
 	const sheet = "Sheet1"
-	outFile := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
+	savePath := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
 
 	t.Run("MiddleRowOfEmptyFile", func(t *testing.T) {
 		f := NewFile()
 
 		assert.NoError(t, f.DuplicateRow(sheet, 99))
 
-		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, "MiddleRowOfEmptyFile"))) {
+		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, "MiddleRowOfEmptyFile"))) {
 			t.FailNow()
 		}
 		expect := map[string]string{
@@ -659,7 +659,7 @@ func TestDuplicateRowMiddleRowOfEmptyFile(t *testing.T) {
 
 func TestDuplicateRowWithLargeOffsetToMiddleOfData(t *testing.T) {
 	const sheet = "Sheet1"
-	outFile := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
+	savePath := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
 
 	cells := map[string]string{
 		"A1": "A1 Value",
@@ -674,7 +674,7 @@ func TestDuplicateRowWithLargeOffsetToMiddleOfData(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, f.DuplicateRowTo(sheet, 1, 3))
 
-		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, "WithLargeOffsetToMiddleOfData"))) {
+		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, "WithLargeOffsetToMiddleOfData"))) {
 			t.FailNow()
 		}
 		expect := map[string]string{
@@ -695,7 +695,7 @@ func TestDuplicateRowWithLargeOffsetToMiddleOfData(t *testing.T) {
 
 func TestDuplicateRowWithLargeOffsetToEmptyRows(t *testing.T) {
 	const sheet = "Sheet1"
-	outFile := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
+	savePath := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
 	cells := map[string]string{
 		"A1": "A1 Value",
 		"A2": "A2 Value",
@@ -709,7 +709,7 @@ func TestDuplicateRowWithLargeOffsetToEmptyRows(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, f.DuplicateRowTo(sheet, 1, 7))
 
-		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, "WithLargeOffsetToEmptyRows"))) {
+		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, "WithLargeOffsetToEmptyRows"))) {
 			t.FailNow()
 		}
 		expect := map[string]string{
@@ -730,7 +730,7 @@ func TestDuplicateRowWithLargeOffsetToEmptyRows(t *testing.T) {
 
 func TestDuplicateRowInsertBefore(t *testing.T) {
 	const sheet = "Sheet1"
-	outFile := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
+	savePath := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
 	cells := map[string]string{
 		"A1": "A1 Value",
 		"A2": "A2 Value",
@@ -745,7 +745,7 @@ func TestDuplicateRowInsertBefore(t *testing.T) {
 		assert.NoError(t, f.DuplicateRowTo(sheet, 2, 1))
 		assert.NoError(t, f.DuplicateRowTo(sheet, 10, 4))
 
-		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, "InsertBefore"))) {
+		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, "InsertBefore"))) {
 			t.FailNow()
 		}
 
@@ -767,7 +767,7 @@ func TestDuplicateRowInsertBefore(t *testing.T) {
 
 func TestDuplicateRowInsertBeforeWithLargeOffset(t *testing.T) {
 	const sheet = "Sheet1"
-	outFile := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
+	savePath := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
 	cells := map[string]string{
 		"A1": "A1 Value",
 		"A2": "A2 Value",
@@ -781,7 +781,7 @@ func TestDuplicateRowInsertBeforeWithLargeOffset(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, f.DuplicateRowTo(sheet, 3, 1))
 
-		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, "InsertBeforeWithLargeOffset"))) {
+		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, "InsertBeforeWithLargeOffset"))) {
 			t.FailNow()
 		}
 
@@ -803,7 +803,7 @@ func TestDuplicateRowInsertBeforeWithLargeOffset(t *testing.T) {
 
 func TestDuplicateRowInsertBeforeWithMergeCells(t *testing.T) {
 	const sheet = "Sheet1"
-	outFile := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
+	savePath := filepath.Join("test", "TestDuplicateRow.%s.xlsx")
 	t.Run("InsertBeforeWithLargeOffset", func(t *testing.T) {
 		f, err := prepareTestBook2()
 		assert.NoError(t, err)
@@ -813,7 +813,7 @@ func TestDuplicateRowInsertBeforeWithMergeCells(t *testing.T) {
 		assert.NoError(t, f.DuplicateRowTo(sheet, 2, 1))
 		assert.NoError(t, f.DuplicateRowTo(sheet, 1, 8))
 
-		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, "InsertBeforeWithMergeCells"))) {
+		if !assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, "InsertBeforeWithMergeCells"))) {
 			t.FailNow()
 		}
 
@@ -835,7 +835,7 @@ func TestDuplicateRowInsertBeforeWithMergeCells(t *testing.T) {
 
 func TestDuplicateRowInvalidRowNum(t *testing.T) {
 	const sheet = "Sheet1"
-	outFile := filepath.Join("test", "TestDuplicateRow.InvalidRowNum.%s.xlsx")
+	savePath := filepath.Join("test", "TestDuplicateRow.InvalidRowNum.%s.xlsx")
 
 	cells := map[string]string{
 		"A1": "A1 Value",
@@ -865,7 +865,7 @@ func TestDuplicateRowInvalidRowNum(t *testing.T) {
 					t.FailNow()
 				}
 			}
-			assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, name)))
+			assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, name)))
 		})
 	}
 
@@ -887,7 +887,7 @@ func TestDuplicateRowInvalidRowNum(t *testing.T) {
 						t.FailNow()
 					}
 				}
-				assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, name)))
+				assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, name)))
 			})
 		}
 	}

--- a/sheet_test.go
+++ b/sheet_test.go
@@ -694,11 +694,11 @@ func BenchmarkNewSheet(b *testing.B) {
 }
 
 func newSheetWithSet() {
-	file := NewFile()
+	f := NewFile()
 	for i := 0; i < 1000; i++ {
-		_ = file.SetCellInt("Sheet1", "A"+strconv.Itoa(i+1), int64(i))
+		_ = f.SetCellInt("Sheet1", "A"+strconv.Itoa(i+1), int64(i))
 	}
-	file = nil
+	f = nil
 }
 
 func BenchmarkFile_SaveAs(b *testing.B) {
@@ -710,11 +710,11 @@ func BenchmarkFile_SaveAs(b *testing.B) {
 }
 
 func newSheetWithSave() {
-	file := NewFile()
+	f := NewFile()
 	for i := 0; i < 1000; i++ {
-		_ = file.SetCellInt("Sheet1", "A"+strconv.Itoa(i+1), int64(i))
+		_ = f.SetCellInt("Sheet1", "A"+strconv.Itoa(i+1), int64(i))
 	}
-	_ = file.Save()
+	_ = f.Save()
 }
 
 func TestAttrValToBool(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -589,6 +589,17 @@ func (sw *StreamWriter) setCellTime(c *xlsxC, val time.Time) error {
 	return nil
 }
 
+// setCellDuration provides a function to set number of a cell with a duration.
+func (sw *StreamWriter) setCellDuration(c *xlsxC, val time.Duration) error {
+	c.T, c.V = setCellDuration(val)
+	if c.S != 0 {
+		return nil
+	}
+	var err error
+	c.S, err = sw.file.NewStyle(&Style{NumFmt: getDurationNumFmt(val)})
+	return err
+}
+
 // setCellValFunc provides a function to set value of a cell.
 func (sw *StreamWriter) setCellValFunc(c *xlsxC, val interface{}) error {
 	var err error
@@ -604,7 +615,7 @@ func (sw *StreamWriter) setCellValFunc(c *xlsxC, val interface{}) error {
 	case []byte:
 		c.setCellValue(string(val))
 	case time.Duration:
-		c.T, c.V = setCellDuration(val)
+		err = sw.setCellDuration(c, val)
 	case time.Time:
 		err = sw.setCellTime(c, val)
 	case bool:

--- a/stream_test.go
+++ b/stream_test.go
@@ -425,6 +425,78 @@ func TestStreamSetRowWithStyle(t *testing.T) {
 	}
 }
 
+func TestStreamWriterDurationFormat(t *testing.T) {
+	file := NewFile()
+	defer func() {
+		assert.NoError(t, file.Close())
+	}()
+	_, err := file.NewSheet("Stream")
+	assert.NoError(t, err)
+
+	streamWriter, err := file.NewStreamWriter("Stream")
+	assert.NoError(t, err)
+
+	for row, test := range []struct {
+		value  time.Duration
+		numFmt int
+	}{
+		// Whole minutes below 24 hours use the hour-and-minute format.
+		{time.Hour*21 + time.Minute*50, 20},
+		// Durations with seconds below 24 hours use the hour-minute-second format.
+		{time.Hour*21 + time.Minute*51 + time.Second*44, 21},
+		// Durations of 24 hours or more use the elapsed-hours format.
+		{time.Hour*25 + time.Minute*30, 46},
+	} {
+		cell := fmt.Sprintf("A%d", row+1)
+		assert.NoError(t, file.SetCellValue("Sheet1", cell, test.value))
+		assert.NoError(t, streamWriter.SetRow(cell, []any{test.value}))
+	}
+
+	// An explicitly supplied cell style must not be replaced by the default duration format.
+	explicitStyleID, err := file.NewStyle(&Style{Font: &Font{Color: "777777"}})
+	assert.NoError(t, err)
+	assert.NoError(t, streamWriter.SetRow("A10", []any{
+		Cell{StyleID: explicitStyleID, Value: time.Hour},
+	}))
+	assert.NoError(t, streamWriter.Flush())
+	styleID, err := file.GetCellStyle("Stream", "A10")
+	assert.NoError(t, err)
+	assert.Equal(t, explicitStyleID, styleID)
+
+	// Compare styles and values after flushing the streamed worksheet.
+	for row, test := range []struct {
+		value  time.Duration
+		numFmt int
+	}{
+		{time.Hour*21 + time.Minute*50, 20},
+		{time.Hour*21 + time.Minute*51 + time.Second*44, 21},
+		{time.Hour*25 + time.Minute*30, 46},
+	} {
+		cell := fmt.Sprintf("A%d", row+1)
+		normalStyleID, err := file.GetCellStyle("Sheet1", cell)
+		assert.NoError(t, err)
+		streamStyleID, err := file.GetCellStyle("Stream", cell)
+		assert.NoError(t, err)
+		normalStyle, err := file.GetStyle(normalStyleID)
+		assert.NoError(t, err)
+		streamStyle, err := file.GetStyle(streamStyleID)
+		assert.NoError(t, err)
+		assert.Equal(t, test.numFmt, normalStyle.NumFmt)
+		assert.Equal(t, normalStyle.NumFmt, streamStyle.NumFmt)
+
+		normalValue, err := file.GetCellValue("Sheet1", cell)
+		assert.NoError(t, err)
+		streamValue, err := file.GetCellValue("Stream", cell)
+		assert.NoError(t, err)
+		assert.Equal(t, normalValue, streamValue)
+		normalRaw, err := file.GetCellValue("Sheet1", cell, Options{RawCellValue: true})
+		assert.NoError(t, err)
+		streamRaw, err := file.GetCellValue("Stream", cell, Options{RawCellValue: true})
+		assert.NoError(t, err)
+		assert.Equal(t, normalRaw, streamRaw)
+	}
+}
+
 func TestStreamSetCellValFunc(t *testing.T) {
 	f := NewFile()
 	defer func() {

--- a/stream_test.go
+++ b/stream_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 func BenchmarkStreamWriter(b *testing.B) {
-	file := NewFile()
+	f := NewFile()
 	defer func() {
-		if err := file.Close(); err != nil {
+		if err := f.Close(); err != nil {
 			b.Error(err)
 		}
 	}()
@@ -28,10 +28,10 @@ func BenchmarkStreamWriter(b *testing.B) {
 	}
 
 	for b.Loop() {
-		streamWriter, _ := file.NewStreamWriter("Sheet1")
+		sw, _ := f.NewStreamWriter("Sheet1")
 		for rowID := 10; rowID <= 110; rowID++ {
 			cell, _ := CoordinatesToCellName(1, rowID)
-			_ = streamWriter.SetRow(cell, row)
+			_ = sw.SetRow(cell, row)
 		}
 	}
 
@@ -39,33 +39,33 @@ func BenchmarkStreamWriter(b *testing.B) {
 }
 
 func TestStreamWriter(t *testing.T) {
-	file := NewFile()
-	streamWriter, err := file.NewStreamWriter("Sheet1")
+	f := NewFile()
+	sw, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
 
 	// Test max characters in a cell
 	row := make([]interface{}, 1)
 	row[0] = strings.Repeat("c", TotalCellChars+2)
-	assert.NoError(t, streamWriter.SetRow("A1", row))
+	assert.NoError(t, sw.SetRow("A1", row))
 
 	// Test leading and ending space(s) character characters in a cell
 	row = make([]interface{}, 1)
 	row[0] = " characters"
-	assert.NoError(t, streamWriter.SetRow("A2", row))
+	assert.NoError(t, sw.SetRow("A2", row))
 
 	row = make([]interface{}, 1)
 	row[0] = []byte("Word")
-	assert.NoError(t, streamWriter.SetRow("A3", row))
+	assert.NoError(t, sw.SetRow("A3", row))
 
 	// Test set cell with style and rich text
-	styleID, err := file.NewStyle(&Style{Font: &Font{Color: "777777"}})
+	styleID, err := f.NewStyle(&Style{Font: &Font{Color: "777777"}})
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.SetRow("A4", []interface{}{
+	assert.NoError(t, sw.SetRow("A4", []interface{}{
 		Cell{StyleID: styleID},
 		Cell{Formula: "SUM(A10,B10)", Value: " preserve space "},
 	},
 		RowOpts{Height: 45, StyleID: styleID}))
-	assert.NoError(t, streamWriter.SetRow("A5", []interface{}{
+	assert.NoError(t, sw.SetRow("A5", []interface{}{
 		&Cell{StyleID: styleID, Value: "cell <>&'\""},
 		&Cell{Formula: "SUM(A10,B10)"},
 		[]RichTextRun{
@@ -73,11 +73,11 @@ func TestStreamWriter(t *testing.T) {
 			{Text: "Text", Font: &Font{Color: "E83723"}},
 		},
 	}))
-	assert.NoError(t, streamWriter.SetRow("A6", []interface{}{time.Now()}))
-	assert.NoError(t, streamWriter.SetRow("A7", nil, RowOpts{Height: 20, Hidden: true, StyleID: styleID}))
-	assert.Equal(t, ErrMaxRowHeight, streamWriter.SetRow("A8", nil, RowOpts{Height: MaxRowHeight + 1}))
+	assert.NoError(t, sw.SetRow("A6", []interface{}{time.Now()}))
+	assert.NoError(t, sw.SetRow("A7", nil, RowOpts{Height: 20, Hidden: true, StyleID: styleID}))
+	assert.Equal(t, ErrMaxRowHeight, sw.SetRow("A8", nil, RowOpts{Height: MaxRowHeight + 1}))
 
-	assert.NoError(t, streamWriter.SetRow("A9", []interface{}{math.NaN(), math.Inf(0), math.Inf(-1)}))
+	assert.NoError(t, sw.SetRow("A9", []interface{}{math.NaN(), math.Inf(0), math.Inf(-1)}))
 
 	for rowID := 10; rowID <= 51200; rowID++ {
 		row := make([]interface{}, 50)
@@ -85,20 +85,20 @@ func TestStreamWriter(t *testing.T) {
 			row[colID] = rand.Intn(640000)
 		}
 		cell, _ := CoordinatesToCellName(1, rowID)
-		assert.NoError(t, streamWriter.SetRow(cell, row))
+		assert.NoError(t, sw.SetRow(cell, row))
 	}
 
-	assert.NoError(t, streamWriter.Flush())
+	assert.NoError(t, sw.Flush())
 	// Save spreadsheet by the given path
-	assert.NoError(t, file.SaveAs(filepath.Join("test", "TestStreamWriter.xlsx")))
+	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestStreamWriter.xlsx")))
 
 	// Test set cell column overflow
-	assert.ErrorIs(t, streamWriter.SetRow("XFD51201", []interface{}{"A", "B", "C"}), ErrColumnNumber)
-	assert.NoError(t, file.Close())
+	assert.ErrorIs(t, sw.SetRow("XFD51201", []interface{}{"A", "B", "C"}), ErrColumnNumber)
+	assert.NoError(t, f.Close())
 
 	// Test close temporary file error
-	file = NewFile(Options{TmpDir: os.TempDir()})
-	streamWriter, err = file.NewStreamWriter("Sheet1")
+	f = NewFile(Options{TmpDir: os.TempDir()})
+	sw, err = f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
 	for rowID := 10; rowID <= 25600; rowID++ {
 		row := make([]interface{}, 50)
@@ -106,40 +106,40 @@ func TestStreamWriter(t *testing.T) {
 			row[colID] = rand.Intn(640000)
 		}
 		cell, _ := CoordinatesToCellName(1, rowID)
-		assert.NoError(t, streamWriter.SetRow(cell, row))
+		assert.NoError(t, sw.SetRow(cell, row))
 	}
-	assert.NoError(t, streamWriter.rawData.Close())
-	assert.Error(t, streamWriter.Flush())
+	assert.NoError(t, sw.rawData.Close())
+	assert.Error(t, sw.Flush())
 
-	streamWriter.rawData.tmp, err = os.CreateTemp(os.TempDir(), "excelize-")
+	sw.rawData.tmp, err = os.CreateTemp(os.TempDir(), "excelize-")
 	assert.NoError(t, err)
-	_, err = streamWriter.rawData.Reader()
+	_, err = sw.rawData.Reader()
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.rawData.tmp.Close())
-	assert.NoError(t, os.Remove(streamWriter.rawData.tmp.Name()))
+	assert.NoError(t, sw.rawData.tmp.Close())
+	assert.NoError(t, os.Remove(sw.rawData.tmp.Name()))
 
 	// Test create stream writer with unsupported charset
-	file = NewFile()
-	file.Sheet.Delete("xl/worksheets/sheet1.xml")
-	file.Pkg.Store("xl/worksheets/sheet1.xml", MacintoshCyrillicCharset)
-	_, err = file.NewStreamWriter("Sheet1")
+	f = NewFile()
+	f.Sheet.Delete("xl/worksheets/sheet1.xml")
+	f.Pkg.Store("xl/worksheets/sheet1.xml", MacintoshCyrillicCharset)
+	_, err = f.NewStreamWriter("Sheet1")
 	assert.EqualError(t, err, "XML syntax error on line 1: invalid UTF-8")
-	assert.NoError(t, file.Close())
+	assert.NoError(t, f.Close())
 
 	// Test read cell
-	file = NewFile()
-	streamWriter, err = file.NewStreamWriter("Sheet1")
+	f = NewFile()
+	sw, err = f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.SetRow("A1", []interface{}{Cell{StyleID: styleID, Value: "Data"}}))
-	assert.NoError(t, streamWriter.Flush())
-	cellValue, err := file.GetCellValue("Sheet1", "A1")
+	assert.NoError(t, sw.SetRow("A1", []interface{}{Cell{StyleID: styleID, Value: "Data"}}))
+	assert.NoError(t, sw.Flush())
+	cellValue, err := f.GetCellValue("Sheet1", "A1")
 	assert.NoError(t, err)
 	assert.Equal(t, "Data", cellValue)
 
 	// Test stream reader for a worksheet with huge amounts of data
-	file, err = OpenFile(filepath.Join("test", "TestStreamWriter.xlsx"))
+	f, err = OpenFile(filepath.Join("test", "TestStreamWriter.xlsx"))
 	assert.NoError(t, err)
-	rows, err := file.Rows("Sheet1")
+	rows, err := f.Rows("Sheet1")
 	assert.NoError(t, err)
 	cells := 0
 	for rows.Next() {
@@ -150,89 +150,89 @@ func TestStreamWriter(t *testing.T) {
 	assert.NoError(t, rows.Close())
 	assert.Equal(t, 2559562, cells)
 	// Save spreadsheet with password.
-	assert.NoError(t, file.SaveAs(filepath.Join("test", "EncryptionTestStreamWriter.xlsx"), Options{Password: "password"}))
-	assert.NoError(t, file.Close())
+	assert.NoError(t, f.SaveAs(filepath.Join("test", "EncryptionTestStreamWriter.xlsx"), Options{Password: "password"}))
+	assert.NoError(t, f.Close())
 }
 
 func TestStreamSetColVisible(t *testing.T) {
-	file := NewFile()
+	f := NewFile()
 	defer func() {
-		assert.NoError(t, file.Close())
+		assert.NoError(t, f.Close())
 	}()
-	streamWriter, err := file.NewStreamWriter("Sheet1")
+	sw, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.SetColVisible(3, 2, false))
-	assert.Equal(t, ErrColumnNumber, streamWriter.SetColVisible(0, 3, false))
-	assert.Equal(t, ErrColumnNumber, streamWriter.SetColVisible(MaxColumns+1, 3, false))
-	assert.NoError(t, streamWriter.SetRow("A1", []interface{}{"A", "B", "C"}))
-	assert.Equal(t, newStreamSetRowOrderError("SetColVisible"), streamWriter.SetColVisible(2, 3, false))
-	assert.NoError(t, streamWriter.Flush())
+	assert.NoError(t, sw.SetColVisible(3, 2, false))
+	assert.Equal(t, ErrColumnNumber, sw.SetColVisible(0, 3, false))
+	assert.Equal(t, ErrColumnNumber, sw.SetColVisible(MaxColumns+1, 3, false))
+	assert.NoError(t, sw.SetRow("A1", []interface{}{"A", "B", "C"}))
+	assert.Equal(t, newStreamSetRowOrderError("SetColVisible"), sw.SetColVisible(2, 3, false))
+	assert.NoError(t, sw.Flush())
 }
 
 func TestStreamSetColOutlineLevel(t *testing.T) {
-	file := NewFile()
+	f := NewFile()
 	defer func() {
-		assert.NoError(t, file.Close())
+		assert.NoError(t, f.Close())
 	}()
-	streamWriter, err := file.NewStreamWriter("Sheet1")
+	sw, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.SetColOutlineLevel(4, 2))
-	assert.Equal(t, ErrOutlineLevel, streamWriter.SetColOutlineLevel(4, 0))
-	assert.Equal(t, ErrOutlineLevel, streamWriter.SetColOutlineLevel(4, 8))
-	assert.Equal(t, ErrColumnNumber, streamWriter.SetColOutlineLevel(0, 2))
-	assert.Equal(t, ErrColumnNumber, streamWriter.SetColOutlineLevel(MaxColumns+1, 2))
-	assert.NoError(t, streamWriter.SetRow("A1", []interface{}{"A", "B", "C"}))
-	assert.Equal(t, newStreamSetRowOrderError("SetColOutlineLevel"), streamWriter.SetColOutlineLevel(4, 2))
-	assert.NoError(t, streamWriter.Flush())
+	assert.NoError(t, sw.SetColOutlineLevel(4, 2))
+	assert.Equal(t, ErrOutlineLevel, sw.SetColOutlineLevel(4, 0))
+	assert.Equal(t, ErrOutlineLevel, sw.SetColOutlineLevel(4, 8))
+	assert.Equal(t, ErrColumnNumber, sw.SetColOutlineLevel(0, 2))
+	assert.Equal(t, ErrColumnNumber, sw.SetColOutlineLevel(MaxColumns+1, 2))
+	assert.NoError(t, sw.SetRow("A1", []interface{}{"A", "B", "C"}))
+	assert.Equal(t, newStreamSetRowOrderError("SetColOutlineLevel"), sw.SetColOutlineLevel(4, 2))
+	assert.NoError(t, sw.Flush())
 }
 
 func TestStreamSetColStyle(t *testing.T) {
-	file := NewFile()
+	f := NewFile()
 	defer func() {
-		assert.NoError(t, file.Close())
+		assert.NoError(t, f.Close())
 	}()
-	streamWriter, err := file.NewStreamWriter("Sheet1")
+	sw, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.SetColStyle(3, 2, 0))
-	assert.Equal(t, ErrColumnNumber, streamWriter.SetColStyle(0, 3, 20))
-	assert.Equal(t, ErrColumnNumber, streamWriter.SetColStyle(MaxColumns+1, 3, 20))
-	assert.Equal(t, newInvalidStyleID(2), streamWriter.SetColStyle(1, 3, 2))
-	assert.NoError(t, streamWriter.SetRow("A1", []interface{}{"A", "B", "C"}))
-	assert.Equal(t, newStreamSetRowOrderError("SetColStyle"), streamWriter.SetColStyle(2, 3, 0))
+	assert.NoError(t, sw.SetColStyle(3, 2, 0))
+	assert.Equal(t, ErrColumnNumber, sw.SetColStyle(0, 3, 20))
+	assert.Equal(t, ErrColumnNumber, sw.SetColStyle(MaxColumns+1, 3, 20))
+	assert.Equal(t, newInvalidStyleID(2), sw.SetColStyle(1, 3, 2))
+	assert.NoError(t, sw.SetRow("A1", []interface{}{"A", "B", "C"}))
+	assert.Equal(t, newStreamSetRowOrderError("SetColStyle"), sw.SetColStyle(2, 3, 0))
 
-	file = NewFile()
+	f = NewFile()
 	defer func() {
-		assert.NoError(t, file.Close())
+		assert.NoError(t, f.Close())
 	}()
 	// Test set column style with unsupported charset style sheet
-	file.Styles = nil
-	file.Pkg.Store(defaultXMLPathStyles, MacintoshCyrillicCharset)
-	streamWriter, err = file.NewStreamWriter("Sheet1")
+	f.Styles = nil
+	f.Pkg.Store(defaultXMLPathStyles, MacintoshCyrillicCharset)
+	sw, err = f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-	assert.EqualError(t, streamWriter.SetColStyle(3, 2, 0), "XML syntax error on line 1: invalid UTF-8")
+	assert.EqualError(t, sw.SetColStyle(3, 2, 0), "XML syntax error on line 1: invalid UTF-8")
 }
 
 func TestStreamSetColWidth(t *testing.T) {
-	file := NewFile()
+	f := NewFile()
 	defer func() {
-		assert.NoError(t, file.Close())
+		assert.NoError(t, f.Close())
 	}()
-	styleID, err := file.NewStyle(&Style{
+	styleID, err := f.NewStyle(&Style{
 		Fill: Fill{Type: "pattern", Color: []string{"E0EBF5"}, Pattern: 1},
 	})
 	if err != nil {
 		fmt.Println(err)
 	}
-	streamWriter, err := file.NewStreamWriter("Sheet1")
+	sw, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.SetColWidth(3, 2, 20))
-	assert.NoError(t, streamWriter.SetColStyle(3, 2, styleID))
-	assert.Equal(t, ErrColumnNumber, streamWriter.SetColWidth(0, 3, 20))
-	assert.Equal(t, ErrColumnNumber, streamWriter.SetColWidth(MaxColumns+1, 3, 20))
-	assert.Equal(t, ErrColumnWidth, streamWriter.SetColWidth(1, 3, MaxColumnWidth+1))
-	assert.NoError(t, streamWriter.SetRow("A1", []interface{}{"A", "B", "C"}))
-	assert.Equal(t, newStreamSetRowOrderError("SetColWidth"), streamWriter.SetColWidth(2, 3, 20))
-	assert.NoError(t, streamWriter.Flush())
+	assert.NoError(t, sw.SetColWidth(3, 2, 20))
+	assert.NoError(t, sw.SetColStyle(3, 2, styleID))
+	assert.Equal(t, ErrColumnNumber, sw.SetColWidth(0, 3, 20))
+	assert.Equal(t, ErrColumnNumber, sw.SetColWidth(MaxColumns+1, 3, 20))
+	assert.Equal(t, ErrColumnWidth, sw.SetColWidth(1, 3, MaxColumnWidth+1))
+	assert.NoError(t, sw.SetRow("A1", []interface{}{"A", "B", "C"}))
+	assert.Equal(t, newStreamSetRowOrderError("SetColWidth"), sw.SetColWidth(2, 3, 20))
+	assert.NoError(t, sw.Flush())
 }
 
 func TestStreamSetPanes(t *testing.T) {
@@ -250,98 +250,98 @@ func TestStreamSetPanes(t *testing.T) {
 	defer func() {
 		assert.NoError(t, file.Close())
 	}()
-	streamWriter, err := file.NewStreamWriter("Sheet1")
+	sw, err := file.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.SetPanes(paneOpts))
-	assert.Equal(t, ErrParameterInvalid, streamWriter.SetPanes(nil))
-	assert.NoError(t, streamWriter.SetRow("A1", []interface{}{"A", "B", "C"}))
-	assert.Equal(t, newStreamSetRowOrderError("SetPanes"), streamWriter.SetPanes(paneOpts))
+	assert.NoError(t, sw.SetPanes(paneOpts))
+	assert.Equal(t, ErrParameterInvalid, sw.SetPanes(nil))
+	assert.NoError(t, sw.SetRow("A1", []interface{}{"A", "B", "C"}))
+	assert.Equal(t, newStreamSetRowOrderError("SetPanes"), sw.SetPanes(paneOpts))
 }
 
 func TestStreamTable(t *testing.T) {
-	file := NewFile()
+	f := NewFile()
 	defer func() {
-		assert.NoError(t, file.Close())
+		assert.NoError(t, f.Close())
 	}()
-	streamWriter, err := file.NewStreamWriter("Sheet1")
+	sw, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
 	// Test add table without table header
-	assert.EqualError(t, streamWriter.AddTable(&Table{Range: "A1:C2"}), "XML syntax error on line 2: unexpected EOF")
+	assert.EqualError(t, sw.AddTable(&Table{Range: "A1:C2"}), "XML syntax error on line 2: unexpected EOF")
 	// Write some rows. We want enough rows to force a temp file (>16MB)
-	assert.NoError(t, streamWriter.SetRow("A1", []interface{}{"A", "B", "C"}))
+	assert.NoError(t, sw.SetRow("A1", []interface{}{"A", "B", "C"}))
 	row := []interface{}{1, 2, 3}
 	for r := 2; r < 10000; r++ {
-		assert.NoError(t, streamWriter.SetRow(fmt.Sprintf("A%d", r), row))
+		assert.NoError(t, sw.SetRow(fmt.Sprintf("A%d", r), row))
 	}
 
 	// Write a table
-	assert.NoError(t, streamWriter.AddTable(&Table{Range: "A1:C2"}))
-	assert.NoError(t, streamWriter.Flush())
+	assert.NoError(t, sw.AddTable(&Table{Range: "A1:C2"}))
+	assert.NoError(t, sw.Flush())
 
 	// Verify the table has names
 	var table xlsxTable
-	val, ok := file.Pkg.Load("xl/tables/table1.xml")
+	val, ok := f.Pkg.Load("xl/tables/table1.xml")
 	assert.True(t, ok)
 	assert.NoError(t, xml.Unmarshal(val.([]byte), &table))
 	assert.Equal(t, "A", table.TableColumns.TableColumn[0].Name)
 	assert.Equal(t, "B", table.TableColumns.TableColumn[1].Name)
 	assert.Equal(t, "C", table.TableColumns.TableColumn[2].Name)
 
-	assert.NoError(t, streamWriter.AddTable(&Table{Range: "A1:C1"}))
+	assert.NoError(t, sw.AddTable(&Table{Range: "A1:C1"}))
 
 	// Test add table with illegal cell reference
-	assert.Equal(t, newCellNameToCoordinatesError("A", newInvalidCellNameError("A")), streamWriter.AddTable(&Table{Range: "A:B1"}))
-	assert.Equal(t, newCellNameToCoordinatesError("B", newInvalidCellNameError("B")), streamWriter.AddTable(&Table{Range: "A1:B"}))
+	assert.Equal(t, newCellNameToCoordinatesError("A", newInvalidCellNameError("A")), sw.AddTable(&Table{Range: "A:B1"}))
+	assert.Equal(t, newCellNameToCoordinatesError("B", newInvalidCellNameError("B")), sw.AddTable(&Table{Range: "A1:B"}))
 	// Test add table with invalid table name
-	assert.Equal(t, newInvalidNameError("1Table"), streamWriter.AddTable(&Table{Range: "A:B1", Name: "1Table"}))
+	assert.Equal(t, newInvalidNameError("1Table"), sw.AddTable(&Table{Range: "A:B1", Name: "1Table"}))
 	// Test add table with row number exceeds maximum limit
-	assert.Equal(t, ErrMaxRows, streamWriter.AddTable(&Table{Range: "A1048576:C1048576"}))
+	assert.Equal(t, ErrMaxRows, sw.AddTable(&Table{Range: "A1048576:C1048576"}))
 	// Test add table with unsupported charset content types
-	file.ContentTypes = nil
-	file.Pkg.Store(defaultXMLPathContentTypes, MacintoshCyrillicCharset)
-	assert.EqualError(t, streamWriter.AddTable(&Table{Range: "A1:C2"}), "XML syntax error on line 1: invalid UTF-8")
+	f.ContentTypes = nil
+	f.Pkg.Store(defaultXMLPathContentTypes, MacintoshCyrillicCharset)
+	assert.EqualError(t, sw.AddTable(&Table{Range: "A1:C2"}), "XML syntax error on line 1: invalid UTF-8")
 }
 
 func TestStreamMergeCells(t *testing.T) {
-	file := NewFile()
+	f := NewFile()
 	defer func() {
-		assert.NoError(t, file.Close())
+		assert.NoError(t, f.Close())
 	}()
-	streamWriter, err := file.NewStreamWriter("Sheet1")
+	sw, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.MergeCell("A1", "D1"))
+	assert.NoError(t, sw.MergeCell("A1", "D1"))
 	// Test merge cells with illegal cell reference
-	assert.Equal(t, newCellNameToCoordinatesError("A", newInvalidCellNameError("A")), streamWriter.MergeCell("A", "D1"))
-	assert.NoError(t, streamWriter.Flush())
+	assert.Equal(t, newCellNameToCoordinatesError("A", newInvalidCellNameError("A")), sw.MergeCell("A", "D1"))
+	assert.NoError(t, sw.Flush())
 	// Save spreadsheet by the given path
-	assert.NoError(t, file.SaveAs(filepath.Join("test", "TestStreamMergeCells.xlsx")))
+	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestStreamMergeCells.xlsx")))
 }
 
 func TestStreamInsertPageBreak(t *testing.T) {
-	file := NewFile()
+	f := NewFile()
 	defer func() {
-		assert.NoError(t, file.Close())
+		assert.NoError(t, f.Close())
 	}()
-	streamWriter, err := file.NewStreamWriter("Sheet1")
+	sw, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.InsertPageBreak("A1"))
-	assert.NoError(t, streamWriter.Flush())
+	assert.NoError(t, sw.InsertPageBreak("A1"))
+	assert.NoError(t, sw.Flush())
 	// Save spreadsheet by the given path
-	assert.NoError(t, file.SaveAs(filepath.Join("test", "TestStreamInsertPageBreak.xlsx")))
+	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestStreamInsertPageBreak.xlsx")))
 }
 
 func TestNewStreamWriter(t *testing.T) {
 	// Test error exceptions
-	file := NewFile()
+	f := NewFile()
 	defer func() {
-		assert.NoError(t, file.Close())
+		assert.NoError(t, f.Close())
 	}()
-	_, err := file.NewStreamWriter("Sheet1")
+	_, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-	_, err = file.NewStreamWriter("SheetN")
+	_, err = f.NewStreamWriter("SheetN")
 	assert.EqualError(t, err, "sheet SheetN does not exist")
 	// Test new stream write with invalid sheet name
-	_, err = file.NewStreamWriter("Sheet:1")
+	_, err = f.NewStreamWriter("Sheet:1")
 	assert.Equal(t, ErrSheetNameInvalid, err)
 }
 
@@ -354,68 +354,68 @@ func TestStreamMarshalAttrs(t *testing.T) {
 
 func TestStreamSetRow(t *testing.T) {
 	// Test error exceptions
-	file := NewFile()
+	f := NewFile()
 	defer func() {
-		assert.NoError(t, file.Close())
+		assert.NoError(t, f.Close())
 	}()
-	streamWriter, err := file.NewStreamWriter("Sheet1")
+	sw, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-	assert.Equal(t, newCellNameToCoordinatesError("A", newInvalidCellNameError("A")), streamWriter.SetRow("A", []interface{}{}))
+	assert.Equal(t, newCellNameToCoordinatesError("A", newInvalidCellNameError("A")), sw.SetRow("A", []interface{}{}))
 	// Test set row with non-ascending row number
-	assert.NoError(t, streamWriter.SetRow("A1", []interface{}{}))
-	assert.Equal(t, newStreamSetRowError(1), streamWriter.SetRow("A1", []interface{}{}))
+	assert.NoError(t, sw.SetRow("A1", []interface{}{}))
+	assert.Equal(t, newStreamSetRowError(1), sw.SetRow("A1", []interface{}{}))
 	// Test set row with unsupported charset workbook
-	file.WorkBook = nil
-	file.Pkg.Store(defaultXMLPathWorkbook, MacintoshCyrillicCharset)
-	assert.EqualError(t, streamWriter.SetRow("A2", []interface{}{time.Now()}), "XML syntax error on line 1: invalid UTF-8")
+	f.WorkBook = nil
+	f.Pkg.Store(defaultXMLPathWorkbook, MacintoshCyrillicCharset)
+	assert.EqualError(t, sw.SetRow("A2", []interface{}{time.Now()}), "XML syntax error on line 1: invalid UTF-8")
 }
 
 func TestStreamSetRowNilValues(t *testing.T) {
-	file := NewFile()
+	f := NewFile()
 	defer func() {
-		assert.NoError(t, file.Close())
+		assert.NoError(t, f.Close())
 	}()
-	streamWriter, err := file.NewStreamWriter("Sheet1")
+	sw, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.SetRow("A1", []interface{}{nil, nil, Cell{Value: "foo"}}))
-	assert.NoError(t, streamWriter.Flush())
-	ws, err := file.workSheetReader("Sheet1")
+	assert.NoError(t, sw.SetRow("A1", []interface{}{nil, nil, Cell{Value: "foo"}}))
+	assert.NoError(t, sw.Flush())
+	ws, err := f.workSheetReader("Sheet1")
 	assert.NoError(t, err)
 	assert.NotEqual(t, ws.SheetData.Row[0].C[0].XMLName.Local, "c")
 }
 
 func TestStreamSetRowWithStyle(t *testing.T) {
-	file := NewFile()
+	f := NewFile()
 	defer func() {
-		assert.NoError(t, file.Close())
+		assert.NoError(t, f.Close())
 	}()
-	grayStyleID, err := file.NewStyle(&Style{Font: &Font{Color: "777777"}})
+	grayStyleID, err := f.NewStyle(&Style{Font: &Font{Color: "777777"}})
 	assert.NoError(t, err)
-	blueStyleID, err := file.NewStyle(&Style{Font: &Font{Color: "0000FF"}})
+	blueStyleID, err := f.NewStyle(&Style{Font: &Font{Color: "0000FF"}})
 	assert.NoError(t, err)
 
 	sheetName := "Sheet1"
-	streamWriter, err := file.NewStreamWriter(sheetName)
+	sw, err := f.NewStreamWriter(sheetName)
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.SetColStyle(1, 1, grayStyleID))
-	assert.NoError(t, streamWriter.SetColStyle(3, 3, blueStyleID))
-	assert.NoError(t, streamWriter.SetRow("A1", []interface{}{
+	assert.NoError(t, sw.SetColStyle(1, 1, grayStyleID))
+	assert.NoError(t, sw.SetColStyle(3, 3, blueStyleID))
+	assert.NoError(t, sw.SetRow("A1", []interface{}{
 		"A1",
 		Cell{Value: "B1"},
 		&Cell{Value: "C1"},
 		Cell{StyleID: blueStyleID, Value: "D1"},
 		&Cell{StyleID: blueStyleID, Value: "E1"},
 	}, RowOpts{StyleID: grayStyleID}))
-	assert.NoError(t, streamWriter.SetRow("A2", []interface{}{
+	assert.NoError(t, sw.SetRow("A2", []interface{}{
 		"A2",
 		Cell{Value: "B2"},
 		&Cell{Value: "C2"},
 		Cell{StyleID: grayStyleID, Value: "D2"},
 		&Cell{StyleID: blueStyleID, Value: "E2"},
 	}))
-	assert.NoError(t, streamWriter.Flush())
+	assert.NoError(t, sw.Flush())
 
-	ws, err := file.workSheetReader(sheetName)
+	ws, err := f.workSheetReader(sheetName)
 	assert.NoError(t, err)
 	for colIdx, expected := range []int{grayStyleID, grayStyleID, grayStyleID, blueStyleID, blueStyleID} {
 		assert.Equal(t, expected, ws.SheetData.Row[0].C[colIdx].S)
@@ -426,75 +426,26 @@ func TestStreamSetRowWithStyle(t *testing.T) {
 }
 
 func TestStreamWriterDurationFormat(t *testing.T) {
-	file := NewFile()
-	defer func() {
-		assert.NoError(t, file.Close())
-	}()
-	_, err := file.NewSheet("Stream")
+	f := NewFile()
+	savePath := filepath.Join("test", "TestStreamWriterDuration.xlsx")
+	val := 25*time.Hour + 30*time.Minute
+	styleID, err := f.NewStyle(&Style{Font: &Font{Color: "777777"}})
 	assert.NoError(t, err)
-
-	streamWriter, err := file.NewStreamWriter("Stream")
+	sw, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
-
-	for row, test := range []struct {
-		value  time.Duration
-		numFmt int
-	}{
-		// Whole minutes below 24 hours use the hour-and-minute format.
-		{time.Hour*21 + time.Minute*50, 20},
-		// Durations with seconds below 24 hours use the hour-minute-second format.
-		{time.Hour*21 + time.Minute*51 + time.Second*44, 21},
-		// Durations of 24 hours or more use the elapsed-hours format.
-		{time.Hour*25 + time.Minute*30, 46},
-	} {
-		cell := fmt.Sprintf("A%d", row+1)
-		assert.NoError(t, file.SetCellValue("Sheet1", cell, test.value))
-		assert.NoError(t, streamWriter.SetRow(cell, []any{test.value}))
-	}
-
-	// An explicitly supplied cell style must not be replaced by the default duration format.
-	explicitStyleID, err := file.NewStyle(&Style{Font: &Font{Color: "777777"}})
+	assert.NoError(t, sw.SetRow("A1", []interface{}{val, Cell{StyleID: styleID, Value: val}}))
+	assert.NoError(t, sw.Flush())
+	assert.NoError(t, f.SaveAs(savePath))
+	assert.NoError(t, f.Close())
+	f, err = OpenFile(savePath)
 	assert.NoError(t, err)
-	assert.NoError(t, streamWriter.SetRow("A10", []any{
-		Cell{StyleID: explicitStyleID, Value: time.Hour},
-	}))
-	assert.NoError(t, streamWriter.Flush())
-	styleID, err := file.GetCellStyle("Stream", "A10")
+	cell, err := f.GetCellValue("Sheet1", "A1")
 	assert.NoError(t, err)
-	assert.Equal(t, explicitStyleID, styleID)
-
-	// Compare styles and values after flushing the streamed worksheet.
-	for row, test := range []struct {
-		value  time.Duration
-		numFmt int
-	}{
-		{time.Hour*21 + time.Minute*50, 20},
-		{time.Hour*21 + time.Minute*51 + time.Second*44, 21},
-		{time.Hour*25 + time.Minute*30, 46},
-	} {
-		cell := fmt.Sprintf("A%d", row+1)
-		normalStyleID, err := file.GetCellStyle("Sheet1", cell)
-		assert.NoError(t, err)
-		streamStyleID, err := file.GetCellStyle("Stream", cell)
-		assert.NoError(t, err)
-		normalStyle, err := file.GetStyle(normalStyleID)
-		assert.NoError(t, err)
-		streamStyle, err := file.GetStyle(streamStyleID)
-		assert.NoError(t, err)
-		assert.Equal(t, test.numFmt, normalStyle.NumFmt)
-		assert.Equal(t, normalStyle.NumFmt, streamStyle.NumFmt)
-
-		normalValue, err := file.GetCellValue("Sheet1", cell)
-		assert.NoError(t, err)
-		streamValue, err := file.GetCellValue("Stream", cell)
-		assert.NoError(t, err)
-		assert.Equal(t, normalValue, streamValue)
-		normalRaw, err := file.GetCellValue("Sheet1", cell, Options{RawCellValue: true})
-		assert.NoError(t, err)
-		streamRaw, err := file.GetCellValue("Stream", cell, Options{RawCellValue: true})
-		assert.NoError(t, err)
-		assert.Equal(t, normalRaw, streamRaw)
-	}
+	assert.Equal(t, "25:30:00", cell)
+	cell, err = f.GetCellValue("Sheet1", "B1")
+	assert.NoError(t, err)
+	assert.Equal(t, "1.0625", cell)
+	assert.NoError(t, f.Close())
 }
 
 func TestStreamSetCellValFunc(t *testing.T) {
@@ -531,27 +482,28 @@ func TestStreamSetCellValFunc(t *testing.T) {
 }
 
 func TestStreamWriterOutlineLevel(t *testing.T) {
-	file := NewFile()
-	streamWriter, err := file.NewStreamWriter("Sheet1")
+	f := NewFile()
+	sw, err := f.NewStreamWriter("Sheet1")
 	assert.NoError(t, err)
 
 	// Test set outlineLevel in row
-	assert.NoError(t, streamWriter.SetRow("A1", nil, RowOpts{OutlineLevel: 1}))
-	assert.NoError(t, streamWriter.SetRow("A2", nil, RowOpts{OutlineLevel: 7}))
-	assert.ErrorIs(t, ErrOutlineLevel, streamWriter.SetRow("A3", nil, RowOpts{OutlineLevel: 8}))
+	assert.NoError(t, sw.SetRow("A1", nil, RowOpts{OutlineLevel: 1}))
+	assert.NoError(t, sw.SetRow("A2", nil, RowOpts{OutlineLevel: 7}))
+	assert.ErrorIs(t, ErrOutlineLevel, sw.SetRow("A3", nil, RowOpts{OutlineLevel: 8}))
 
-	assert.NoError(t, streamWriter.Flush())
+	assert.NoError(t, sw.Flush())
 	// Save spreadsheet by the given path
-	assert.NoError(t, file.SaveAs(filepath.Join("test", "TestStreamWriterSetRowOutlineLevel.xlsx")))
+	savePath := filepath.Join("test", "TestStreamWriterSetRowOutlineLevel.xlsx")
+	assert.NoError(t, f.SaveAs(savePath))
 
-	file, err = OpenFile(filepath.Join("test", "TestStreamWriterSetRowOutlineLevel.xlsx"))
+	f, err = OpenFile(savePath)
 	assert.NoError(t, err)
 	for rowIdx, expected := range []uint8{1, 7, 0} {
-		level, err := file.GetRowOutlineLevel("Sheet1", rowIdx+1)
+		level, err := f.GetRowOutlineLevel("Sheet1", rowIdx+1)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, level)
 	}
-	assert.NoError(t, file.Close())
+	assert.NoError(t, f.Close())
 }
 
 func TestStreamWriterReader(t *testing.T) {

--- a/table_test.go
+++ b/table_test.go
@@ -143,7 +143,7 @@ func TestSetTableColumns(t *testing.T) {
 }
 
 func TestAutoFilter(t *testing.T) {
-	outFile := filepath.Join("test", "TestAutoFilter%d.xlsx")
+	savePath := filepath.Join("test", "TestAutoFilter%d.xlsx")
 	f, err := prepareTestBook1()
 	assert.NoError(t, err)
 	for i, opts := range [][]AutoFilterOptions{
@@ -159,7 +159,7 @@ func TestAutoFilter(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("Expression%d", i+1), func(t *testing.T) {
 			assert.NoError(t, f.AutoFilter("Sheet1", "D4:B1", opts))
-			assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, i+1)))
+			assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, i+1)))
 		})
 	}
 
@@ -179,7 +179,7 @@ func TestAutoFilter(t *testing.T) {
 }
 
 func TestAutoFilterError(t *testing.T) {
-	outFile := filepath.Join("test", "TestAutoFilterError%d.xlsx")
+	savePath := filepath.Join("test", "TestAutoFilterError%d.xlsx")
 	f, err := prepareTestBook1()
 	assert.NoError(t, err)
 	for i, opts := range [][]AutoFilterOptions{
@@ -192,7 +192,7 @@ func TestAutoFilterError(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("Expression%d", i+1), func(t *testing.T) {
 			if assert.Error(t, f.AutoFilter("Sheet2", "D4:B1", opts)) {
-				assert.NoError(t, f.SaveAs(fmt.Sprintf(outFile, i+1)))
+				assert.NoError(t, f.SaveAs(fmt.Sprintf(savePath, i+1)))
 			}
 		})
 	}


### PR DESCRIPTION
# PR Details

## Description

Apply the default number format to unstyled `time.Duration` values written with `StreamWriter`, matching the behavior of `SetCellValue`.

Explicitly specified styles remain unchanged.

## Related Issue

Fixes #2371

## Motivation and Context

`StreamWriter` serialized `time.Duration` values but left them with the General number format. This caused durations written with `StreamWriter` and `SetCellValue` to be displayed differently.

## How Has This Been Tested

Added tests covering:
- durations below 24 hours with whole 
- durations below 24 hours with seconds;
- durations of 24 hours or more;
- preservation of explicitly specified styles.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
