### PR TITLE
This closes a panic on a worksheet with an empty merged cell reference

### DIFF
--- a/cell.go
+++ b/cell.go
@@ -1657,6 +1657,9 @@ func (ws *xlsxWorksheet) mergeCellsParser(cell string) (string, error) {
 				_ = sortCoordinates(rect)
 				ws.MergeCells.Cells[i].rect = rect
 			}
+			if len(ws.MergeCells.Cells[i].rect) == 0 {
+				continue
+			}
 			if cellInRange([]int{col, row}, ws.MergeCells.Cells[i].rect) {
 				cell = strings.Split(ws.MergeCells.Cells[i].Ref, ":")[0]
 				break

--- a/merge_test.go
+++ b/merge_test.go
@@ -238,4 +238,10 @@ func TestMergeCellsParser(t *testing.T) {
 	ws := &xlsxWorksheet{MergeCells: &xlsxMergeCells{Cells: []*xlsxMergeCell{nil}}}
 	_, err := ws.mergeCellsParser("A1")
 	assert.NoError(t, err)
+
+	// Test parse merged cells with empty merged cell reference
+	ws = &xlsxWorksheet{MergeCells: &xlsxMergeCells{Cells: []*xlsxMergeCell{{Ref: ""}}}}
+	cell, err := ws.mergeCellsParser("A1")
+	assert.NoError(t, err)
+	assert.Equal(t, "A1", cell)
 }


### PR DESCRIPTION
Fix for the merged-cell panic reported privately.

`mergeCellsParser` only populates the cached rectangle when `ref != ""`, so a `<mergeCell ref=""/>` leaves `rect` nil, and the `cellInRange` call immediately after is unconditional and indexes it at four positions.

This skips the entry when the rectangle is empty. `checkCellInRangeRef` handled the same shape cleanly through its `len(rng) != 2` guard before a34c81e replaced it with the cached-rect path.

`TestMergeCellsParser` gains the empty-ref case alongside the existing nil-cell one. It panics without the change and passes with it. Full `go test ./...` is green, and `gofmt` and `go vet` are clean.
