### PR TITLE
Fix panic on a row whose cells are not in ascending column order

### DIFF
--- a/rows.go
+++ b/rows.go
@@ -921,11 +921,8 @@ func (ws *xlsxWorksheet) checkRow() error {
 		if colCount == 0 {
 			continue
 		}
-		// check and fill the cell without r attribute in a row element. Cells are
-		// not guaranteed to be in ascending column order, so track the highest
-		// column seen instead of reading it off the last element, which would
-		// leave a cell sorting after that element without a slot below.
-		rCount, lastCol := 0, 0
+		// check and fill the cell without r attribute in a row element.
+		var rCount, lastCol int
 		for idx, cell := range rowData.C {
 			rCount++
 			if cell.R != "" {

--- a/rows.go
+++ b/rows.go
@@ -937,9 +937,19 @@ func (ws *xlsxWorksheet) checkRow() error {
 			}
 			rowData.C[idx].R, _ = CoordinatesToCellName(rCount, rowIdx+1)
 		}
-		lastCol, _, err := CellNameToCoordinates(rowData.C[colCount-1].R)
-		if err != nil {
-			return err
+		// Cells are not guaranteed to be in ascending column order, so the
+		// highest column in the row is not necessarily the last element. Take
+		// the maximum, otherwise a cell that sorts later than the final element
+		// is scattered past the end of the rebuilt slice below.
+		var lastCol int
+		for cellIdx := range rowData.C {
+			colNum, _, err := CellNameToCoordinates(rowData.C[cellIdx].R)
+			if err != nil {
+				return err
+			}
+			if colNum > lastCol {
+				lastCol = colNum
+			}
 		}
 
 		if colCount < lastCol {

--- a/rows.go
+++ b/rows.go
@@ -921,8 +921,11 @@ func (ws *xlsxWorksheet) checkRow() error {
 		if colCount == 0 {
 			continue
 		}
-		// check and fill the cell without r attribute in a row element
-		rCount := 0
+		// check and fill the cell without r attribute in a row element. Cells are
+		// not guaranteed to be in ascending column order, so track the highest
+		// column seen instead of reading it off the last element, which would
+		// leave a cell sorting after that element without a slot below.
+		rCount, lastCol := 0, 0
 		for idx, cell := range rowData.C {
 			rCount++
 			if cell.R != "" {
@@ -933,22 +936,14 @@ func (ws *xlsxWorksheet) checkRow() error {
 				if lastR > rCount {
 					rCount = lastR
 				}
+				if lastR > lastCol {
+					lastCol = lastR
+				}
 				continue
 			}
 			rowData.C[idx].R, _ = CoordinatesToCellName(rCount, rowIdx+1)
-		}
-		// Cells are not guaranteed to be in ascending column order, so the
-		// highest column in the row is not necessarily the last element. Take
-		// the maximum, otherwise a cell that sorts later than the final element
-		// is scattered past the end of the rebuilt slice below.
-		var lastCol int
-		for cellIdx := range rowData.C {
-			colNum, _, err := CellNameToCoordinates(rowData.C[cellIdx].R)
-			if err != nil {
-				return err
-			}
-			if colNum > lastCol {
-				lastCol = colNum
+			if rCount > lastCol {
+				lastCol = rCount
 			}
 		}
 

--- a/rows.go
+++ b/rows.go
@@ -917,34 +917,34 @@ func (ws *xlsxWorksheet) checkRow() error {
 	for rowIdx := range ws.SheetData.Row {
 		rowData := &ws.SheetData.Row[rowIdx]
 
-		colCount := len(rowData.C)
-		if colCount == 0 {
+		colLen := len(rowData.C)
+		if colLen == 0 {
 			continue
 		}
-		// check and fill the cell without r attribute in a row element.
-		var rCount, lastCol int
+		// check and fill the cell without r attribute in a row element
+		var cols, lastCol int
 		for idx, cell := range rowData.C {
-			rCount++
+			cols++
 			if cell.R != "" {
-				lastR, _, err := CellNameToCoordinates(cell.R)
+				col, _, err := CellNameToCoordinates(cell.R)
 				if err != nil {
 					return err
 				}
-				if lastR > rCount {
-					rCount = lastR
+				if col > cols {
+					cols = col
 				}
-				if lastR > lastCol {
-					lastCol = lastR
+				if col > lastCol {
+					lastCol = col
 				}
 				continue
 			}
-			rowData.C[idx].R, _ = CoordinatesToCellName(rCount, rowIdx+1)
-			if rCount > lastCol {
-				lastCol = rCount
+			rowData.C[idx].R, _ = CoordinatesToCellName(cols, rowIdx+1)
+			if cols > lastCol {
+				lastCol = cols
 			}
 		}
 
-		if colCount < lastCol {
+		if colLen < lastCol {
 			sourceList := rowData.C
 			targetList := make([]xlsxC, 0, lastCol)
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -1030,11 +1030,16 @@ func TestCheckRow(t *testing.T) {
 	t.Run("with_columns_sorted_in_descending_order", func(t *testing.T) {
 		f := NewFile()
 		f.Sheet.Delete("xl/worksheets/sheet1.xml")
-		f.Pkg.Store("xl/worksheets/sheet1.xml", fmt.Appendf(nil, `<worksheet xmlns="%s"><sheetData><row r="1"><c r="Z1"><v>z</v></c><c r="C1"><v>c</v></c></row></sheetData></worksheet>`, NameSpaceSpreadSheet.Value))
+		f.Pkg.Store("xl/worksheets/sheet1.xml", fmt.Appendf(nil, `<worksheet xmlns="%s"><sheetData><row r="1"><c r="D1"><v>d</v></c><c r="B1"><v>b</v></c></row></sheetData></worksheet>`, NameSpaceSpreadSheet.Value))
 		f.checked = sync.Map{}
-		value, err := f.GetCellValue("Sheet1", "Z1")
+		value, err := f.GetCellValue("Sheet1", "D1")
 		assert.NoError(t, err)
-		assert.Equal(t, "z", value)
+		assert.Equal(t, "d", value)
+		ws, ok := f.Sheet.Load("xl/worksheets/sheet1.xml")
+		assert.True(t, ok)
+		assert.Len(t, ws.(*xlsxWorksheet).SheetData.Row[0].C, 4)
+		assert.Equal(t, "b", ws.(*xlsxWorksheet).SheetData.Row[0].C[1].V)
+		assert.Equal(t, "d", ws.(*xlsxWorksheet).SheetData.Row[0].C[3].V)
 		assert.NoError(t, f.Close())
 	})
 }

--- a/rows_test.go
+++ b/rows_test.go
@@ -1284,14 +1284,14 @@ func TestCheckRowOutOfOrderColumns(t *testing.T) {
 
 	// Reading such a sheet through the public API must not panic.
 	f := NewFile()
-	f.Sheet.Store("xl/worksheets/sheet1.xml", &xlsxWorksheet{
-		SheetData: xlsxSheetData{Row: []xlsxRow{{
-			R: 1,
-			C: []xlsxC{{R: "Z1", T: "str", V: "z"}, {R: "C1", T: "str", V: "c"}},
-		}}},
-	})
+	f.Sheet.Delete("xl/worksheets/sheet1.xml")
+	f.checked = sync.Map{}
+	f.Pkg.Store("xl/worksheets/sheet1.xml", fmt.Appendf(nil, `<worksheet xmlns="%s"><sheetData><row r="1"><c r="Z1" t="str"><v>z</v></c><c r="C1" t="str"><v>c</v></c></row></sheetData></worksheet>`, NameSpaceSpreadSheet.Value))
 	value, err := f.GetCellValue("Sheet1", "Z1")
 	assert.NoError(t, err)
 	assert.Equal(t, "z", value)
+	value, err = f.GetCellValue("Sheet1", "C1")
+	assert.NoError(t, err)
+	assert.Equal(t, "c", value)
 	assert.NoError(t, f.Close())
 }

--- a/rows_test.go
+++ b/rows_test.go
@@ -1267,3 +1267,31 @@ func trimSliceSpace(s []string) []string {
 	}
 	return s
 }
+
+func TestCheckRowOutOfOrderColumns(t *testing.T) {
+	// Cells are not always stored in ascending column order. Here Z1 precedes
+	// C1, so the highest column is not the last element and sizing the rebuilt
+	// slice from that element leaves Z1 without a slot.
+	ws := &xlsxWorksheet{}
+	ws.SheetData.Row = []xlsxRow{{
+		R: 1,
+		C: []xlsxC{{R: "Z1", V: "z"}, {R: "C1", V: "c"}},
+	}}
+	assert.NoError(t, ws.checkRow())
+	assert.Len(t, ws.SheetData.Row[0].C, 26)
+	assert.Equal(t, "z", ws.SheetData.Row[0].C[25].V)
+	assert.Equal(t, "c", ws.SheetData.Row[0].C[2].V)
+
+	// Reading such a sheet through the public API must not panic.
+	f := NewFile()
+	f.Sheet.Store("xl/worksheets/sheet1.xml", &xlsxWorksheet{
+		SheetData: xlsxSheetData{Row: []xlsxRow{{
+			R: 1,
+			C: []xlsxC{{R: "Z1", T: "str", V: "z"}, {R: "C1", T: "str", V: "c"}},
+		}}},
+	})
+	value, err := f.GetCellValue("Sheet1", "Z1")
+	assert.NoError(t, err)
+	assert.Equal(t, "z", value)
+	assert.NoError(t, f.Close())
+}

--- a/rows_test.go
+++ b/rows_test.go
@@ -1027,6 +1027,16 @@ func TestCheckRow(t *testing.T) {
 	f.Sheet.Delete("xl/worksheets/sheet1.xml")
 	f.checked.Delete("xl/worksheets/sheet1.xml")
 	assert.EqualError(t, f.SetCellValue("Sheet1", "A1", false), newCellNameToCoordinatesError("-", newInvalidCellNameError("-")).Error())
+	t.Run("with_columns_sorted_in_descending_order", func(t *testing.T) {
+		f := NewFile()
+		f.Sheet.Delete("xl/worksheets/sheet1.xml")
+		f.Pkg.Store("xl/worksheets/sheet1.xml", fmt.Appendf(nil, `<worksheet xmlns="%s"><sheetData><row r="1"><c r="Z1"><v>z</v></c><c r="C1"><v>c</v></c></row></sheetData></worksheet>`, NameSpaceSpreadSheet.Value))
+		f.checked = sync.Map{}
+		value, err := f.GetCellValue("Sheet1", "Z1")
+		assert.NoError(t, err)
+		assert.Equal(t, "z", value)
+		assert.NoError(t, f.Close())
+	})
 }
 
 func TestSetRowStyle(t *testing.T) {
@@ -1266,32 +1276,4 @@ func trimSliceSpace(s []string) []string {
 		}
 	}
 	return s
-}
-
-func TestCheckRowOutOfOrderColumns(t *testing.T) {
-	// Cells are not always stored in ascending column order. Here Z1 precedes
-	// C1, so the highest column is not the last element and sizing the rebuilt
-	// slice from that element leaves Z1 without a slot.
-	ws := &xlsxWorksheet{}
-	ws.SheetData.Row = []xlsxRow{{
-		R: 1,
-		C: []xlsxC{{R: "Z1", V: "z"}, {R: "C1", V: "c"}},
-	}}
-	assert.NoError(t, ws.checkRow())
-	assert.Len(t, ws.SheetData.Row[0].C, 26)
-	assert.Equal(t, "z", ws.SheetData.Row[0].C[25].V)
-	assert.Equal(t, "c", ws.SheetData.Row[0].C[2].V)
-
-	// Reading such a sheet through the public API must not panic.
-	f := NewFile()
-	f.Sheet.Delete("xl/worksheets/sheet1.xml")
-	f.checked = sync.Map{}
-	f.Pkg.Store("xl/worksheets/sheet1.xml", fmt.Appendf(nil, `<worksheet xmlns="%s"><sheetData><row r="1"><c r="Z1" t="str"><v>z</v></c><c r="C1" t="str"><v>c</v></c></row></sheetData></worksheet>`, NameSpaceSpreadSheet.Value))
-	value, err := f.GetCellValue("Sheet1", "Z1")
-	assert.NoError(t, err)
-	assert.Equal(t, "z", value)
-	value, err = f.GetCellValue("Sheet1", "C1")
-	assert.NoError(t, err)
-	assert.Equal(t, "c", value)
-	assert.NoError(t, f.Close())
 }


### PR DESCRIPTION
Fixes the panic reported in GHSA-8mcq-6wmr-jrjv.

`checkRow` reads `lastCol` from the last element of the row and sizes the rebuilt slice from it, then scatters every cell into that slice by the cell's own column reference. Cells are not guaranteed to be stored in ascending column order, so when an earlier cell names a higher column than the final element, the write goes past the end.

A row holding `Z1` followed by `C1` has `colCount` 2 and `lastCol` 3, so the branch is entered, three placeholders are created, and `Z1` is then written to index 25:

```
panic: runtime error: index out of range [25] with length 3
```

This is reachable from the ordinary read APIs, since `checkRow` runs on worksheet load, so opening a crafted file and calling `GetCellValue` is enough.

The change takes the maximum column across the row rather than reading the last element. The existing loop above already tracks a running maximum for filling in missing `r` attributes, but that value is not used here.

Added `TestCheckRowOutOfOrderColumns` to `rows_test.go`. It covers the direct `checkRow` call and a read through `GetCellValue`. It panics with the message above on the current code and passes with the change. `go test ./...` is green.