### PR TITLE
Return every conditional formatting rule on a repeated range reference

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -3278,10 +3278,6 @@ func (f *File) GetConditionalFormats(sheet string) (map[string][]ConditionalForm
 				opts = append(opts, extractFunc(f, mastCell, cr, ws.ExtLst))
 			}
 		}
-		// A worksheet may hold more than one conditional formatting block for
-		// the same range reference, which Excel writes whenever a rule is
-		// added to a range that already has one. Append so that those rules
-		// are all reported instead of the last block replacing the others.
 		conditionalFormats[cf.SQRef] = append(conditionalFormats[cf.SQRef], opts...)
 	}
 	if ws.ExtLst != nil {

--- a/styles.go
+++ b/styles.go
@@ -3278,7 +3278,11 @@ func (f *File) GetConditionalFormats(sheet string) (map[string][]ConditionalForm
 				opts = append(opts, extractFunc(f, mastCell, cr, ws.ExtLst))
 			}
 		}
-		conditionalFormats[cf.SQRef] = opts
+		// A worksheet may hold more than one conditional formatting block for
+		// the same range reference, which Excel writes whenever a rule is
+		// added to a range that already has one. Append so that those rules
+		// are all reported instead of the last block replacing the others.
+		conditionalFormats[cf.SQRef] = append(conditionalFormats[cf.SQRef], opts...)
 	}
 	if ws.ExtLst != nil {
 		decodeExtLst := new(decodeExtLst)

--- a/styles_test.go
+++ b/styles_test.go
@@ -290,22 +290,24 @@ func TestGetConditionalFormats(t *testing.T) {
 		assert.Equal(t, format, opts[fmt.Sprintf("%s1:%s10", col, col)])
 	}
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestGetConditionalFormats.xlsx")))
-	// Test get conditional formats for a range reference carrying more than
-	// one conditional formatting block, which Excel writes whenever a rule is
-	// added to a range that already has one
-	repeatedBlocks := NewFile()
-	repeatedStyleID, err := repeatedBlocks.NewConditionalStyle(&Style{Fill: Fill{Type: "pattern", Color: []string{"FEC7CE"}, Pattern: 1}})
-	assert.NoError(t, err)
-	for _, format := range [][]ConditionalFormatOptions{
-		{{Type: "cell", Format: &repeatedStyleID, Criteria: "less than", Value: "5"}},
-		{{Type: "cell", Format: &repeatedStyleID, Criteria: "greater than", Value: "10"}},
-	} {
-		assert.NoError(t, repeatedBlocks.SetConditionalFormat("Sheet1", "A1:A10", format))
-	}
-	repeated, err := repeatedBlocks.GetConditionalFormats("Sheet1")
-	assert.NoError(t, err)
-	assert.Len(t, repeated["A1:A10"], 2)
-	assert.NoError(t, repeatedBlocks.Close())
+
+	t.Run("with_multiple_rules_in_a_range", func(t *testing.T) {
+		f := NewFile()
+		format, err := f.NewConditionalStyle(&Style{Fill: Fill{Type: "pattern", Color: []string{"FEC7CE"}, Pattern: 1}})
+		assert.NoError(t, err)
+		expected := []ConditionalFormatOptions{
+			{Type: "cell", Format: &format, Criteria: "less than", Value: "5"},
+			{Type: "cell", Format: &format, Criteria: "greater than", Value: "10"},
+		}
+		for _, format := range expected {
+			assert.NoError(t, f.SetConditionalFormat("Sheet1", "A1:A10", []ConditionalFormatOptions{format}))
+		}
+		opts, err := f.GetConditionalFormats("Sheet1")
+		assert.NoError(t, err)
+		assert.Equal(t, expected, opts["A1:A10"])
+		assert.NoError(t, f.Close())
+	})
+
 	// Test unset all conditional formats
 	f, err = OpenFile(filepath.Join("test", "TestGetConditionalFormats.xlsx"))
 	assert.NoError(t, f.AddSparkline("Sheet1", &SparklineOptions{

--- a/styles_test.go
+++ b/styles_test.go
@@ -290,6 +290,22 @@ func TestGetConditionalFormats(t *testing.T) {
 		assert.Equal(t, format, opts[fmt.Sprintf("%s1:%s10", col, col)])
 	}
 	assert.NoError(t, f.SaveAs(filepath.Join("test", "TestGetConditionalFormats.xlsx")))
+	// Test get conditional formats for a range reference carrying more than
+	// one conditional formatting block, which Excel writes whenever a rule is
+	// added to a range that already has one
+	repeatedBlocks := NewFile()
+	repeatedStyleID, err := repeatedBlocks.NewConditionalStyle(&Style{Fill: Fill{Type: "pattern", Color: []string{"FEC7CE"}, Pattern: 1}})
+	assert.NoError(t, err)
+	for _, format := range [][]ConditionalFormatOptions{
+		{{Type: "cell", Format: &repeatedStyleID, Criteria: "less than", Value: "5"}},
+		{{Type: "cell", Format: &repeatedStyleID, Criteria: "greater than", Value: "10"}},
+	} {
+		assert.NoError(t, repeatedBlocks.SetConditionalFormat("Sheet1", "A1:A10", format))
+	}
+	repeated, err := repeatedBlocks.GetConditionalFormats("Sheet1")
+	assert.NoError(t, err)
+	assert.Len(t, repeated["A1:A10"], 2)
+	assert.NoError(t, repeatedBlocks.Close())
 	// Test unset all conditional formats
 	f, err = OpenFile(filepath.Join("test", "TestGetConditionalFormats.xlsx"))
 	assert.NoError(t, f.AddSparkline("Sheet1", &SparklineOptions{


### PR DESCRIPTION
# PR Details

## Description

`GetConditionalFormats` built its result by assigning each conditional formatting block's rules into a map keyed by the block's range reference:

```go
conditionalFormats[cf.SQRef] = opts
```

A worksheet may hold several `<conditionalFormatting>` elements sharing one `sqref`, so every block but the last was dropped from the returned map.

This changes the assignment to an append, which is how the x14 extension list rules are already collected further down the same function.

## Related Issue

Closes #2398

## Motivation and Context

Excel writes a separate `<conditionalFormatting>` block whenever a rule is added to a range that already carries one, and `SetConditionalFormat` does the same on a second call for the same range. Both are ordinary, so the rules lost this way are ordinary too.

The loss is silent: no error is returned and the omitted rules are valid and honoured by Excel. A caller reading a sheet in order to inspect or preserve its conditional formatting has no way to tell that anything is missing. On a workbook written by Excel with 5 blocks and 12 rules across 4 distinct ranges, two blocks sharing one `sqref`, the function returned 4 keys and 11 rules.

## How Has This Been Tested

Added a case to `TestGetConditionalFormats` that writes two rules to `A1:A10` in separate `SetConditionalFormat` calls and asserts both are returned.

Confirmed the test fails without the change:

```
Error: "[{cell false false 0x400a0a23ac48 greater than 10 ...}]" should have 2 item(s), but has 1
```

and passes with it. The full test suite passes (`go test .`), together with `go build ./...`, `go vet ./...` and `gofmt -l .`.

Tested on go1.27.1 darwin/arm64, macOS 27.0.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


