### PR TITLE
This closes #324, update worksheet name in chart cell reference formulas on sheet rename

### DIFF
--- a/adjust.go
+++ b/adjust.go
@@ -317,6 +317,16 @@ func escapeSheetName(name string) string {
 	return name
 }
 
+// unescapeSheetName returns the worksheet name with the enclosing single
+// quotation marks removed and the doubled single quotation marks restored, as
+// the inverse of the escapeSheetName function.
+func unescapeSheetName(name string) string {
+	if len(name) > 1 && strings.HasPrefix(name, "'") && strings.HasSuffix(name, "'") {
+		return strings.ReplaceAll(name[1:len(name)-1], "''", "'")
+	}
+	return name
+}
+
 // adjustFormulaColumnName adjust column name in the formula reference.
 func adjustFormulaColumnName(name, operand string, abs, keepRelative bool, dir adjustDirection, num, offset int) (string, string, bool, error) {
 	if name == "" || (!abs && keepRelative) {
@@ -487,17 +497,15 @@ func transformParenthesesToken(token efp.Token) string {
 // adjustRangeSheetName returns replaced range reference by given source and
 // target sheet name.
 func adjustRangeSheetName(rng, source, target string) string {
-	source = escapeSheetName(source)
 	cellRefs := strings.Split(rng, ",")
 	for i, cellRef := range cellRefs {
 		rangeRefs := strings.Split(cellRef, ":")
 		for j, rangeRef := range rangeRefs {
 			parts := strings.Split(rangeRef, "!")
 			for k, part := range parts {
-				if strings.TrimPrefix(strings.TrimSuffix(part, "'"), "'") == source {
-					part = escapeSheetName(target)
+				if unescapeSheetName(part) == source {
+					parts[k] = escapeSheetName(target)
 				}
-				parts[k] = part
 			}
 			rangeRefs[j] = strings.Join(parts, "!")
 		}

--- a/adjust_test.go
+++ b/adjust_test.go
@@ -1347,3 +1347,25 @@ func TestAdjustDefinedNames(t *testing.T) {
 	f.Pkg.Store(defaultXMLPathWorkbook, MacintoshCyrillicCharset)
 	assert.EqualError(t, f.adjustDefinedNames("Sheet1", columns, 0, 0), "XML syntax error on line 1: invalid UTF-8")
 }
+
+func TestAdjustRangeSheetName(t *testing.T) {
+	for _, tc := range []struct {
+		rng, source, target, expected string
+	}{
+		{"Sheet1!$A$1:$B$2", "Sheet1", "Sheet2", "Sheet2!$A$1:$B$2"},
+		{"Sheet1!$A$1", "Sheet1", "New Sheet", "'New Sheet'!$A$1"},
+		{"'My Data'!$A$1:$A$3", "My Data", "Renamed", "Renamed!$A$1:$A$3"},
+		{"'My Data'!$A$1", "My Data", "New Data", "'New Data'!$A$1"},
+		{"Sheet2!$A$1", "Sheet1", "Renamed", "Sheet2!$A$1"},
+		{"Sheet1!A1,Sheet2!A1", "Sheet1", "Renamed", "Renamed!A1,Sheet2!A1"},
+	} {
+		assert.Equal(t, tc.expected, adjustRangeSheetName(tc.rng, tc.source, tc.target))
+	}
+}
+
+func TestUnescapeSheetName(t *testing.T) {
+	assert.Equal(t, "Sheet1", unescapeSheetName("Sheet1"))
+	assert.Equal(t, "My Data", unescapeSheetName("'My Data'"))
+	assert.Equal(t, "O'Brien", unescapeSheetName("'O''Brien'"))
+	assert.Equal(t, "'", unescapeSheetName("'"))
+}

--- a/chart.go
+++ b/chart.go
@@ -14,9 +14,16 @@ package excelize
 import (
 	"encoding/xml"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 )
+
+// chartRefFormulaRegex matches the cell reference formula element in the chart
+// part XML, for example, <f>Sheet1!$A$1:$A$3</f>. The formula content never
+// contains the '<' character since it is XML-escaped when it appears in a
+// worksheet name.
+var chartRefFormulaRegex = regexp.MustCompile(`<f>([^<]*)</f>`)
 
 // ChartType is the type of supported chart types.
 type ChartType byte
@@ -1402,6 +1409,40 @@ func (f *File) countCharts() int {
 		return true
 	})
 	return count
+}
+
+// adjustCharts provides a function to update the worksheet name in the cell
+// reference formulas of the charts after a worksheet has been renamed by the
+// SetSheetName function, so that the charts keep referencing the renamed
+// worksheet instead of losing their series data.
+func (f *File) adjustCharts(source, target string) {
+	f.Pkg.Range(func(k, v interface{}) bool {
+		path := k.(string)
+		if !strings.Contains(path, "xl/charts/chart") {
+			return true
+		}
+		if adjusted, changed := adjustChartRefSheetName(v.([]byte), source, target); changed {
+			f.Pkg.Store(path, adjusted)
+		}
+		return true
+	})
+}
+
+// adjustChartRefSheetName replaces the source worksheet name with the target
+// worksheet name in every cell reference formula of the given chart part XML
+// content, and reports whether any replacement was made.
+func adjustChartRefSheetName(content []byte, source, target string) ([]byte, bool) {
+	var changed bool
+	adjusted := chartRefFormulaRegex.ReplaceAllFunc(content, func(match []byte) []byte {
+		formula := formulaUnescaper.Replace(string(chartRefFormulaRegex.FindSubmatch(match)[1]))
+		ref := adjustRangeSheetName(formula, source, target)
+		if ref == formula {
+			return match
+		}
+		changed = true
+		return []byte("<f>" + formulaEscaper.Replace(ref) + "</f>")
+	})
+	return adjusted, changed
 }
 
 // ptToEMUs provides a function to convert pt to EMUs, 1 pt = 12700 EMUs. The

--- a/chart_test.go
+++ b/chart_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -647,4 +648,56 @@ func TestChartWithLogarithmicBase(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestSetSheetNameWithChart(t *testing.T) {
+	// collectChartRefs returns the cell reference formulas from every chart part
+	// in the workbook.
+	collectChartRefs := func(f *File) []string {
+		var refs []string
+		f.Pkg.Range(func(k, v interface{}) bool {
+			if path, ok := k.(string); ok && strings.Contains(path, "xl/charts/chart") {
+				for _, sub := range chartRefFormulaRegex.FindAllSubmatch(v.([]byte), -1) {
+					refs = append(refs, string(sub[1]))
+				}
+			}
+			return true
+		})
+		return refs
+	}
+
+	f := NewFile()
+	assert.NoError(t, f.SetCellValue("Sheet1", "A1", "Apple"))
+	assert.NoError(t, f.SetCellValue("Sheet1", "B1", 3))
+	_, err := f.NewSheet("Data")
+	assert.NoError(t, err)
+	assert.NoError(t, f.SetCellValue("Data", "A1", 5))
+	assert.NoError(t, f.AddChart("Sheet1", "E1", &Chart{
+		Type: Line,
+		Series: []ChartSeries{
+			{Name: "Sheet1!$A$1", Categories: "Sheet1!$A$1", Values: "Sheet1!$B$1"},
+			{Name: "Data!$A$1", Categories: "Data!$A$1", Values: "Data!$A$1"},
+		},
+	}))
+
+	// Renaming a worksheet must update the chart series references, including
+	// quoting the worksheet name when it contains a space, while leaving
+	// references to other worksheets untouched.
+	assert.NoError(t, f.SetSheetName("Sheet1", "New Sheet"))
+	for _, ref := range collectChartRefs(f) {
+		assert.NotContains(t, ref, "Sheet1!", "stale reference to the renamed worksheet")
+	}
+	assert.Contains(t, collectChartRefs(f), "'New Sheet'!$B$1")
+	assert.Contains(t, collectChartRefs(f), "Data!$A$1")
+
+	// The updated references must survive a save and reopen round trip.
+	buf, err := f.WriteToBuffer()
+	assert.NoError(t, err)
+	reopened, err := OpenReader(buf)
+	assert.NoError(t, err)
+	for _, ref := range collectChartRefs(reopened) {
+		assert.NotContains(t, ref, "Sheet1!", "stale reference after round trip")
+	}
+	assert.NoError(t, reopened.Close())
+	assert.NoError(t, f.Close())
 }

--- a/sheet.go
+++ b/sheet.go
@@ -367,10 +367,11 @@ func (f *File) getActiveSheetID() int {
 }
 
 // SetSheetName provides a function to set the worksheet name by given source and
-// target worksheet names. Maximum 31 characters are allowed in sheet title and
-// this function only changes the name of the sheet and will not update the
-// sheet name in the formula or reference associated with the cell. So there
-// may be problem formula error or reference missing.
+// target worksheet names. Maximum 31 characters are allowed in sheet title. This
+// function updates the worksheet name in the defined names and in the cell
+// reference formulas of the charts, but it will not update the sheet name in the
+// formula or reference associated with the cell. So there may be problem formula
+// error or reference missing.
 func (f *File) SetSheetName(source, target string) error {
 	var err error
 	if err = checkSheetName(target); err != nil {
@@ -388,6 +389,7 @@ func (f *File) SetSheetName(source, target string) error {
 			delete(f.sheetMap, source)
 		}
 	}
+	f.adjustCharts(source, target)
 	if wb.DefinedNames == nil {
 		return err
 	}


### PR DESCRIPTION
## Description

`SetSheetName` renames a worksheet but does not update the cell reference formulas that charts store in `xl/charts/chart*.xml`. Because those formulas keep pointing at the old worksheet name (for example `Sheet1!$B$2:$B$3`), the reference becomes dangling once the sheet no longer exists, and Excel opens the workbook with an empty chart — the series data is lost.

This change updates the worksheet name in every chart series reference (name, categories and values) when a sheet is renamed, so charts keep their data. References to other worksheets are left untouched, and the worksheet name is quoted when it contains a space or other non-alphabetical characters, matching how Excel writes the formula.

While wiring this up I also fixed `adjustRangeSheetName`, which is used for renaming references in defined names. It escaped the *source* name before comparing, so a source worksheet whose name required quoting (e.g. `My Data`) never matched and was silently left unchanged. It now unescapes each reference token before comparing, so quoted source names are handled correctly for both defined names and charts. A small `unescapeSheetName` helper (the inverse of the existing `escapeSheetName`) was added for this.

## Related Issue

Closes #324

## Motivation and Context

Renaming a sheet that has a chart on it is a common operation, and today it silently corrupts the chart. On the issue, the maintainer noted that solving this requires checking and updating the references (such as `xl/charts/chart*.xml`) when a sheet is renamed; this implements that for charts.

## How Has This Been Tested

- Added `TestSetSheetNameWithChart`, which builds a chart with series that reference two worksheets, renames one of them to a name containing a space, and asserts that the renamed references are updated and correctly quoted, that references to the other worksheet are preserved, and that the result survives a save/reopen round trip.
- Added `TestAdjustRangeSheetName` and `TestUnescapeSheetName` covering unquoted names, quoted (spaced) source and target names, escaped single quotes, and references to unrelated worksheets.
- `go test ./`, `go vet ./` and `gofmt` all pass; the new and changed functions are covered 100%.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
