### PR TITLE
This closes #2217: Preserve editAs positioning when copying pictures with twoCellAnchor

### DIFF
--- a/picture.go
+++ b/picture.go
@@ -701,7 +701,9 @@ func (f *File) extractPictureFromAnchor(drawingRelationships string, a *xdrCellA
 			pic.Format.Locked = &a.ClientData.FLocksWithSheet
 			pic.Format.PrintObject = &a.ClientData.FPrintsWithSheet
 		}
-		if a.To == nil {
+		if a.EditAs != "" {
+			pic.Format.Positioning = a.EditAs
+		} else if a.To == nil {
 			pic.Format.Positioning = "oneCell"
 		}
 		if a.Pic != nil {
@@ -761,7 +763,9 @@ func (f *File) extractPictureFromDecodeAnchor(drawingRelationships string, a *de
 			pic.Format.Locked = &a.ClientData.FLocksWithSheet
 			pic.Format.PrintObject = &a.ClientData.FPrintsWithSheet
 		}
-		if a.To == nil {
+		if a.EditAs != "" {
+			pic.Format.Positioning = a.EditAs
+		} else if a.To == nil {
 			pic.Format.Positioning = "oneCell"
 		}
 		if a.Pic != nil {
@@ -825,6 +829,9 @@ func (f *File) extractDecodeCellAnchor(anchor *xdrCellAnchor, drawingRelationshi
 		deCellAnchor = new(decodeCellAnchor)
 	)
 	_ = f.xmlNewDecoder(strings.NewReader("<decodeCellAnchor>" + anchor.GraphicFrame + "</decodeCellAnchor>")).Decode(&deCellAnchor)
+	if deCellAnchor.EditAs == "" {
+		deCellAnchor.EditAs = anchor.EditAs
+	}
 	if deCellAnchor.From != nil && deCellAnchor.Pic != nil {
 		if cond(deCellAnchor.From) {
 			if drawRel = f.getDrawingRelationships(drawingRelationships, deCellAnchor.Pic.BlipFill.Blip.Embed); drawRel != nil {

--- a/picture_test.go
+++ b/picture_test.go
@@ -291,7 +291,15 @@ func TestGetPicture(t *testing.T) {
 	// Try to get picture cells with one cell anchor
 	cells, err := f.GetPictureCells("Sheet2")
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"K16"}, cells)
+        assert.Equal(t, []string{"K16"}, cells)
+
+	f.Drawings.Delete("xl/drawings/drawing2.xml")
+	f.Pkg.Store("xl/drawings/drawing2.xml", []byte(`<xdr:wsDr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:twoCellAnchor editAs="oneCell"><xdr:from><xdr:col>10</xdr:col><xdr:row>15</xdr:row></xdr:from><xdr:to><xdr:col>13</xdr:col><xdr:row>22</xdr:row></xdr:to><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="2"></xdr:cNvPr></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="rId1"></a:blip></xdr:blipFill></xdr:pic></xdr:twoCellAnchor></xdr:wsDr>`))
+	pics, err = f.GetPictures("Sheet2", "K16")
+	assert.NoError(t, err)
+	if assert.Len(t, pics, 1) {
+			assert.Equal(t, "oneCell", pics[0].Format.Positioning)
+	}
 
 	// Try to get picture cells with absolute target path in the drawing relationship
 	rels, err := f.relsReader("xl/drawings/_rels/drawing2.xml.rels")


### PR DESCRIPTION
### Fixes #2217

## Problem

Copying a picture via `AddPictureFromBytes` produced a visibly stretched/
distorted copy when the source picture was anchored with a `twoCellAnchor`
element carrying an explicit `editAs="oneCell"` attribute. This is a valid,
spec-compliant anchor pattern commonly produced by WPS Office (and other
third-party tools), distinct from excelize's own writer, which always emits
a true `oneCellAnchor` element for size-locked pictures.

## Root cause

Two issues compounded to cause this:

1. `extractPictureFromAnchor` and `extractPictureFromDecodeAnchor` only
   inferred `Format.Positioning = "oneCell"` when the anchor had no `<to>`
   element at all. They never checked the anchor's own `editAs` attribute,
   so a `twoCellAnchor` with `editAs="oneCell"` (which does have a `<to>`)
   was never recognized as size-locked.

2. For anchors that fall through to the fallback decode path
   (`extractDecodeCellAnchor`, used when a drawing part mixes chart/
   graphicFrame anchors together with picture anchors), the re-parse of the
   anchor's inner content did not preserve the parent anchor's `editAs`
   attribute, so it was lost even when correctly read initially.

The end result: `Format.Positioning` came back empty for these pictures, so
`AddPictureFromBytes` wrote a plain `twoCellAnchor` with no `editAs` on
copy — making the copied picture resize with its cells instead of keeping
its original locked size.

## Fix

- Recognize `editAs` directly when reading a picture's anchor, falling back
  to the existing "oneCell when no `to`" inference only when `editAs` is
  absent.
- Preserve the parent anchor's `editAs` when the decode-fallback path
  re-parses anchor content.

## Testing

- Added a new case to `TestGetPicture` covering a `twoCellAnchor` with
  `editAs="oneCell"` and a `to` element present, asserting `GetPictures`
  returns `Format.Positioning == "oneCell"`.
- Verified against a real `.xlsx` file produced by WPS Office: before the
  fix, copying the picture dropped `editAs="oneCell"` from the resulting
  `drawing*.xml` (becoming a plain `twoCellAnchor`, which visibly stretched
  the picture); after the fix, the copy correctly writes a proper
  size-locked `oneCellAnchor`, matching the source picture's appearance.
- Ran the full test suite (`go test ./...`) with no regressions.
- Proceeded to run (gofmt -l) . and (go vet ./...) and found no errors