### PR TITLE
Fix panics in GetConditionalFormats on malformed conditional formatting rules

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -3000,7 +3000,9 @@ func (f *File) extractCondFmtCellIs(c *xlsxCfRule, extLst *xlsxExtLst) Condition
 		format.MinValue, format.MaxValue = c.Formula[0], c.Formula[1]
 		return format
 	}
-	format.Value = c.Formula[0]
+	if len(c.Formula) > 0 {
+		format.Value = c.Formula[0]
+	}
 	return format
 }
 
@@ -3129,6 +3131,9 @@ func (f *File) extractCondFmtNoErrors(c *xlsxCfRule, extLst *xlsxExtLst) Conditi
 func (f *File) extractCondFmtColorScale(c *xlsxCfRule, extLst *xlsxExtLst) ConditionalFormatOptions {
 	format := ConditionalFormatOptions{StopIfTrue: c.StopIfTrue}
 	format.Type, format.Criteria = "2_color_scale", "="
+	if c.ColorScale == nil {
+		return format
+	}
 	values := len(c.ColorScale.Cfvo)
 	colors := len(c.ColorScale.Color)
 	if colors > 1 && values > 1 {
@@ -3143,7 +3148,7 @@ func (f *File) extractCondFmtColorScale(c *xlsxCfRule, extLst *xlsxExtLst) Condi
 		}
 		format.MaxColor = "#" + f.getThemeColor(c.ColorScale.Color[1])
 	}
