### PR TITLE
Limit the spin count when deriving the agile decryption key

### DIFF
--- a/crypt.go
+++ b/crypt.go
@@ -48,6 +48,7 @@ var (
 	packageOffset               = 8 // First 8 bytes are the size of the stream
 	sheetProtectionSpinCount    = 1e5
 	workbookProtectionSpinCount = 1e5
+	maxSpinCount                = 1e7
 )
 
 // Encryption specifies the encryption structure, streams, and storages are
@@ -429,6 +430,11 @@ func agileDecrypt(encryptionInfoBuf, encryptedPackageBuf []byte, opts *Options) 
 // convertPasswdToKey convert the password into an encryption key.
 func convertPasswdToKey(passwd string, blockKey []byte, encryption Encryption) (key []byte, err error) {
 	var b bytes.Buffer
+	spinCount := encryption.KeyEncryptors.KeyEncryptor[0].EncryptedKey.SpinCount
+	if spinCount < 0 || spinCount > int(maxSpinCount) {
+		err = ErrMaxSpinCount
+		return
+	}
 	saltValue, err := base64.StdEncoding.DecodeString(encryption.KeyEncryptors.KeyEncryptor[0].EncryptedKey.SaltValue)
 	if err != nil {
 		return
@@ -443,7 +449,7 @@ func convertPasswdToKey(passwd string, blockKey []byte, encryption Encryption) (
 	// Generate the initial hash.
 	key = hashing(encryption.KeyData.HashAlgorithm, b.Bytes())
 	// Now regenerate until spin count.
-	for i := 0; i < encryption.KeyEncryptors.KeyEncryptor[0].EncryptedKey.SpinCount; i++ {
+	for i := 0; i < spinCount; i++ {
 		iterator := createUInt32LEBuffer(i, 4)
 		key = hashing(encryption.KeyData.HashAlgorithm, iterator, key)
 	}

--- a/crypt_test.go
+++ b/crypt_test.go
@@ -227,3 +227,25 @@ func TestGenISOPasswdHash(t *testing.T) {
 		assert.Equal(t, expected[1], saltValue)
 	}
 }
+
+func TestMaxSpinCount(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("test", "encryptSHA1.xlsx"))
+	assert.NoError(t, err)
+	doc, err := mscfb.New(bytes.NewReader(raw))
+	assert.NoError(t, err)
+	encryptionInfoBuf, _, err := extractPart(doc)
+	assert.NoError(t, err)
+	// Test decrypt spreadsheet with a spin count exceeds the maximum limit
+	tampered := bytes.Replace(encryptionInfoBuf,
+		[]byte(`spinCount="100000"`), []byte(`spinCount="100000000"`), 1)
+	assert.NotEqual(t, encryptionInfoBuf, tampered)
+	_, err = agileDecrypt(tampered, blockKey, &Options{Password: "password"})
+	assert.Equal(t, ErrMaxSpinCount, err)
+	// Test convert the password into an encryption key with a negative spin count
+	_, err = convertPasswdToKey("password", nil, Encryption{
+		KeyEncryptors: KeyEncryptors{KeyEncryptor: []KeyEncryptor{
+			{EncryptedKey: EncryptedKey{SpinCount: -1}},
+		}},
+	})
+	assert.Equal(t, ErrMaxSpinCount, err)
+}

--- a/errors.go
+++ b/errors.go
@@ -100,6 +100,9 @@ var (
 	// ErrMaxRows defined the error message on receive a row number exceeds
 	// maximum limit.
 	ErrMaxRows = errors.New("row number exceeds maximum limit")
+	// ErrMaxSpinCount defined the error message on receiving a spin count in
+	// the encryption info exceeds the maximum limit.
+	ErrMaxSpinCount = errors.New("spin count exceeds maximum limit")
 	// ErrNameLength defined the error message on receiving the defined name or
 	// table name length exceeds the limit.
 	ErrNameLength = fmt.Errorf("the name length exceeds the %d characters limit", MaxFieldLength)


### PR DESCRIPTION
As discussed in the advisory, this bounds the key derivation loop instead of letting the file pick the iteration count.

`convertPasswdToKey` now reads `SpinCount` once and returns `ErrMaxSpinCount` if it is negative or above `maxSpinCount`, which I set to 1e7 next to the existing `sheetProtectionSpinCount` and `workbookProtectionSpinCount`. Excel and LibreOffice both write 100000, so that leaves two orders of magnitude of headroom over anything a real producer emits.

The test takes the real `encryptSHA1.xlsx`, rewrites the spin count in its EncryptionInfo stream and calls `agileDecrypt`, so it goes through the same path `OpenFile` uses rather than calling the helper directly. It also covers the negative case. With the check removed the test does not fail so much as hang, and `go test` kills it at the timeout; with the check in place it finishes in about half a second.

Full suite passes locally on go1.27.1.

Happy to change the constant or move the check to parse time if you would rather reject it when the XML is read.
