### PR TITLE
This closes #2391, preserve empty cells in IF functions

### DIFF
--- a/calc.go
+++ b/calc.go
@@ -329,19 +329,6 @@ func (fa formulaArg) Value() (value string) {
 	return
 }
 
-// ToResult returns a formula argument as the result of a formula function.
-// A reference to a blank cell is preserved as blank so that the consumer
-// of the result applies the required coercion
-func (fa formulaArg) ToResult() formulaArg {
-	switch fa.Type {
-	case ArgNumber:
-		return fa.ToNumber()
-	case ArgEmpty:
-		return fa
-	}
-	return newStringFormulaArg(fa.Value())
-}
-
 // ToNumber returns a formula argument with number data type.
 func (fa formulaArg) ToNumber() formulaArg {
 	var n float64
@@ -15058,10 +15045,27 @@ func (fn *formulaFuncs) IF(argsList *list.List) formulaArg {
 		return newBoolFormulaArg(cond)
 	}
 	if cond {
-		return fn.implicitIntersect(argsList.Front().Next().Value.(formulaArg)).ToResult()
+		value := fn.implicitIntersect(argsList.Front().Next().Value.(formulaArg))
+		switch value.Type {
+		case ArgNumber:
+			result = value.ToNumber()
+		case ArgEmpty:
+			result = value
+		default:
+			result = newStringFormulaArg(value.Value())
+		}
+		return result
 	}
 	if argsList.Len() == 3 {
-		result = fn.implicitIntersect(argsList.Back().Value.(formulaArg)).ToResult()
+		value := fn.implicitIntersect(argsList.Back().Value.(formulaArg))
+		switch value.Type {
+		case ArgNumber:
+			result = value.ToNumber()
+		case ArgEmpty:
+			result = value
+		default:
+			result = newStringFormulaArg(value.Value())
+		}
 	}
 	return result
 }

--- a/calc.go
+++ b/calc.go
@@ -329,6 +329,19 @@ func (fa formulaArg) Value() (value string) {
 	return
 }
 
+// ToResult returns a formula argument as the result of a formula function.
+// A reference to a blank cell is preserved as blank so that the consumer
+// of the result applies the required coercion
+func (fa formulaArg) ToResult() formulaArg {
+	switch fa.Type {
+	case ArgNumber:
+		return fa.ToNumber()
+	case ArgEmpty:
+		return fa
+	}
+	return newStringFormulaArg(fa.Value())
+}
+
 // ToNumber returns a formula argument with number data type.
 func (fa formulaArg) ToNumber() formulaArg {
 	var n float64
@@ -15045,23 +15058,10 @@ func (fn *formulaFuncs) IF(argsList *list.List) formulaArg {
 		return newBoolFormulaArg(cond)
 	}
 	if cond {
-		value := fn.implicitIntersect(argsList.Front().Next().Value.(formulaArg))
-		switch value.Type {
-		case ArgNumber:
-			result = value.ToNumber()
-		default:
-			result = newStringFormulaArg(value.Value())
-		}
-		return result
+		return fn.implicitIntersect(argsList.Front().Next().Value.(formulaArg)).ToResult()
 	}
 	if argsList.Len() == 3 {
-		value := fn.implicitIntersect(argsList.Back().Value.(formulaArg))
-		switch value.Type {
-		case ArgNumber:
-			result = value.ToNumber()
-		default:
-			result = newStringFormulaArg(value.Value())
-		}
+		result = fn.implicitIntersect(argsList.Back().Value.(formulaArg)).ToResult()
 	}
 	return result
 }

--- a/calc_test.go
+++ b/calc_test.go
@@ -1993,6 +1993,8 @@ func TestCalcCellValue(t *testing.T) {
 		"VALUETOTEXT(D1,1)": "\"Month\"",
 		// Conditional Functions
 		// IF
+		"A1-IF(FALSE,1,C1)":                         "1",
+		"IF(TRUE,C1,1)":                             "",
 		"IF(1=1)":                                   "TRUE",
 		"IF(1<>1)":                                  "FALSE",
 		"IF(5<0, \"negative\", \"positive\")":       "positive",
@@ -4878,24 +4880,6 @@ func TestCalcAND(t *testing.T) {
 		Matrix: [][]formulaArg{{{Type: ArgUnknown}}},
 	})
 	assert.Equal(t, newBoolFormulaArg(true), fn.AND(argsList))
-}
-
-func TestCalcEmptyCellRef(t *testing.T) {
-	f := NewFile()
-	assert.NoError(t, f.SetCellValue("Sheet1", "A1", 1))
-
-	formulaList := map[string]string{
-		"=A1-B1":                "1",
-		"=A1-IF(FALSE,1,B1)":    "1",
-		"=IF(FALSE,1,B1)&\"x\"": "x",
-		"=IF(FALSE,1,\"\")":     "",
-	}
-	for formula, expected := range formulaList {
-		assert.NoError(t, f.SetCellFormula("Sheet1", "D1", formula), formula)
-		result, err := f.CalcCellValue("Sheet1", "D1")
-		assert.NoError(t, err, formula)
-		assert.Equal(t, expected, result, formula)
-	}
 }
 
 func TestCalcISBLANK(t *testing.T) {

--- a/calc_test.go
+++ b/calc_test.go
@@ -4880,6 +4880,24 @@ func TestCalcAND(t *testing.T) {
 	assert.Equal(t, newBoolFormulaArg(true), fn.AND(argsList))
 }
 
+func TestCalcEmptyCellRef(t *testing.T) {
+	f := NewFile()
+	assert.NoError(t, f.SetCellValue("Sheet1", "A1", 1))
+
+	formulaList := map[string]string{
+		"=A1-B1":                "1",
+		"=A1-IF(FALSE,1,B1)":    "1",
+		"=IF(FALSE,1,B1)&\"x\"": "x",
+		"=IF(FALSE,1,\"\")":     "",
+	}
+	for formula, expected := range formulaList {
+		assert.NoError(t, f.SetCellFormula("Sheet1", "D1", formula), formula)
+		result, err := f.CalcCellValue("Sheet1", "D1")
+		assert.NoError(t, err, formula)
+		assert.Equal(t, expected, result, formula)
+	}
+}
+
 func TestCalcISBLANK(t *testing.T) {
 	argsList := list.New()
 	argsList.PushBack(formulaArg{


### PR DESCRIPTION
# PR Details

Make IF function preserve empty cells as empty and not cast them as empty strings.

## Description

This change adds formulaArg.ToResult, which returns an argument as the result of a formula function while preserving ArgEmpty instead of flattening it into a string. The coercion is then applied by the consumer of the result. 

## Related Issue

https://github.com/qax-os/excelize/issues/2391

## Motivation and Context

=IF(FALSE,1,B1)+1 with B1 empty is valid in excel and evaluates to 1. This change makes excelize consistent with excel behaviour.

## How Has This Been Tested

Added a unit test

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