-	if colors == 3 {
+	if colors == 3 && values > 2 {
 		format.Type = "3_color_scale"
 		format.MidType = c.ColorScale.Cfvo[1].Type
 		if c.ColorScale.Cfvo[1].Val != "0" {
@@ -3181,7 +3186,7 @@ func (f *File) extractCondFmtDataBarRule(ID string, format *ConditionalFormatOpt
 // settings for data bar by given conditional formatting rule.
 func (f *File) extractCondFmtDataBar(c *xlsxCfRule, extLst *xlsxExtLst) ConditionalFormatOptions {
 	format := ConditionalFormatOptions{Type: "data_bar", Criteria: "="}
-	if c.DataBar != nil {
+	if c.DataBar != nil && len(c.DataBar.Cfvo) > 1 && len(c.DataBar.Color) > 0 {
 		format.StopIfTrue = c.StopIfTrue
 		format.MinType = c.DataBar.Cfvo[0].Type
 		format.MinValue = c.DataBar.Cfvo[0].Val

--- a/styles_test.go
+++ b/styles_test.go
@@ -1,8 +1,6 @@
 package excelize
 
 import (
-	"archive/zip"
-	"bytes"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -336,6 +334,25 @@ func TestGetConditionalFormats(t *testing.T) {
 	ws.ExtLst = &xlsxExtLst{Ext: fmt.Sprintf(`<ext uri="%s"><x14:conditionalFormattings></ext>`, ExtURIConditionalFormattings)}
 	_, err = f.GetConditionalFormats("Sheet1")
 	assert.EqualError(t, err, "XML syntax error on line 1: element <conditionalFormattings> closed by </ext>")
+
+	t.Run("with_invalid_rules", func(t *testing.T) {
+		for _, condFmt := range []string{
+			// Test get conditional formats with cellIs rule without formula
+			`<conditionalFormatting sqref="A1"><cfRule type="cellIs" operator="equal" priority="1" dxfId="0"/></conditionalFormatting>`,
+			// Test get conditional formats with colorScale element absent rule
+			`<conditionalFormatting sqref="A1"><cfRule type="colorScale" priority="1"/></conditionalFormatting>`,
+			// Test get conditional formats with dataBar element empty rule
+			`<conditionalFormatting sqref="A1"><cfRule type="dataBar" priority="1"><dataBar></dataBar></cfRule></conditionalFormatting>`,
+			// Test get conditional formats with three colors rule but one cfvo
+			`<conditionalFormatting sqref="A1"><cfRule type="colorScale" priority="1"><colorScale><cfvo type="min"/><color rgb="FFFF0000"/><color rgb="FF00FF00"/><color rgb="FF0000FF"/></colorScale></cfRule></conditionalFormatting>`,
+		} {
+			f := NewFile()
+			f.Sheet.Delete("xl/worksheets/sheet1.xml")
+			f.Pkg.Store("xl/worksheets/sheet1.xml", fmt.Appendf(nil, `<worksheet xmlns="%s"><sheetData/>%s</worksheet>`, NameSpaceSpreadSheet.Value, condFmt))
+			_, err := f.GetConditionalFormats("Sheet1")
+			assert.NoError(t, err)
+		}
+	})
 }
 
 func TestUnsetConditionalFormat(t *testing.T) {
@@ -919,52 +936,4 @@ func TestGetStyle(t *testing.T) {
 			assert.NoError(t, f.Close(), testCase.label)
 		}
 	})
-}
-
-// buildBookWithRule wraps a <conditionalFormatting> fragment in a minimal
-// workbook so the public OpenReader path parses it.
-func buildBookWithRule(t *testing.T, fragment string) []byte {
-	t.Helper()
-	parts := map[string]string{
-		"[Content_Types].xml": `<?xml version="1.0" encoding="UTF-8"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/></Types>`,
-		"_rels/.rels":         `<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>`,
-		"xl/workbook.xml":     `<?xml version="1.0" encoding="UTF-8"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>`,
-		"xl/_rels/workbook.xml.rels": `<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>`,
-		"xl/worksheets/sheet1.xml": `<?xml version="1.0" encoding="UTF-8"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/>` + fragment + `</worksheet>`,
-	}
-	buf := new(bytes.Buffer)
-	zw := zip.NewWriter(buf)
-	for name, body := range parts {
-		w, err := zw.Create(name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := w.Write([]byte(body)); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := zw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	return buf.Bytes()
-}
-
-func TestGetConditionalFormatsMalformedRules(t *testing.T) {
-	for _, tc := range []struct{ name, fragment string }{
-		{"cellIs without formula", `<conditionalFormatting sqref="A1"><cfRule type="cellIs" operator="equal" priority="1" dxfId="0"/></conditionalFormatting>`},
-		{"colorScale element absent", `<conditionalFormatting sqref="A1"><cfRule type="colorScale" priority="1"/></conditionalFormatting>`},
-		{"dataBar element empty", `<conditionalFormatting sqref="A1"><cfRule type="dataBar" priority="1"><dataBar></dataBar></cfRule></conditionalFormatting>`},
-		{"three colors but one cfvo", `<conditionalFormatting sqref="A1"><cfRule type="colorScale" priority="1"><colorScale><cfvo type="min"/><color rgb="FFFF0000"/><color rgb="FF00FF00"/><color rgb="FF0000FF"/></colorScale></cfRule></conditionalFormatting>`},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			fl, err := OpenReader(bytes.NewReader(buildBookWithRule(t, tc.fragment)))
-			if err != nil {
-				t.Fatalf("OpenReader: %v", err)
-			}
-			defer fl.Close()
-			if _, err := fl.GetConditionalFormats("Sheet1"); err != nil {
-				t.Fatalf("GetConditionalFormats returned an error: %v", err)
-			}
-		})
-	}
 }

--- a/styles_test.go
+++ b/styles_test.go
@@ -1,6 +1,8 @@
 package excelize
 
 import (
+	"archive/zip"
+	"bytes"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -917,4 +919,52 @@ func TestGetStyle(t *testing.T) {
 			assert.NoError(t, f.Close(), testCase.label)
 		}
 	})
+}
+
+// buildBookWithRule wraps a <conditionalFormatting> fragment in a minimal
+// workbook so the public OpenReader path parses it.
+func buildBookWithRule(t *testing.T, fragment string) []byte {
+	t.Helper()
+	parts := map[string]string{
+		"[Content_Types].xml": `<?xml version="1.0" encoding="UTF-8"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/></Types>`,
+		"_rels/.rels":         `<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>`,
+		"xl/workbook.xml":     `<?xml version="1.0" encoding="UTF-8"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets></workbook>`,
+		"xl/_rels/workbook.xml.rels": `<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>`,
+		"xl/worksheets/sheet1.xml": `<?xml version="1.0" encoding="UTF-8"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/>` + fragment + `</worksheet>`,
+	}
+	buf := new(bytes.Buffer)
+	zw := zip.NewWriter(buf)
+	for name, body := range parts {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestGetConditionalFormatsMalformedRules(t *testing.T) {
+	for _, tc := range []struct{ name, fragment string }{
+		{"cellIs without formula", `<conditionalFormatting sqref="A1"><cfRule type="cellIs" operator="equal" priority="1" dxfId="0"/></conditionalFormatting>`},
+		{"colorScale element absent", `<conditionalFormatting sqref="A1"><cfRule type="colorScale" priority="1"/></conditionalFormatting>`},
+		{"dataBar element empty", `<conditionalFormatting sqref="A1"><cfRule type="dataBar" priority="1"><dataBar></dataBar></cfRule></conditionalFormatting>`},
+		{"three colors but one cfvo", `<conditionalFormatting sqref="A1"><cfRule type="colorScale" priority="1"><colorScale><cfvo type="min"/><color rgb="FFFF0000"/><color rgb="FF00FF00"/><color rgb="FF0000FF"/></colorScale></cfRule></conditionalFormatting>`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fl, err := OpenReader(bytes.NewReader(buildBookWithRule(t, tc.fragment)))
+			if err != nil {
+				t.Fatalf("OpenReader: %v", err)
+			}
+			defer fl.Close()
+			if _, err := fl.GetConditionalFormats("Sheet1"); err != nil {
+				t.Fatalf("GetConditionalFormats returned an error: %v", err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fix for `GHSA-rxcj-4pj5-74gr`. Thanks for asking for the PR.

## What panics

`GetConditionalFormats` reaches three extractors that index `cfRule` sub-elements straight out of the worksheet XML, without checking length and in one case without checking for nil. A workbook whose rule is missing a child that Excel would always write panics the call, so a service that opens an untrusted spreadsheet and reads its conditional formats can be crashed by a small file.

Four sinks, all in `styles.go`:

| where | guard before | what reaches it |
|---|---|---|
| `extractCondFmtCellIs` | none | `cellIs` rule with no `<formula>`, indexing `Formula[0]` on an empty slice |
| `extractCondFmtColorScale` | none | `colorScale` rule with no `<colorScale>` child, so `c.ColorScale` is nil |
| same, three-colour branch | `colors == 3` | three `<color>` elements and one `<cfvo>`, indexing `Cfvo[1]` and `Cfvo[2]` |
| `extractCondFmtDataBar` | `c.DataBar != nil` | empty `<dataBar></dataBar>`, indexing `Cfvo[0]`, `Cfvo[1]` and `Color[0]` |

**The third one is not in the advisory.** It turned up while writing the tests: that branch is gated on the colour count and then indexes the cfvo slice, so the two counts can disagree. Worth fixing in the same pass.

## The change

Four guards, eleven lines in `styles.go`. Each one leaves the surrounding behaviour alone: a rule missing its children now yields the zero value for those fields rather than stopping the caller. No signature changes and no new error returns, so this is not a breaking change for anyone whose files are well formed.

## Tests

Four cases appended to `styles_test.go`. Each builds a minimal workbook in memory with `archive/zip`, opens it with the public `OpenReader` and calls `GetConditionalFormats`, so they drive the same path a caller does rather than reaching into internals.

Verified individually, since a panic takes the test binary down and would otherwise mask the later cases:

```
cellIs_without_formula         panic: index out of range [0] with length 0
colorScale_element_absent      panic: invalid memory address or nil pointer dereference
dataBar_element_empty          panic: index out of range [0] with length 0
three_colors_but_one_cfvo      panic: index out of range [1] with length 1
```

With the change, all four pass and the full suite is green:

```
ok  github.com/xuri/excelize/v2  72.413s
```

`gofmt` and `go vet` are clean.

Happy to split the third fix into its own commit or PR if you would rather keep the advisory scope exact.
