### PR TITLE
Reject a conditional format style index that is not a differential style

### DIFF
--- a/styles.go
+++ b/styles.go
@@ -1731,7 +1731,8 @@ func (f *File) getStyleID(ss *xlsxStyleSheet, style *Style) (int, error) {
 
 // NewConditionalStyle provides a function to create style for conditional
 // format by given style format. The parameters are the same with the NewStyle
-// function.
+// function. Use the returned index, not one from NewStyle, as the Format of
+// ConditionalFormatOptions.
 func (f *File) NewConditionalStyle(style *Style) (int, error) {
 	f.mu.Lock()
 	s, err := f.stylesReader()
@@ -1772,7 +1773,8 @@ func (f *File) NewConditionalStyle(style *Style) (int, error) {
 }
 
 // GetConditionalStyle returns conditional format style definition by specified
-// style index.
+// style index, as returned by NewConditionalStyle. The GetStyle function does
+// not accept this index.
 func (f *File) GetConditionalStyle(idx int) (*Style, error) {
 	var style *Style
 	f.mu.Lock()
@@ -2836,6 +2838,32 @@ func (f *File) SetCellStyle(sheet, topLeftCell, bottomRightCell string, styleID 
 // formatting rule when more than one rule is applied to a cell or a range of
 // cells. When this parameter is set then subsequent rules are not evaluated
 // if the current rule is true.
+// condFmtTypesWithoutDxf lists the conditional formatting rule types whose
+// generated rule carries no dxfId attribute.
+var condFmtTypesWithoutDxf = []string{"2_color_scale", "3_color_scale", "data_bar", "icon_set"}
+
+// validateConditionalFormatStyleID checks that every style index given in the
+// conditional format options refers to an existing differential style.
+func (f *File) validateConditionalFormatStyleID(opts []ConditionalFormatOptions) error {
+	f.mu.Lock()
+	s, err := f.stylesReader()
+	if err != nil {
+		f.mu.Unlock()
+		return err
+	}
+	f.mu.Unlock()
+	for _, opt := range opts {
+		// Color scales, data bars and icon sets never write a dxfId
+		if opt.Format == nil || inStrSlice(condFmtTypesWithoutDxf, opt.Type, true) != -1 {
+			continue
+		}
+		if *opt.Format < 0 || s.Dxfs == nil || len(s.Dxfs.Dxfs) <= *opt.Format {
+			return newInvalidStyleID(*opt.Format)
+		}
+	}
+	return nil
+}
+
 func (f *File) SetConditionalFormat(sheet, rangeRef string, opts []ConditionalFormatOptions) error {
 	ws, err := f.workSheetReader(sheet)
 	if err != nil {
@@ -2843,6 +2871,9 @@ func (f *File) SetConditionalFormat(sheet, rangeRef string, opts []ConditionalFo
 	}
 	SQRef, mastCell, err := prepareConditionalFormatRange(rangeRef)
 	if err != nil {
+		return err
+	}
+	if err := f.validateConditionalFormatStyleID(opts); err != nil {
 		return err
 	}
 	// Create a pseudo GUID for each unique rule.

--- a/styles_test.go
+++ b/styles_test.go
@@ -239,6 +239,19 @@ func TestSetConditionalFormat(t *testing.T) {
 		assert.Equal(t, expected, priorities)
 		assert.NoError(t, f.Close())
 	})
+	t.Run("with_style_index_that_is_not_a_differential_style", func(t *testing.T) {
+		f := NewFile()
+		// NewStyle indexes the cell styles, not the differential styles the
+		// Format field refers to
+		cellStyleID, err := f.NewStyle(&Style{Font: &Font{Color: "FF0000"}})
+		assert.NoError(t, err)
+		assert.Equal(t, newInvalidStyleID(cellStyleID), f.SetConditionalFormat("Sheet1", "A1:A10",
+			[]ConditionalFormatOptions{{Type: "cell", Format: &cellStyleID, Criteria: "greater than", Value: "6"}}))
+		negative := -1
+		assert.Equal(t, newInvalidStyleID(negative), f.SetConditionalFormat("Sheet1", "A1:A10",
+			[]ConditionalFormatOptions{{Type: "cell", Format: &negative, Criteria: "greater than", Value: "6"}}))
+		assert.NoError(t, f.Close())
+	})
 }
 
 func TestGetConditionalFormats(t *testing.T) {


### PR DESCRIPTION
# PR Details

## Description

`SetConditionalFormat` wrote `ConditionalFormatOptions.Format` into the rule's `dxfId` attribute without checking it against the differential styles. This validates the index before any rule is written and returns the same invalid style ID error that `GetConditionalStyle` already returns for such an index.

Color scales, data bars and icon sets never write a `dxfId`, so they are skipped and keep accepting any `Format`, as the existing data bar test relies on.

The `NewConditionalStyle` and `GetConditionalStyle` doc comments now note that the index belongs to the differential styles, not the cell styles `NewStyle` returns.

## Related Issue

Closes #2400

## Motivation and Context

Passing an index from `NewStyle` is an easy mistake, and it was accepted without an error. The saved workbook then held a rule pointing at a differential style that does not exist, with nothing in the library or the file to flag it.

## How Has This Been Tested

Added a `with_style_index_that_is_not_a_differential_style` subtest to `TestSetConditionalFormat`. It asserts an invalid style ID error for an index from `NewStyle` and for a negative index.

The full test suite passes (`go test .`), along with `go build ./...`, `go vet ./...` and `gofmt -l .`.

Tested on go1.27.1 darwin/arm64, macOS 27.0.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
